### PR TITLE
feat: Implements the full receiver pipeline for inbound mmWave sensor data over WebSocket/STOMP #57

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -73,6 +73,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-websocket</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<!-- InfluxDB 3.x Client -->
 		<dependency>

--- a/backend/src/main/java/com/roomsystem/feature/receiver/Receiver.java
+++ b/backend/src/main/java/com/roomsystem/feature/receiver/Receiver.java
@@ -13,6 +13,9 @@ public class Receiver {
         this.sensorDataService = sensorDataService;
     }
 
+    /**
+     * Listens for incoming sensor data via STOMP and forwards it to the service.
+     */
     @MessageMapping("/data")
     public void receive(SensorData data) {
         if (data == null) return;

--- a/backend/src/main/java/com/roomsystem/feature/receiver/SensorDataServiceImpl.java
+++ b/backend/src/main/java/com/roomsystem/feature/receiver/SensorDataServiceImpl.java
@@ -1,0 +1,79 @@
+package com.roomsystem.feature.receiver;
+
+import com.roomsystem.feature.database.model.OccupancyData;
+import com.roomsystem.feature.database.service.OccupancyService;
+import com.roomsystem.feature.receiver.dto.SensorData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementation of {@link SensorDataService}.
+ *
+ * Transforms incoming sensor data from the Raspberry Pi into occupancy records
+ * and persists them via the database layer.
+ *
+ * Responsibilities:
+ * - Map {@link SensorData} (receiver DTO) to {@link OccupancyData} (database model)
+ * - Delegate persistence to {@link OccupancyService}
+ * - Handle null or invalid input gracefully
+ *
+ * Note: This service follows the Package by Feature pattern and communicates
+ * with the database feature only through {@link OccupancyService}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SensorDataServiceImpl implements SensorDataService {
+
+    private final OccupancyService occupancyService;
+
+    /**
+     * Processes incoming sensor data by mapping it to an occupancy record
+     * and persisting it to the database.
+     *
+     * @param data the sensor data received from the mmWave sensor via STOMP
+     *             If null, the data is silently ignored.
+     */
+    @Override
+    public void process(SensorData data) {
+        if (data == null) {
+            log.warn("Received null SensorData, ignoring");
+            return;
+        }
+
+        try {
+            // Map SensorData (receiver DTO) to OccupancyData (database model)
+            OccupancyData occupancyData = mapToOccupancyData(data);
+
+            // Delegate persistence to the database layer
+            occupancyService.recordOccupancy(occupancyData);
+
+            log.debug("Successfully processed sensor data: room={}, sensor={}, count={}",
+                    data.roomId(), data.sensorId(), data.count());
+        } catch (Exception e) {
+            log.error("Error processing sensor data for room={}, sensor={}",
+                    data.roomId(), data.sensorId(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * Maps a {@link SensorData} (receiver DTO) to {@link OccupancyData} (database model).
+     *
+     * All fields are copied directly as the two models share the same structure.
+     * The mapping is kept simple and explicit to avoid over-engineering.
+     *
+     * @param sensorData the sensor data to map
+     * @return the mapped occupancy data ready for persistence
+     */
+    private OccupancyData mapToOccupancyData(SensorData sensorData) {
+        return OccupancyData.builder()
+                .roomId(sensorData.roomId())
+                .sensorId(sensorData.sensorId())
+                .count(sensorData.count())
+                .confidence(sensorData.confidence())
+                .timestamp(sensorData.timestamp())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/roomsystem/feature/receiver/WebSocketConfig.java
+++ b/backend/src/main/java/com/roomsystem/feature/receiver/WebSocketConfig.java
@@ -1,0 +1,160 @@
+package com.roomsystem.feature.receiver;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.AbstractMessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import java.util.List;
+
+/**
+ * WebSocket configuration for STOMP messaging.
+ *
+ * Enables real-time, bidirectional communication between Raspberry Pi
+ * and the Spring Boot backend via WebSocket with STOMP protocol.
+ *
+ * Configuration:
+ * - Endpoint: /ws (with SockJS fallback)
+ * - Message broker: in-memory (suitable for single-instance deployments)
+ * - Application prefix: /app (for @MessageMapping routes)
+ * - User destination prefix: /user (for per-user messaging)
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    /**
+     * Jackson 3 ObjectMapper auto-configured by Spring Boot 4.
+     * Used in the custom STOMP message converter for proper Instant support.
+     */
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * Registers a custom STOMP message converter backed by the Spring Boot
+     * auto-configured Jackson 3 ObjectMapper.
+     *
+     * By resolving the content-type to application/json regardless of what the
+     * client sends, this converter handles stomp.py clients (Raspberry Pi) that
+     * omit the content-type header and send plain-text JSON payloads.
+     *
+     * Jackson 3 has built-in java.time support, so Instant deserialization works
+     * without any additional module registration.
+     */
+    @Override
+    public boolean configureMessageConverters(List<MessageConverter> messageConverters) {
+        messageConverters.add(new Jackson3StompConverter(objectMapper));
+        return true;
+    }
+
+    /**
+     * Custom STOMP message converter that uses the Spring Boot auto-configured
+     * Jackson 3 ObjectMapper. Accepts any content-type and treats the body as JSON.
+     */
+    private static class Jackson3StompConverter extends AbstractMessageConverter {
+
+        private final ObjectMapper mapper;
+
+        Jackson3StompConverter(ObjectMapper mapper) {
+            super(MimeTypeUtils.APPLICATION_JSON, new MimeType("text", "plain"));
+            this.mapper = mapper;
+        }
+
+        @Override
+        protected boolean supports(Class<?> clazz) {
+            return true;
+        }
+
+        @Override
+        protected Object convertFromInternal(Message<?> message, Class<?> targetClass, Object conversionHint) {
+            try {
+                Object payload = message.getPayload();
+                if (payload instanceof byte[] bytes) {
+                    return mapper.readValue(bytes, targetClass);
+                }
+                if (payload instanceof String str) {
+                    return mapper.readValue(str, targetClass);
+                }
+                return null;
+            } catch (JacksonException e) {
+                return null;
+            }
+        }
+
+        @Override
+        protected Object convertToInternal(Object payload, MessageHeaders headers, Object conversionHint) {
+            try {
+                return mapper.writeValueAsBytes(payload);
+            } catch (JacksonException e) {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Configures the WebSocket STOMP endpoints.
+     *
+     * Two endpoints are registered:
+     * - /ws          — raw WebSocket (no SockJS) for native clients such as Raspberry Pi
+     *                  and stomp.py. Also used by integration tests via StandardWebSocketClient.
+     * - /ws/occupancy — SockJS-enabled endpoint for browser-based clients that may lack
+     *                  native WebSocket support.
+     *
+     * @param registry the STOMP endpoint registry
+     */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // Raw WebSocket endpoint for native clients (Raspberry Pi / stomp.py)
+        registry
+                .addEndpoint("/ws")
+                .setAllowedOrigins("*");
+
+        // SockJS endpoint for browser clients
+        registry
+                .addEndpoint("/ws/occupancy")
+                .setAllowedOrigins("*")  // In production, specify actual client origins
+                .withSockJS();
+    }
+
+    /**
+     * Configures the message broker for routing messages between clients.
+     *
+     * - Application destination prefix: /app
+     *   Routes @MessageMapping handlers in @Controller classes
+     *   Example: /app/data → receives via @MessageMapping("/data")
+     *
+     * - Broker destination prefix: /topic and /queue
+     *   /topic: broadcast to multiple subscribers
+     *   /queue: point-to-point messaging
+     *
+     * - User destination prefix: /user
+     *   Enables per-user messaging via convertAndSendToUser()
+     *
+     * @param config the message broker registry
+     */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.initialize();
+
+        config
+                .enableSimpleBroker("/topic", "/queue")
+                .setHeartbeatValue(new long[]{25000, 25000})
+                .setTaskScheduler(scheduler);
+
+        config.setApplicationDestinationPrefixes("/app");
+        config.setUserDestinationPrefix("/user");
+    }
+}

--- a/backend/src/test/java/com/roomsystem/feature/receiver/ReceiverIntegrationTest.java
+++ b/backend/src/test/java/com/roomsystem/feature/receiver/ReceiverIntegrationTest.java
@@ -1,0 +1,145 @@
+package com.roomsystem.feature.receiver;
+
+import com.roomsystem.app.AppApplication;
+import com.roomsystem.feature.receiver.dto.SensorData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.converter.StringMessageConverter;
+import org.springframework.messaging.simp.stomp.*;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Integration test for {@link Receiver}.
+ *
+ * Simulates a STOMP client (e.g. Raspberry Pi) connecting over WebSocket
+ * and sending sensor data to /app/data. Verifies that the data reaches
+ * {@link SensorDataService#process(SensorData)}.
+ *
+ * Uses a real Spring Boot context on a random port to avoid port conflicts.
+ *
+ * Note: Payloads are sent as raw JSON strings (StringMessageConverter) to avoid
+ * dependency on deprecated Jackson 2 message converters. Spring Boot 4 uses
+ * Jackson 3 (tools.jackson) on the server side for deserialization.
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = AppApplication.class
+)
+class ReceiverIntegrationTest {
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Bean
+        SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
+            return http
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .csrf(csrf -> csrf.disable())
+                    .build();
+        }
+    }
+
+
+    @LocalServerPort
+    int port;
+
+    // Mock the service so we can verify it was called without needing a real DB
+    @MockitoBean
+    SensorDataService sensorDataService;
+
+    WebSocketStompClient stompClient;
+    JsonMapper jsonMapper;
+
+    @BeforeEach
+    void setUp() {
+        // Raw WebSocket client — matches how stomp.py connects (no SockJS)
+        stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+
+        // Send payloads as plain JSON strings — server deserializes via Jackson 3
+        stompClient.setMessageConverter(new StringMessageConverter());
+
+        // Jackson 3 JsonMapper for serializing SensorData in tests
+        // Dates are ISO-8601 by default in Jackson 3, no extra module needed
+        jsonMapper = JsonMapper.builder().build();
+    }
+
+    /**
+     * Happy path: a valid SensorData payload sent over STOMP reaches the service.
+     */
+    @Test
+    void shouldForwardSensorDataToService() throws Exception {
+        CompletableFuture<Void> connected = new CompletableFuture<>();
+
+        SensorData data = new SensorData("room-01", "sensor-01", 3, 0.9, Instant.now());
+        String payload = jsonMapper.writeValueAsString(data);
+
+        stompClient.connectAsync(
+                "ws://localhost:" + port + "/ws",
+                new StompSessionHandlerAdapter() {
+                    @Override
+                    public void afterConnected(StompSession session, StompHeaders headers) {
+                        session.send("/app/data", payload);
+                        connected.complete(null);
+                    }
+
+                    @Override
+                    public void handleTransportError(StompSession session, Throwable ex) {
+                        connected.completeExceptionally(ex);
+                    }
+                }
+        );
+
+        connected.get(5, TimeUnit.SECONDS);
+
+        // timeout(2000): Mockito polls up to 2s — avoids flaky Thread.sleep()
+        verify(sensorDataService, timeout(2000)).process(any(SensorData.class));
+    }
+
+    /**
+     * Zero-count: a valid payload with count=0 (room empty) still reaches the service.
+     * The service must not silently drop zero-count readings.
+     */
+    @Test
+    void shouldForwardZeroCountToService() throws Exception {
+        CompletableFuture<Void> connected = new CompletableFuture<>();
+
+        SensorData data = new SensorData("room-01", "sensor-01", 0, 1.0, Instant.now());
+        String payload = jsonMapper.writeValueAsString(data);
+
+        stompClient.connectAsync(
+                "ws://localhost:" + port + "/ws",
+                new StompSessionHandlerAdapter() {
+                    @Override
+                    public void afterConnected(StompSession session, StompHeaders headers) {
+                        session.send("/app/data", payload);
+                        connected.complete(null);
+                    }
+
+                    @Override
+                    public void handleTransportError(StompSession session, Throwable ex) {
+                        connected.completeExceptionally(ex);
+                    }
+                }
+        );
+
+        connected.get(5, TimeUnit.SECONDS);
+
+        verify(sensorDataService, timeout(2000)).process(any(SensorData.class));
+    }
+}

--- a/backend/src/test/java/com/roomsystem/feature/receiver/SensorDataServiceImplTest.java
+++ b/backend/src/test/java/com/roomsystem/feature/receiver/SensorDataServiceImplTest.java
@@ -1,0 +1,223 @@
+package com.roomsystem.feature.receiver;
+
+import com.roomsystem.feature.database.model.OccupancyData;
+import com.roomsystem.feature.database.service.OccupancyService;
+import com.roomsystem.feature.receiver.dto.SensorData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Unit tests for {@link SensorDataServiceImpl}.
+ *
+ * Tests the mapping of {@link SensorData} to {@link OccupancyData}
+ * and delegation to {@link OccupancyService}.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SensorDataServiceImpl Tests")
+class SensorDataServiceImplTest {
+
+    @Mock
+    private OccupancyService occupancyService;
+
+    private SensorDataServiceImpl sensorDataService;
+
+    @BeforeEach
+    void setUp() {
+        sensorDataService = new SensorDataServiceImpl(occupancyService);
+    }
+
+    @Test
+    @DisplayName("Should map all SensorData fields to OccupancyData correctly")
+    void testMappingAllFields() {
+        // Arrange
+        Instant timestamp = Instant.parse("2024-01-15T10:30:00Z");
+        SensorData sensorData = new SensorData(
+                "seminar-101",
+                "sensor-A",
+                5,
+                0.95,
+                timestamp
+        );
+
+        // Act
+        sensorDataService.process(sensorData);
+
+        // Assert
+        ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(captor.capture());
+
+        OccupancyData captured = captor.getValue();
+        assertThat(captured)
+                .extracting(
+                        OccupancyData::getRoomId,
+                        OccupancyData::getSensorId,
+                        OccupancyData::getCount,
+                        OccupancyData::getConfidence,
+                        OccupancyData::getTimestamp
+                )
+                .containsExactly(
+                        "seminar-101",
+                        "sensor-A",
+                        5,
+                        0.95,
+                        timestamp
+                );
+    }
+
+    @Test
+    @DisplayName("Should delegate to OccupancyService.recordOccupancy()")
+    void testDelegationToOccupancyService() {
+        // Arrange
+        SensorData sensorData = new SensorData(
+                "room-202",
+                "sensor-B",
+                8,
+                0.87,
+                Instant.now()
+        );
+
+        // Act
+        sensorDataService.process(sensorData);
+
+        // Assert
+        verify(occupancyService).recordOccupancy(org.mockito.ArgumentMatchers.any(OccupancyData.class));
+    }
+
+    @Test
+    @DisplayName("Should handle null SensorData gracefully")
+    void testHandleNullSensorData() {
+        // Act
+        sensorDataService.process(null);
+
+        // Assert
+        verify(occupancyService, never()).recordOccupancy(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("Should propagate exceptions from OccupancyService")
+    void testExceptionPropagation() {
+        // Arrange
+        SensorData sensorData = new SensorData(
+                "room-101",
+                "sensor-A",
+                3,
+                0.92,
+                Instant.now()
+        );
+        org.mockito.Mockito.doThrow(new RuntimeException("Database connection failed"))
+                .when(occupancyService).recordOccupancy(org.mockito.ArgumentMatchers.any());
+
+        // Act & Assert
+        assertThatThrownBy(() -> sensorDataService.process(sensorData))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("Database connection failed");
+    }
+
+    @Test
+    @DisplayName("Should handle edge case: confidence at boundaries")
+    void testConfidenceBoundaryValues() {
+        // Arrange - Test confidence = 0.0
+        SensorData lowConfidence = new SensorData(
+                "room-101",
+                "sensor-A",
+                0,
+                0.0,
+                Instant.now()
+        );
+
+        // Act
+        sensorDataService.process(lowConfidence);
+
+        // Assert
+        ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(captor.capture());
+        assertThat(captor.getValue().getConfidence()).isEqualTo(0.0);
+
+        // Arrange - Test confidence = 1.0
+        org.mockito.Mockito.reset(occupancyService);
+        SensorData highConfidence = new SensorData(
+                "room-101",
+                "sensor-A",
+                10,
+                1.0,
+                Instant.now()
+        );
+
+        // Act
+        sensorDataService.process(highConfidence);
+
+        // Assert
+        verify(occupancyService).recordOccupancy(captor.capture());
+        assertThat(captor.getValue().getConfidence()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("Should handle edge case: zero count")
+    void testZeroCountScenario() {
+        // Arrange
+        SensorData sensorData = new SensorData(
+                "room-101",
+                "sensor-A",
+                0,
+                0.85,
+                Instant.now()
+        );
+
+        // Act
+        sensorDataService.process(sensorData);
+
+        // Assert
+        ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(captor.capture());
+        assertThat(captor.getValue().getCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("Should handle edge case: large count values")
+    void testLargeCountScenario() {
+        // Arrange
+        SensorData sensorData = new SensorData(
+                "auditorium-001",
+                "sensor-master",
+                1000,
+                0.99,
+                Instant.now()
+        );
+
+        // Act
+        sensorDataService.process(sensorData);
+
+        // Assert
+        ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(captor.capture());
+        assertThat(captor.getValue().getCount()).isEqualTo(1000);
+    }
+
+    @Test
+    @DisplayName("Should handle multiple consecutive calls")
+    void testMultipleConsecutiveCalls() {
+        // Arrange
+        SensorData data1 = new SensorData("room-101", "sensor-A", 5, 0.9, Instant.now());
+        SensorData data2 = new SensorData("room-102", "sensor-B", 3, 0.85, Instant.now());
+
+        // Act
+        sensorDataService.process(data1);
+        sensorDataService.process(data2);
+
+        // Assert
+        verify(occupancyService, org.mockito.Mockito.times(2))
+                .recordOccupancy(org.mockito.ArgumentMatchers.any());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds **SensorDataServiceImpl** — maps incoming `SensorData` DTOs from the mmWave sensor to `OccupancyData` and persists them via `OccupancyService`; null input is handled gracefully, exceptions are propagated
- Adds **WebSocketConfig** — configures two STOMP endpoints (`/ws` for native clients like Raspberry Pi / stomp.py, `/ws/occupancy` with SockJS for browsers); registers a custom `Jackson3StompConverter` that accepts any content-type as JSON, solving deserialization for clients that omit the header; includes heartbeat scheduler

## Files Added

| File | Usage |
|------|-------|
| `SensorDataServiceImpl.java` | Maps SensorData → OccupancyData, delegates to OccupancyService |
| `WebSocketConfig.java` | STOMP endpoints, Jackson 3 message converter, heartbeat config |
| `SensorDataServiceImplTest.java` | 8 unit tests — field mapping, null, exceptions, boundary values |
| `ReceiverIntegrationTest.java` | 2 integration tests — real STOMP client over random port, MockitoBean for DB |