### PR TITLE
add: throughput and system metrics tracking #16

### DIFF
--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -5,8 +5,8 @@ ROOM_ID   = os.getenv("ROOM_ID",   "room-01")
 SENSOR_ID = os.getenv("SENSOR_ID", "sensor-01")
 
 # --- Serial ---
-SERIAL_CFG_PORT  = os.getenv("SERIAL_CFG_PORT",  "/dev/ttyUSB0")
-SERIAL_DATA_PORT = os.getenv("SERIAL_DATA_PORT", "/dev/ttyUSB1")
+SERIAL_CFG_PORT  = os.getenv("SERIAL_CFG_PORT",  "/dev/tty.usbserial-010BCEBF0")
+SERIAL_DATA_PORT = os.getenv("SERIAL_DATA_PORT", "/dev/tty.usbserial-010BCEBF1")
 SERIAL_CFG_BAUD  = 115200
 SERIAL_DATA_BAUD = 921600
 
@@ -19,6 +19,7 @@ STOMP_DESTINATION   = os.getenv("STOMP_DESTINATION",   "/app/data")
 # --- Queue & Processing ---
 QUEUE_MAX_SIZE      = int(os.getenv("QUEUE_MAX_SIZE",      "100"))
 PROCESSING_INTERVAL = float(os.getenv("PROCESSING_INTERVAL", "0.1"))  # seconds (= 10fps)
+METRICS_INTERVAL = float(os.getenv("METRICS_INTERVAL", "10")) # seconds between metric log lines
 
 # --- WebSocket Reconnect ---
 WS_RECONNECT_DELAY = int(os.getenv("WS_RECONNECT_DELAY", "5"))  # seconds until next try

--- a/raspberry/main.py
+++ b/raspberry/main.py
@@ -14,10 +14,12 @@ from config import (
     WS_RECONNECT_DELAY, WS_MAX_RETRIES, BACKEND_WS_PATH,
 )
 from sensor.receiver import open_ports, send_config, read_frame, CONFIG_FILE
+from sensor.metrics import ThroughputMetrics, start_metrics_monitor, log_snapshot
 from sender.processor import map_to_occupancy
 from mock_data import mock_sensor_loop
 from stomp import exception as stomp_exception
 
