### PR TITLE
feat: occupancy forecast based on weighted historical averages

### DIFF
--- a/backend/src/main/java/com/occupi/feature/forecast/ForecastController.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/ForecastController.java
@@ -1,0 +1,49 @@
+package com.occupi.feature.forecast;
+
+import com.occupi.feature.forecast.dto.ForecastResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoint for room occupancy forecasts.
+ *
+ * <pre>
+ * GET /api/forecast?roomId=room-42&forecastHours=2
+ * </pre>
+ */
+@RestController
+@RequestMapping("/api/forecast")
+public class ForecastController {
+
+    private final ForecastService forecastService;
+
+    public ForecastController(ForecastService forecastService) {
+        this.forecastService = forecastService;
+    }
+
+    /**
+     * Returns a predicted occupancy count for the given room and lookahead window.
+     *
+     * @param roomId  the room identifier (required)
+     * @param forecastHours the forecast horizon in hours (default: 2, must be &gt; 0)
+     * @return 200 OK with {@link ForecastResponse}, or 400 if parameters are invalid
+     */
+    @GetMapping
+    public ResponseEntity<ForecastResponse> getForecast(
+            @RequestParam String roomId,
+            @RequestParam(defaultValue = "2") int forecastHours) {
+
+        if (roomId == null || roomId.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        if (forecastHours <= 0) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        ForecastResponse response = forecastService.forecast(roomId, forecastHours);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/forecast/ForecastService.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/ForecastService.java
@@ -1,0 +1,15 @@
+package com.occupi.feature.forecast;
+
+import com.occupi.feature.forecast.dto.ForecastResponse;
+
+public interface ForecastService {
+
+    /**
+     * Produces a short-term occupancy forecast for the given room.
+     *
+     * @param roomId  the room to forecast
+     * @param minutes the lookahead horizon in minutes (e.g., 30)
+     * @return a {@link ForecastResponse} containing the predicted count and metadata
+     */
+    ForecastResponse forecast(String roomId, int hours);
+}

--- a/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
@@ -1,0 +1,144 @@
+package com.occupi.feature.forecast;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.forecast.dto.ForecastPoint;
+import com.occupi.feature.forecast.dto.ForecastResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Stream;
+
+@Slf4j
+@Service
+public class ForecastServiceImpl implements ForecastService {
+
+    private final InfluxDBClient influxDBClient;
+
+    @Value("${influxdb.measurement:occupancy}")
+    private String measurement;
+
+    @Value("${forecast.lookback-weeks:4}")
+    private int lookbackWeeks;
+
+    @Value("${forecast.slot-minutes:30}")
+    private int slotMinutes;
+
+    @Value("${forecast.decay:0.5}")
+    private double decay;
+
+    public ForecastServiceImpl(InfluxDBClient influxDBClient) {
+        this.influxDBClient = influxDBClient;
+    }
+
+    @Override
+    public ForecastResponse forecast(String roomId, int forecastHours) {
+        if (roomId == null || roomId.isBlank()) {
+            throw new IllegalArgumentException("roomId must not be blank");
+        }
+        if (!roomId.matches("[a-zA-Z0-9\\-]+")) {
+            throw new IllegalArgumentException("roomId contains invalid characters: " + roomId);
+        }
+        if (forecastHours <= 0) {
+            throw new IllegalArgumentException("forecastHours must be positive, got: " + forecastHours);
+        }
+
+        Instant now = Instant.now();
+        Instant forecastEnd = now.plus(forecastHours, ChronoUnit.HOURS);
+
+        // slot key → weighted sum and total weight
+        Map<Long, double[]> slotBuckets = new LinkedHashMap<>(); // [weightedSum, totalWeight]
+
+        for (int week = 1; week <= lookbackWeeks; week++) {
+            Instant windowStart = now.minus(week * 7L, ChronoUnit.DAYS);
+            Instant windowEnd   = forecastEnd.minus(week * 7L, ChronoUnit.DAYS);
+            double weight       = Math.pow(decay, week - 1); // 1.0, 0.5, 0.25, 0.125, …
+
+            queryReadings(roomId, windowStart, windowEnd).forEach(row -> {
+                double count    = ((Number) row[0]).doubleValue();
+                Instant ts      = (Instant) row[1];
+                long slotKey    = toSlotKey(ts);
+
+                double[] bucket = slotBuckets.computeIfAbsent(slotKey, k -> new double[]{0.0, 0.0});
+                bucket[0] += count * weight;  // weighted sum
+                bucket[1] += weight;          // total weight
+            });
+        }
+
+        List<ForecastPoint> points = slotBuckets.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .filter(e -> e.getValue()[1] > 0)  // skip slots with no data
+                .map(e -> {
+                    double weightedAvg = e.getValue()[0] / e.getValue()[1];
+                    Instant slotInstant = toInstant(now, forecastHours, e.getKey());
+                    return new ForecastPoint(slotInstant, weightedAvg);
+                })
+                .toList();
+
+        double confidence = computeConfidence(slotBuckets, forecastHours);
+
+        log.debug("Forecast for room={} horizon={}h: points={} confidence={}",
+                roomId, forecastHours, points.size(), confidence);
+
+        return new ForecastResponse(roomId, forecastHours, points, confidence, now);
+    }
+
+    private List<Object[]> queryReadings(String roomId, Instant windowStart, Instant windowEnd) {
+        String sql = """
+            SELECT "count", time
+            FROM "%s"
+            WHERE "roomId" = '%s'
+              AND time >= '%s'
+              AND time < '%s'
+            ORDER BY time ASC
+            """.formatted(measurement, roomId, windowStart, windowEnd);
+
+        List<Object[]> result = new ArrayList<>();
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            rows.forEach(row -> {
+                if (row.length >= 2 && row[0] != null && row[1] != null) {
+                    result.add(row);
+                }
+            });
+        }
+        return result;
+    }
+
+    private long toSlotKey(Instant timestamp) {
+        ZonedDateTime zdt = timestamp.atZone(ZoneId.systemDefault());
+        long minuteOfDay = zdt.getHour() * 60L + zdt.getMinute();
+        return (minuteOfDay / slotMinutes) * slotMinutes;
+    }
+
+    /**
+     * Reconstructs the correct forecast-window date for a slot key.
+     * Slots before the current time-of-day belong to tomorrow if the
+     * forecast window spans midnight.
+     */
+    private Instant toInstant(Instant base, int forecastHours, long slotKeyMinutes) {
+        ZonedDateTime today = base.atZone(ZoneId.systemDefault()).truncatedTo(ChronoUnit.DAYS);
+        ZonedDateTime candidate = today.plusMinutes(slotKeyMinutes);
+
+        // If the slot is in the past relative to now, it must belong to tomorrow
+        if (candidate.toInstant().isBefore(base)) {
+            candidate = candidate.plusDays(1);
+        }
+        return candidate.toInstant();
+    }
+
+    private double computeConfidence(Map<Long, double[]> buckets, int forecastHours) {
+        int expectedSlots = (forecastHours * 60) / slotMinutes;
+        int expectedTotal = expectedSlots * lookbackWeeks;
+        if (expectedTotal == 0) return 1.0;
+        // Each slot's total weight reflects how many weeks contributed data
+        double actualWeight = buckets.values().stream().mapToDouble(b -> b[1]).sum();
+        double maxWeight = expectedTotal * 1.0; // max if all weeks had data, weight=1 each
+        return Math.min(1.0, actualWeight / maxWeight);
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/forecast/dto/ForecastPoint.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/dto/ForecastPoint.java
@@ -1,0 +1,14 @@
+package com.occupi.feature.forecast.dto;
+
+import java.time.Instant;
+
+/**
+ * A single point in a forecast series.
+ *
+ * @param time           the instant this prediction applies to
+ * @param predictedCount the expected number of occupants at that instant
+ */
+public record ForecastPoint(
+        Instant time,
+        double predictedCount
+) {}

--- a/backend/src/main/java/com/occupi/feature/forecast/dto/ForecastResponse.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/dto/ForecastResponse.java
@@ -1,0 +1,21 @@
+package com.occupi.feature.forecast.dto;
+
+import java.time.Instant;
+
+/**
+ * Response DTO for a room occupancy forecast.
+ *
+ * @param roomId          the room for which the forecast was computed
+ * @param forecastMinutes the lookahead window in minutes that was requested
+ * @param predictedCount  the predicted number of occupants (sliding-window average)
+ * @param confidence      coverage ratio in [0.0, 1.0]; 1.0 = full historical
+ *                        window was populated with data points
+ * @param generatedAt     the instant the forecast was produced
+ */
+public record ForecastResponse(
+        String roomId,
+        int forecastMinutes,
+        double predictedCount,
+        double confidence,
+        Instant generatedAt
+) {}

--- a/backend/src/main/java/com/occupi/feature/forecast/dto/ForecastResponse.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/dto/ForecastResponse.java
@@ -1,21 +1,22 @@
 package com.occupi.feature.forecast.dto;
 
 import java.time.Instant;
+import java.util.List;
 
 /**
  * Response DTO for a room occupancy forecast.
  *
- * @param roomId          the room for which the forecast was computed
- * @param forecastMinutes the lookahead window in minutes that was requested
- * @param predictedCount  the predicted number of occupants (sliding-window average)
- * @param confidence      coverage ratio in [0.0, 1.0]; 1.0 = full historical
- *                        window was populated with data points
- * @param generatedAt     the instant the forecast was produced
+ * @param roomId        the room for which the forecast was computed
+ * @param forecastHours the lookahead window in hours that was requested
+ * @param forecast      the list of predicted occupancy points over the horizon
+ * @param confidence    coverage ratio in [0.0, 1.0]; 1.0 = full historical
+ *                      window was populated with data points
+ * @param generatedAt   the instant the forecast was produced
  */
 public record ForecastResponse(
         String roomId,
-        int forecastMinutes,
-        double predictedCount,
+        int forecastHours,
+        List<ForecastPoint> forecast,
         double confidence,
         Instant generatedAt
 ) {}

--- a/backend/src/test/java/com/occupi/feature/forecast/ForecastControllerTest.java
+++ b/backend/src/test/java/com/occupi/feature/forecast/ForecastControllerTest.java
@@ -1,0 +1,84 @@
+package com.occupi.feature.forecast;
+
+import com.occupi.feature.forecast.dto.ForecastPoint;
+import com.occupi.feature.forecast.dto.ForecastResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ForecastControllerTest {
+
+    @Mock
+    private ForecastService forecastService;
+
+    @InjectMocks
+    private ForecastController controller;
+
+    private ForecastResponse sampleResponse;
+
+    @BeforeEach
+    void setUp() {
+        sampleResponse = new ForecastResponse(
+                "room-1",
+                2,
+                List.of(
+                        new ForecastPoint(Instant.parse("2025-01-07T09:00:00Z"), 3.5),
+                        new ForecastPoint(Instant.parse("2025-01-07T09:30:00Z"), 4.0)
+                ),
+                0.8,
+                Instant.now()
+        );
+    }
+
+    @Test
+    @DisplayName("returns 200 with forecast when roomId and forecastHours are valid")
+    void getForecast_validParams_returns200() {
+        when(forecastService.forecast("room-1", 2)).thenReturn(sampleResponse);
+
+        ResponseEntity<ForecastResponse> response = controller.getForecast("room-1", 2);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(sampleResponse);
+        verify(forecastService).forecast("room-1", 2);
+    }
+
+    @Test
+    @DisplayName("returns 400 when roomId is blank")
+    void getForecast_blankRoomId_returns400() {
+        ResponseEntity<ForecastResponse> response = controller.getForecast("  ", 2);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(forecastService);
+    }
+
+    @Test
+    @DisplayName("returns 400 when forecastHours is zero")
+    void getForecast_zeroHours_returns400() {
+        ResponseEntity<ForecastResponse> response = controller.getForecast("room-1", 0);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(forecastService);
+    }
+
+    @Test
+    @DisplayName("returns 400 when forecastHours is negative")
+    void getForecast_negativeHours_returns400() {
+        ResponseEntity<ForecastResponse> response = controller.getForecast("room-1", -10);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(forecastService);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
@@ -1,0 +1,189 @@
+package com.occupi.feature.forecast;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.forecast.dto.ForecastResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ForecastServiceImplTest {
+
+    @Mock
+    private InfluxDBClient influxDBClient;
+
+    private ForecastServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ForecastServiceImpl(influxDBClient);
+        // Mirror the @Value defaults used in production
+        ReflectionTestUtils.setField(service, "measurement", "occupancy");
+        ReflectionTestUtils.setField(service, "database", "occupi");
+        ReflectionTestUtils.setField(service, "sensorIntervalSeconds", 30);
+    }
+
+    // -------------------------------------------------------------------------
+    // Input validation
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("forecast() throws when roomId is null")
+    void forecast_nullRoomId_throws() {
+        assertThatThrownBy(() -> service.forecast(null, 30))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("roomId");
+    }
+
+    @Test
+    @DisplayName("forecast() throws when roomId is blank")
+    void forecast_blankRoomId_throws() {
+        assertThatThrownBy(() -> service.forecast("  ", 30))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("roomId");
+    }
+
+    @Test
+    @DisplayName("forecast() throws when minutes is zero or negative")
+    void forecast_nonPositiveMinutes_throws() {
+        assertThatThrownBy(() -> service.forecast("room-1", 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("minutes");
+
+        assertThatThrownBy(() -> service.forecast("room-1", -5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("minutes");
+    }
+
+    // -------------------------------------------------------------------------
+    // Algorithm correctness
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("predictedCount is the average of all returned count values")
+    void forecast_returnsAverageCount() {
+        // Simulate three rows with counts 2, 4, 6 → expected average = 4.0
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenReturn(Stream.of(
+                        new Object[]{2},
+                        new Object[]{4},
+                        new Object[]{6}
+                ));
+
+        ForecastResponse response = service.forecast("room-42", 30);
+
+        assertThat(response.predictedCount()).isCloseTo(4.0, within(0.001));
+    }
+
+    @Test
+    @DisplayName("predictedCount is 0.0 when no historical data exists")
+    void forecast_noData_returnsZero() {
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenReturn(Stream.empty());
+
+        ForecastResponse response = service.forecast("room-42", 30);
+
+        assertThat(response.predictedCount()).isZero();
+    }
+
+    // -------------------------------------------------------------------------
+    // Confidence
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("confidence is 1.0 when data points fill the entire window")
+    void forecast_fullWindow_confidenceIsOne() {
+        // 30-min window, 30 s interval → 60 expected points; supply exactly 60
+        Stream<Object[]> rows = Stream.iterate(new Object[]{3}, r -> new Object[]{3}).limit(60);
+        when(influxDBClient.query(anyString(), any(QueryOptions.class))).thenReturn(rows);
+
+        ForecastResponse response = service.forecast("room-1", 30);
+
+        assertThat(response.confidence()).isCloseTo(1.0, within(0.001));
+    }
+
+    @Test
+    @DisplayName("confidence is 0.0 when no data points are available")
+    void forecast_noData_confidenceIsZero() {
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenReturn(Stream.empty());
+
+        ForecastResponse response = service.forecast("room-1", 30);
+
+        assertThat(response.confidence()).isZero();
+    }
+
+    @Test
+    @DisplayName("confidence is capped at 1.0 even if sensor reported more often than interval")
+    void forecast_excessData_confidenceCappedAtOne() {
+        // 60 expected, 120 actual — should not exceed 1.0
+        Stream<Object[]> rows = Stream.iterate(new Object[]{1}, r -> new Object[]{1}).limit(120);
+        when(influxDBClient.query(anyString(), any(QueryOptions.class))).thenReturn(rows);
+
+        ForecastResponse response = service.forecast("room-1", 30);
+
+        assertThat(response.confidence()).isLessThanOrEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("confidence is proportional when window is partially populated")
+    void forecast_partialWindow_confidenceIsProportional() {
+        // 60 expected, 30 actual → confidence should be ~0.5
+        Stream<Object[]> rows = Stream.iterate(new Object[]{2}, r -> new Object[]{2}).limit(30);
+        when(influxDBClient.query(anyString(), any(QueryOptions.class))).thenReturn(rows);
+
+        ForecastResponse response = service.forecast("room-1", 30);
+
+        assertThat(response.confidence()).isCloseTo(0.5, within(0.001));
+    }
+
+    // -------------------------------------------------------------------------
+    // Response metadata
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("response carries back the original roomId and forecastMinutes")
+    void forecast_responseMetadata() {
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.of(
+                        new Object[]{2},
+                        new Object[]{4},
+                        new Object[]{6}
+                ));
+
+        ForecastResponse response = service.forecast("room-99", 15);
+
+        assertThat(response.roomId()).isEqualTo("room-99");
+        assertThat(response.forecastMinutes()).isEqualTo(15);
+        assertThat(response.generatedAt()).isNotNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // Resilience
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("InfluxDB query failure propagates the exception")
+    void forecast_influxFailure_propagatesException() {
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenThrow(new RuntimeException("connection refused"));
+
+        assertThatThrownBy(() -> service.forecast("room-1", 30))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("connection refused");
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
@@ -11,13 +11,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Instant;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.within;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,162 +26,86 @@ class ForecastServiceImplTest {
 
     private ForecastServiceImpl service;
 
+    // Fixed timestamp well away from slot boundaries and midnight
+    private static final Instant FIXED_TS = Instant.parse("2025-01-13T10:15:00Z");
+
     @BeforeEach
     void setUp() {
         service = new ForecastServiceImpl(influxDBClient);
-        // Mirror the @Value defaults used in production
-        ReflectionTestUtils.setField(service, "measurement", "occupancy");
-        ReflectionTestUtils.setField(service, "database", "occupi");
-        ReflectionTestUtils.setField(service, "sensorIntervalSeconds", 30);
-    }
-
-    // -------------------------------------------------------------------------
-    // Input validation
-    // -------------------------------------------------------------------------
-
-    @Test
-    @DisplayName("forecast() throws when roomId is null")
-    void forecast_nullRoomId_throws() {
-        assertThatThrownBy(() -> service.forecast(null, 30))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("roomId");
+        ReflectionTestUtils.setField(service, "measurement",  "occupancy");
+        ReflectionTestUtils.setField(service, "lookbackWeeks", 4);
+        ReflectionTestUtils.setField(service, "slotMinutes",  30);
+        ReflectionTestUtils.setField(service, "decay",        0.5);
     }
 
     @Test
-    @DisplayName("forecast() throws when roomId is blank")
+    @DisplayName("applies exponential weighting across weeks — most recent week counts most")
+    void forecast_appliesExponentialWeighting() {
+        // week 1 (weight 1.0): count=2, week 2 (0.5): count=4,
+        // week 3 (0.25): count=4, week 4 (0.125): count=6
+        // weighted avg = (2×1.0 + 4×0.5 + 4×0.25 + 6×0.125) / (1.0+0.5+0.25+0.125)
+        //              = (2 + 2 + 1 + 0.75) / 1.875 = 5.75 / 1.875 ≈ 3.067
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{2.0, FIXED_TS}))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, FIXED_TS}))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, FIXED_TS}))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{6.0, FIXED_TS}));
+
+        ForecastResponse response = service.forecast("room-1", 2);
+
+        assertThat(response.forecast()).hasSize(1);
+        assertThat(response.forecast().get(0).predictedCount())
+                .isCloseTo(3.067, within(0.001));
+    }
+
+    @Test
+    @DisplayName("returns empty forecast when no historical data exists")
+    void forecast_noData_returnsEmptyPoints() {
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.empty());
+
+        ForecastResponse response = service.forecast("room-1", 2);
+
+        assertThat(response.forecast()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("skips weeks with missing data without skewing the average")
+    void forecast_skipsWeeksWithNoData() {
+        // Only weeks 1 and 3 return data — week 2 and 4 are empty
+        // week 1 (weight 1.0): count=4, week 3 (weight 0.25): count=8
+        // weighted avg = (4×1.0 + 8×0.25) / (1.0+0.25) = 6.0 / 1.25 = 4.8
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, FIXED_TS}))
+                .thenAnswer(inv -> Stream.empty())
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{8.0, FIXED_TS}))
+                .thenAnswer(inv -> Stream.empty());
+
+        ForecastResponse response = service.forecast("room-1", 2);
+
+        assertThat(response.forecast()).hasSize(1);
+        assertThat(response.forecast().get(0).predictedCount())
+                .isCloseTo(4.8, within(0.001));
+    }
+
+    @Test
+    @DisplayName("throws on blank roomId")
     void forecast_blankRoomId_throws() {
-        assertThatThrownBy(() -> service.forecast("  ", 30))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("roomId");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> service.forecast("  ", 2));
     }
 
     @Test
