### PR TITLE
add: raspberry config settings and receiver refactor

### DIFF
--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -1,0 +1,21 @@
+import os
+
+# --- Sensor Identity ---
+ROOM_ID   = os.getenv("ROOM_ID",   "room-01")
+SENSOR_ID = os.getenv("SENSOR_ID", "sensor-01")
+
+# --- Serial ---
+SERIAL_CFG_PORT  = os.getenv("SERIAL_CFG_PORT",  "/dev/ttyUSB0")
+SERIAL_DATA_PORT = os.getenv("SERIAL_DATA_PORT", "/dev/ttyUSB1")
+SERIAL_CFG_BAUD  = 115200
+SERIAL_DATA_BAUD = 921600
+
+# --- Backend WebSocket ---
+BACKEND_HOST    = os.getenv("BACKEND_HOST",    "localhost")
+BACKEND_PORT    = os.getenv("BACKEND_PORT",    "8000")
+BACKEND_WS_PATH = os.getenv("BACKEND_WS_PATH", "/ws/occupancy")
+BACKEND_WS_URL  = f"ws://{BACKEND_HOST}:{BACKEND_PORT}{BACKEND_WS_PATH}"
+
+# --- WebSocket Reconnect ---
+WS_RECONNECT_DELAY = 5  # seconds until next try
+WS_MAX_RETRIES     = 0  # 0 = infinite retries

--- a/raspberry/receiver.py
+++ b/raspberry/receiver.py
@@ -8,13 +8,12 @@ import struct
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 CONFIG_FILE = os.path.join(BASE_DIR, "chirp_configs", "AOP_6m_default.cfg")
 
-# Serial port settings (adjust as needed for system)
-# COM Ports are the actual physical ports on your device
-# BAUD -> how many bits are transferred per second. Needs to be on receiver and sender the same
-CFG_PORT = "COM3"
-DATA_PORT = "COM4"
-CFG_BAUD = 115200
-DATA_BAUD = 921600
+# Serial port settings loaded from config.py
+# Override via environment variables if needed for different device than raspberry pi(e.g. SERIAL_CFG_PORT=COM3 on Windows)
+from config import (
+    SERIAL_CFG_PORT, SERIAL_DATA_PORT,
+    SERIAL_CFG_BAUD, SERIAL_DATA_BAUD
+)
 
 # Magic word for when Frame starts. Refer to the User Guide for details on Frame Structure and Header
 MAGIC_WORD = b'\x02\x01\x04\x03\x06\x05\x08\x07'
@@ -38,8 +37,8 @@ log = logging.getLogger(__name__)
 
 # Open the serial ports for configuration and data
 def open_ports():
-    cfg_port = serial.Serial(CFG_PORT, CFG_BAUD, timeout=1)
-    data_port = serial.Serial(DATA_PORT, DATA_BAUD, timeout=1)
+    cfg_port = serial.Serial(SERIAL_CFG_PORT, SERIAL_CFG_BAUD, timeout=1)
+    data_port = serial.Serial(SERIAL_DATA_PORT, SERIAL_DATA_BAUD, timeout=1)
     return cfg_port, data_port
 
 

--- a/raspberry/receiver.py
+++ b/raspberry/receiver.py
@@ -10,6 +10,7 @@ CONFIG_FILE = os.path.join(BASE_DIR, "chirp_configs", "AOP_6m_default.cfg")
 
 # Serial port settings loaded from config.py
 # Override via environment variables if needed for different device than raspberry pi(e.g. SERIAL_CFG_PORT=COM3 on Windows)
+sys.path.insert(0, BASE_DIR)
 from config import (
     SERIAL_CFG_PORT, SERIAL_DATA_PORT,
     SERIAL_CFG_BAUD, SERIAL_DATA_BAUD


### PR DESCRIPTION
Adds config.py with environment-based configuration for serial ports
and WebSocket settings. Updates receiver.py to use config values
instead of hardcoded ports.

Closes #11