+# Logging configuration
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s %(levelname)s %(message)s',
@@ -26,7 +28,7 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 _queue: queue.Queue = queue.Queue(maxsize=QUEUE_MAX_SIZE)
-
+_metrics = ThroughputMetrics()
 
 def enqueue_frame(frame: dict) -> None:
     """
@@ -39,6 +41,7 @@ def enqueue_frame(frame: dict) -> None:
         try:
             _queue.get_nowait()  # drop oldest
             _queue.put_nowait(frame)
+            _metrics.record_dropped()
             log.warning("Queue full – oldest frame dropped.")
         except queue.Empty:
             pass
@@ -80,12 +83,15 @@ def _sender_loop() -> None:
 
         try:
             frame = _queue.get(timeout=1)
+            t_start = time.monotonic()
             payload = map_to_occupancy(frame)
             conn.send(
                 destination=STOMP_DESTINATION,
                 body=json.dumps(payload),
                 content_type="application/json",
             )
+            processing_ms = (time.monotonic() - t_start) * 1000
+            _metrics.record_sent(processing_ms)
             log.debug(f"Sent: {payload}")
         except queue.Empty:
             continue  # nothing to send, check connection and wait
@@ -103,18 +109,6 @@ def start_sender() -> None:
     t.start()
     log.info("Sender thread started.")
 
-def _queue_monitor_loop() -> None:
-    """Periodically logs the current queue length."""
-    while True:
-        log.info(f"Queue length: {_queue.qsize()}/{QUEUE_MAX_SIZE}")
-        time.sleep(10)
-
-
-def start_queue_monitor() -> None:
-    """Starts the queue monitor loop in a daemon thread."""
-    t = threading.Thread(target=_queue_monitor_loop, daemon=True)
-    t.start()
-    log.info("Queue monitor started.")
 
 # Set to False for real sensor data
 USE_MOCK = True
@@ -125,10 +119,14 @@ if __name__ == '__main__':
 
     try:
         start_sender()
-        start_queue_monitor()
+        start_metrics_monitor(_queue, _metrics)
 
         if USE_MOCK:
             mock_sensor_loop(enqueue_frame)
+            # wait for sender to drain the queue before logging final metrics
+            while not _queue.empty():
+                time.sleep(0.05)
+            log_snapshot(_queue, _metrics)
         else:
             cfg_port, data_port = open_ports()
             send_config(cfg_port, CONFIG_FILE)

--- a/raspberry/requirements.txt
+++ b/raspberry/requirements.txt
@@ -1,2 +1,3 @@
 pyserial==3.5
 stomp.py==8.1.2
+psutil==7.2.2

--- a/raspberry/sensor/metrics.py
+++ b/raspberry/sensor/metrics.py
@@ -1,0 +1,79 @@
+import collections
+import threading
+import time
+import logging
+import psutil
+
+from config import (
+    QUEUE_MAX_SIZE,
+    METRICS_INTERVAL )
+
+log = logging.getLogger(__name__)
+
+class ThroughputMetrics:
+    """Thread-safe counters for message throughput and processing latency."""
+
+    def __init__(self, max_samples: int = 100):
+        self._lock = threading.Lock()
+        self._sent = 0
+        self._dropped = 0
+        self._processing_times: collections.deque = collections.deque(maxlen=max_samples)
+
+    def record_sent(self, processing_ms: float) -> None:
+        with self._lock:
+            self._sent += 1
+            self._processing_times.append(processing_ms)
+
+    def record_dropped(self) -> None:
+        with self._lock:
+            self._dropped += 1
+
+    def snapshot(self) -> dict:
+        with self._lock:
+            times = list(self._processing_times)
+            sent = self._sent
+            dropped = self._dropped
+        avg_ms = sum(times) / len(times) if times else 0.0
+        return {
+            "sent": sent,
+            "dropped": dropped,
+            "avg_processing_ms": round(avg_ms, 2),
+        }
+
+def get_system_metrics() -> dict:
+    """
+    Collects current system metrics from the Raspberry Pi.
+
+    :return: Dictionary with cpu_percent and memory_percent
+    """
+    return {
+        "cpu_percent": psutil.cpu_percent(interval=1, percpu=False),
+        "memory_percent": psutil.virtual_memory().percent,
+    }
+
+def log_snapshot(_queue, _metrics) -> None:
+    """Logs a single metrics snapshot."""
+    sys_m = get_system_metrics()
+    thr_m = _metrics.snapshot()
+    log.info(
+        f"[metrics] "
+        f"cpu={sys_m['cpu_percent']}% "
+        f"mem={sys_m['memory_percent']}% "
+        f"queue={_queue.qsize()}/{QUEUE_MAX_SIZE} "
+        f"sent={thr_m['sent']} "
+        f"dropped={thr_m['dropped']} "
+        f"avg_processing={thr_m['avg_processing_ms']}ms"
+    )
+
+def _metrics_loop(_queue, _metrics) -> None:
+    """Periodically logs all system and throughput metrics (issue #16)."""
+    while True:
+        time.sleep(METRICS_INTERVAL)
+        log_snapshot(_queue, _metrics)
+
+
+def start_metrics_monitor(_queue, _metrics) -> None:
+    """Starts the metrics loop in a daemon thread."""
+    t = threading.Thread(target=_metrics_loop, args=(_queue, _metrics), daemon=True)
+    t.start()
+    log.info("Metrics monitor started.")


### PR DESCRIPTION
## Summary
- Add `ThroughputMetrics` class with thread-safe counters for sent and dropped messages
- Add `get_system_metrics()` for CPU and memory tracking on the Raspberry Pi
- Add periodic metrics logging via `start_metrics_monitor()` and `log_snapshot()`

> **Note:** This PR only covers local metrics collection and logging. Forwarding metrics data to the backend is out of scope and, if needed, will be addressed in a separate issue.

## Changes
- `raspberry/sensor/metrics.py` — new file: throughput and system metrics
- `raspberry/main.py` — integrate metrics monitor and delegate metrics logging to metrics.py
- `raspberry/config.py` — add `METRICS_INTERVAL` constant

## Test plan
- [x] Run with `USE_MOCK=True` and verify metrics are logged after the 10 frames are logged
- [x] Run with `USE_MOCK=False` and verify metrics are logged every 10 seconds


Closes #16 and Closes #14