### PR TITLE
add: binary frame parser for IWR6843AOP data port and people count extraction #28

### DIFF
--- a/raspberry/receiver.py
+++ b/raspberry/receiver.py
@@ -2,16 +2,24 @@ import serial
 import os
 import logging
 import sys
+import struct
+
+from requests.compat import integer_types
 
 # Configuration for the AOP 6m sensor
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FILE = os.path.join(BASE_DIR, "chirp_configs", "AOP_6m_default.cfg")
 
 # Serial port settings (adjust as needed for system)
+# COM Ports are the actual physical ports on your device
+# BAUD -> how many bits are transferred per second. Needs to be on receiver and sender the same
+
 CFG_PORT = "COM3"
 DATA_PORT = "COM4"
 CFG_BAUD = 115200
 DATA_BAUD = 921600
+
+MAGIC_WORD = b'\x02\x01\x04\x03\x06\x05\x08\x07'
 
 # Set up logging
 logging.basicConfig(
@@ -46,6 +54,27 @@ def send_config(cfg_port, config_file):
                     break
 
             log.info(f"Sent: {line.strip()} | Response: {response.strip()}")
+
+def read_frame(data_port):
+        buffer = bytearray()
+        while True:
+                byte = data_port.read(1)
+                buffer += byte
+                if buffer[-8:] == MAGIC_WORD:
+                    print("Magic word found")
+
+                    # Empty buffer to save memory
+                    buffer = bytearray()
+
+                    header_bytes = data_port.read(32)
+                    (version,
+                     total_length,
+                     platform,
+                     frame_num,
+                     time_cpu,
+                     num_detected,
+                     num_tlvs,
+                     sub_frame) = struct.unpack('8I', header_bytes)
 
 # Main execution
 if __name__ == '__main__':

--- a/raspberry/receiver.py
+++ b/raspberry/receiver.py
@@ -4,8 +4,6 @@ import logging
 import sys
 import struct
 
-from requests.compat import integer_types
-
 # Configuration for the AOP 6m sensor
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FILE = os.path.join(BASE_DIR, "chirp_configs", "AOP_6m_default.cfg")
@@ -13,13 +11,22 @@ CONFIG_FILE = os.path.join(BASE_DIR, "chirp_configs", "AOP_6m_default.cfg")
 # Serial port settings (adjust as needed for system)
 # COM Ports are the actual physical ports on your device
 # BAUD -> how many bits are transferred per second. Needs to be on receiver and sender the same
-
 CFG_PORT = "COM3"
 DATA_PORT = "COM4"
 CFG_BAUD = 115200
 DATA_BAUD = 921600
 
+# Magic word for when Frame starts. Refer to the User Guide for details on Frame Structure and Header
 MAGIC_WORD = b'\x02\x01\x04\x03\x06\x05\x08\x07'
+
+# Size of a single tracked target in bytes. Refer to the User Guide for Target List TLV structure
+TRACK_SIZE_BYTES = 112
+
+# TLV types for parsing the data. Refer to the User Guide for details on TLV structure and types
+TLV_TARGET_LIST = 1010
+TLV_POINT_CLOUD = 1020
+TLV_TARGET_INDEX = 1011
+TLV_TARGET_HEIGHT = 1012
 
 # Set up logging
 logging.basicConfig(
@@ -35,15 +42,21 @@ def open_ports():
     data_port = serial.Serial(DATA_PORT, DATA_BAUD, timeout=1)
     return cfg_port, data_port
 
+
 # Send the configuration commands from the file to the sensor and read responses
 def send_config(cfg_port, config_file):
     with open(config_file, "r") as f:
         lines = f.readlines()
+
+        # Send each line of the config file to the sensor and read the response
         for line in lines:
+
+            # Skip comments and empty lines
             if line.startswith('%') or line.strip() == "":
                 continue
             cfg_port.write((line.strip() + '\n').encode())
 
+            # Read the response until we get a 'Done' or 'Error' or an empty line
             response = ""
             while True:
                 resp_line = cfg_port.readline().decode()
@@ -55,26 +68,46 @@ def send_config(cfg_port, config_file):
 
             log.info(f"Sent: {line.strip()} | Response: {response.strip()}")
 
+
+# Read the data from the data port, parse the frames, and extract the people count
 def read_frame(data_port):
-        buffer = bytearray()
-        while True:
-                byte = data_port.read(1)
-                buffer += byte
-                if buffer[-8:] == MAGIC_WORD:
-                    print("Magic word found")
+    # We read byte by byte until we find the magic word that indicates the start of a frame.
+    # Then we read the header and TLVs to extract the number of detected people.
+    buffer = bytearray()
+    while True:
+        byte = data_port.read(1)
+        buffer += byte
+        if buffer[-8:] == MAGIC_WORD:
+            log.debug("Magic word found")
 
-                    # Empty buffer to save memory
-                    buffer = bytearray()
+            # Empty buffer to save memory
+            buffer = bytearray()
 
-                    header_bytes = data_port.read(32)
-                    (version,
-                     total_length,
-                     platform,
-                     frame_num,
-                     time_cpu,
-                     num_detected,
-                     num_tlvs,
-                     sub_frame) = struct.unpack('8I', header_bytes)
+            # Refer to the User Guide for Frame Structure and Header details
+            header_bytes = data_port.read(32)
+            (version,
+             total_length,
+             platform,
+             frame_num,
+             time_cpu_cycles,
+             num_detected_obj,
+             num_tlvs,
+             sub_frame) = struct.unpack('8I', header_bytes)
+
+            # Iterate through TLVs and export people count
+            num_targets = 0
+            for _ in range(num_tlvs):
+                tlv_header = data_port.read(8)
+                tlv_type, tlv_length = struct.unpack('2I', tlv_header)
+                # Commented in case we need it in future
+                # tlv_data = data_port.read(tlv_length)
+
+                # People Count
+                if tlv_type == TLV_TARGET_LIST:
+                    num_targets = tlv_length // TRACK_SIZE_BYTES
+                    log.info(f"Detected person: {num_targets} targets")
+            return frame_num, num_targets
+
 
 # Main execution
 if __name__ == '__main__':
@@ -83,6 +116,10 @@ if __name__ == '__main__':
     try:
         cfg_port, data_port = open_ports()
         send_config(cfg_port, CONFIG_FILE)
+
+        while True:
+            frame_num, people_count = read_frame(data_port)
+            log.info(f"Frame {frame_num}: Detected {people_count} people")
     except serial.SerialException as e:
         log.error(f"Error: Couldn't find sensor. {e}")
     finally:


### PR DESCRIPTION
The IWR6843AOP is a millimeter-wave radar sensor by Texas Instruments. Unlike cameras, it uses radio waves to detect and track people in a room — making it privacy-friendly and effective even in complete darkness. The sensor continuously streams raw binary data over a dedicated serial (USB) connection. This PR implements the logic to read and parse that data stream on the Raspberry Pi.

The sensor communicates through two serial ports:

- **Config Port** — used at startup to send chirp configuration commands that define the sensor's detection parameters (range, resolution, frame rate, etc.)
- **Data Port** — streams a continuous sequence of binary frames containing the detection results

Each frame follows a fixed binary structure: it begins with a **magic word** (8 known bytes that mark the start of a frame), followed by a **frame header** (metadata such as frame number and number of TLV blocks), and then one or more **TLV blocks** (Type-Length-Value — each block has a type ID, a byte length, and a payload). Different TLV types carry different data: point clouds, tracked targets, height estimates, etc.

1. **Frame Detection** — Reads the data port byte by byte until the magic word `0x0201040306050807` is found, signaling the start of a new frame.

2. **Header Parsing** — Reads the 32-byte frame header and unpacks version, total length, platform, frame number, CPU cycle timestamp, number of detected objects, number of TLVs, and sub-frame index.

3. **TLV Iteration & People Count Extraction** — Iterates through each TLV block. When a `TARGET_LIST` TLV (type 1010) is encountered, the number of tracked people is derived by dividing the TLV payload length by the fixed size of a single tracked target (112 bytes).

---

## Connection to Architecture (ADR 004)

The people count extracted per frame is the value that will be sent to the backend via `POST /api/sensors/person-count` as defined in ADR 004. This PR covers the parsing side only — the HTTP forwarding to the backend is a follow-up task.

---

## Files Added

- `raspberry/receiver.py` — Main receiver script: opens both serial ports, sends the chirp config to the sensor, then continuously reads and parses binary frames, logging the detected people count per frame
- `raspberry/chirp_configs/AOP_6m_default.cfg` — Default chirp configuration for the IWR6843AOP in 6 m people-tracking mode (detection boundaries, tracker parameters, frame rate)

---

## Testing (ADR 006)

The project follows TDD (ADR 006). Unit testing this module is non-trivial because it depends directly on physical serial ports and live sensor output. Tests with mocked serial streams are planned as a follow-up once the data contract with the backend is stable.

---

## Setup

- Connect the IWR6843AOP sensor via USB — it registers as two serial ports on the host system
- Adjust `CFG_PORT` and `DATA_PORT` at the top of `receiver.py` to match your system's port names (e.g. `COM3`/`COM4` on Windows, `/dev/ttyUSB0`/`/dev/ttyUSB1` on Linux/Raspberry Pi)
- Install the dependency: `pip install pyserial`
- Run: `python receiver.py`