-    @DisplayName("forecast() throws when minutes is zero or negative")
-    void forecast_nonPositiveMinutes_throws() {
-        assertThatThrownBy(() -> service.forecast("room-1", 0))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("minutes");
-
-        assertThatThrownBy(() -> service.forecast("room-1", -5))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("minutes");
-    }
-
-    // -------------------------------------------------------------------------
-    // Algorithm correctness
-    // -------------------------------------------------------------------------
-
-    @Test
-    @DisplayName("predictedCount is the average of all returned count values")
-    void forecast_returnsAverageCount() {
-        // Simulate three rows with counts 2, 4, 6 → expected average = 4.0
-        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenReturn(Stream.of(
-                        new Object[]{2},
-                        new Object[]{4},
-                        new Object[]{6}
-                ));
-
-        ForecastResponse response = service.forecast("room-42", 30);
-
-        assertThat(response.predictedCount()).isCloseTo(4.0, within(0.001));
+    @DisplayName("throws on roomId with invalid characters")
+    void forecast_invalidRoomId_throws() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> service.forecast("room'; DROP TABLE--", 2));
     }
 
     @Test
-    @DisplayName("predictedCount is 0.0 when no historical data exists")
-    void forecast_noData_returnsZero() {
-        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenReturn(Stream.empty());
-
-        ForecastResponse response = service.forecast("room-42", 30);
-
-        assertThat(response.predictedCount()).isZero();
-    }
-
-    // -------------------------------------------------------------------------
-    // Confidence
-    // -------------------------------------------------------------------------
-
-    @Test
-    @DisplayName("confidence is 1.0 when data points fill the entire window")
-    void forecast_fullWindow_confidenceIsOne() {
-        // 30-min window, 30 s interval → 60 expected points; supply exactly 60
-        Stream<Object[]> rows = Stream.iterate(new Object[]{3}, r -> new Object[]{3}).limit(60);
-        when(influxDBClient.query(anyString(), any(QueryOptions.class))).thenReturn(rows);
-
-        ForecastResponse response = service.forecast("room-1", 30);
-
-        assertThat(response.confidence()).isCloseTo(1.0, within(0.001));
-    }
-
-    @Test
-    @DisplayName("confidence is 0.0 when no data points are available")
-    void forecast_noData_confidenceIsZero() {
-        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenReturn(Stream.empty());
-
-        ForecastResponse response = service.forecast("room-1", 30);
-
-        assertThat(response.confidence()).isZero();
-    }
-
-    @Test
-    @DisplayName("confidence is capped at 1.0 even if sensor reported more often than interval")
-    void forecast_excessData_confidenceCappedAtOne() {
-        // 60 expected, 120 actual — should not exceed 1.0
-        Stream<Object[]> rows = Stream.iterate(new Object[]{1}, r -> new Object[]{1}).limit(120);
-        when(influxDBClient.query(anyString(), any(QueryOptions.class))).thenReturn(rows);
-
-        ForecastResponse response = service.forecast("room-1", 30);
-
-        assertThat(response.confidence()).isLessThanOrEqualTo(1.0);
-    }
-
-    @Test
-    @DisplayName("confidence is proportional when window is partially populated")
-    void forecast_partialWindow_confidenceIsProportional() {
-        // 60 expected, 30 actual → confidence should be ~0.5
-        Stream<Object[]> rows = Stream.iterate(new Object[]{2}, r -> new Object[]{2}).limit(30);
-        when(influxDBClient.query(anyString(), any(QueryOptions.class))).thenReturn(rows);
-
-        ForecastResponse response = service.forecast("room-1", 30);
-
-        assertThat(response.confidence()).isCloseTo(0.5, within(0.001));
-    }
-
-    // -------------------------------------------------------------------------
-    // Response metadata
-    // -------------------------------------------------------------------------
-
-    @Test
-    @DisplayName("response carries back the original roomId and forecastMinutes")
-    void forecast_responseMetadata() {
-        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenAnswer(inv -> Stream.of(
-                        new Object[]{2},
-                        new Object[]{4},
-                        new Object[]{6}
-                ));
-
-        ForecastResponse response = service.forecast("room-99", 15);
-
-        assertThat(response.roomId()).isEqualTo("room-99");
-        assertThat(response.forecastMinutes()).isEqualTo(15);
-        assertThat(response.generatedAt()).isNotNull();
-    }
-
-    // -------------------------------------------------------------------------
-    // Resilience
-    // -------------------------------------------------------------------------
-
-    @Test
-    @DisplayName("InfluxDB query failure propagates the exception")
-    void forecast_influxFailure_propagatesException() {
-        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenThrow(new RuntimeException("connection refused"));
-
-        assertThatThrownBy(() -> service.forecast("room-1", 30))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("connection refused");
+    @DisplayName("throws on non-positive forecastHours")
+    void forecast_negativeHours_throws() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> service.forecast("room-1", 0));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ForecastServiceImpl` — computes expected room occupancy over a configurable horizon by querying InfluxDB for the past N weeks, bucketing readings into 30-minute slots, and applying an exponentially weighted average so recent weeks contribute more; empty slots are skipped and confidence is reported based on historical data coverage

- Adds `ForecastController` — exposes `GET /api/forecast?roomId=&forecastHours=` and delegates all validation to the service layer

## Files Added
| File | Usage|
| --- | --- |
| `ForecastService` | Interface defining the forecast contract |
| `ForecastServiceImpl.java` | Queries InfluxDB, applies exponential decay weighting across lookback weeks, returns predicted counts per slot |
| `ForecastController.java` | REST endpoint, delegates to ForecastService |
| `ForecastPoint.java` | DTO for a single predicted occupancy value at a given instant |
| `ForecastResponse.java` | DTO wrapping room, horizon, forecast points, confidence, and generation timestamp |
| `ForecastServiceImplTest.java` | 6 unit tests — exponential weighting, skipped weeks, empty data, invalid input |
| `ForecastControllerTest.java` | 4 unit tests — return 200 when valid, return 400 when invalid|