### PR TITLE
feat(receiver): merge receiver feature to develop branch

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -68,6 +68,12 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-websocket</artifactId>
+			<version>4.0.5</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/roomsystem/feature/receiver/Receiver.java
+++ b/backend/src/main/java/com/roomsystem/feature/receiver/Receiver.java
@@ -1,0 +1,21 @@
+package com.roomsystem.feature.receiver;
+
+import com.roomsystem.feature.receiver.dto.SensorData;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class Receiver {
+
+    private final SensorDataService sensorDataService;
+
+    public Receiver(SensorDataService sensorDataService) {
+        this.sensorDataService = sensorDataService;
+    }
+
+    @MessageMapping("/data")
+    public void receive(SensorData data) {
+        if (data == null) return;
+        sensorDataService.process(data);
+    }
+}

--- a/backend/src/main/java/com/roomsystem/feature/receiver/SensorDataService.java
+++ b/backend/src/main/java/com/roomsystem/feature/receiver/SensorDataService.java
@@ -1,0 +1,7 @@
+package com.roomsystem.feature.receiver;
+
+import com.roomsystem.feature.receiver.dto.SensorData;
+
+public interface SensorDataService {
+    void process(SensorData data);
+}

--- a/backend/src/main/java/com/roomsystem/feature/receiver/dto/SensorData.java
+++ b/backend/src/main/java/com/roomsystem/feature/receiver/dto/SensorData.java
@@ -1,0 +1,13 @@
+package com.roomsystem.feature.receiver.dto;
+
+import java.time.Instant;
+
+public record SensorData(
+        String roomId,
+        String sensorId,
+        int count,
+        double confidence,
+        Instant timestamp
+) {}
+
+// Port InfluxDB: 8181

--- a/backend/src/test/java/com/roomsystem/feature/receiver/ReceiverTest.java
+++ b/backend/src/test/java/com/roomsystem/feature/receiver/ReceiverTest.java
@@ -1,0 +1,61 @@
+package com.roomsystem.feature.receiver;
+
+import com.roomsystem.feature.receiver.dto.SensorData;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.roomsystem.feature.receiver.Receiver;
+import java.time.Instant;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class ReceiverTest {
+
+    @Mock
+    private SensorDataService sensorDataService;
+
+    @InjectMocks
+    private Receiver receiver;
+
+    @Test
+    void shouldForwardParsedDataToService() {
+        SensorData data = new SensorData(
+                "room-42",
+                "sensor-7",
+                3,
+                0.95,
+                Instant.parse("2026-04-13T10:30:00Z")
+        );
+
+        receiver.receive(data);
+
+        verify(sensorDataService).process(data);
+    }
+
+    @Test
+    void shouldHandleZeroCount() {
+        SensorData data = new SensorData(
+                "room-1",
+                "sensor-1",
+                0,
+                1.0,
+                Instant.now()
+        );
+
+        receiver.receive(data);
+
+        verify(sensorDataService).process(data);
+    }
+
+    @Test
+    void shouldNotProcessWhenDataIsNull() {
+        receiver.receive(null);
+
+        verifyNoInteractions(sensorDataService);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SensorData` DTO (record) with `roomId`, `sensorId`, `count`, `confidence`, `timestamp`
- Adds `SensorDataService` interface as the contract between receiver and future processing logic
- Adds unit tests for all three scenarios (forward, zero count, null guard)

## What's still missing (next step)

`SensorDataService` has no implementation yet  the connection to `OccupancyService` (database feature) will be established in the next step. STOMP Websockets need to be configured and integrated.

## Test plan

- [x] `ReceiverTest` — shouldForwardParsedDataToService
- [x] `ReceiverTest` — shouldHandleZeroCount
- [x] `ReceiverTest` — shouldNotProcessWhenDataIsNull