### PR TITLE
feat: Rasperry Pi metrics receiver and metrics measurement

### DIFF
--- a/backend/src/main/java/com/occupi/feature/database/model/MetricsData.java
+++ b/backend/src/main/java/com/occupi/feature/database/model/MetricsData.java
@@ -1,0 +1,23 @@
+package com.occupi.feature.database.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MetricsData {
+    String sensorId;
+    double cpuPercentage;
+    double memoryPercentage;
+    int queueSize;
+    int sent;
+    int dropped;
+    float avgProcessTime;
+    Instant timestamp;
+}

--- a/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
@@ -1,0 +1,106 @@
+package com.occupi.feature.database.repository;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.Point;
+import com.occupi.feature.database.model.MetricsData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class MetricsRepository {
+
+    static final String MEASUREMENT_NAME = "metrics";
+
+    private final InfluxDBClient influxDBClient;
+
+    public void save(MetricsData metrics) {
+        validate(metrics);
+        assignTimestampIfMissing(metrics);
+
+        Point point = toPoint(metrics);
+        influxDBClient.writePoint(point);
+
+        log.debug("Saved metrics data: sensorId={}, cpuPercentage={}, " +
+                        "memoryPercentage={}, queueSize={}, " +
+                        "sent={}, dropped={}, avgProcessTime={}, ts={}",
+                metrics.getSensorId(),
+                metrics.getCpuPercentage(),
+                metrics.getMemoryPercentage(),
+                metrics.getQueueSize(),
+                metrics.getSent(),
+                metrics.getDropped(),
+                metrics.getAvgProcessTime(),
+                metrics.getTimestamp());
+    }
+
+    public void saveBatch(List<MetricsData> batch) {
+        if (batch == null || batch.isEmpty()) {
+            throw new IllegalArgumentException("Batch must not be null or empty");
+        }
+
+        batch.forEach(this::validate);
+        batch.forEach(this::assignTimestampIfMissing);
+
+        List<Point> points = batch.stream()
+                .map(this::toPoint)
+                .toList();
+
+        influxDBClient.writePoints(points);
+
+        log.debug("Saved batch of {} metrics measurements", batch.size());
+    }
+
+    private Point toPoint(MetricsData metrics) {
+        return Point.measurement(MEASUREMENT_NAME)
+                .setTag("sensorId", metrics.getSensorId())
+                .setFloatField("cpuPercentage", metrics.getCpuPercentage())
+                .setFloatField("memoryPercentage", metrics.getMemoryPercentage())
+                .setIntegerField("queueSize", metrics.getQueueSize())
+                .setIntegerField("sent", metrics.getSent())
+                .setIntegerField("dropped", metrics.getDropped())
+                .setFloatField("avgProcessTime", metrics.getAvgProcessTime())
+                .setTimestamp(metrics.getTimestamp());
+    }
+
+    private void validate(MetricsData metrics) {
+        if (metrics == null) {
+            throw new IllegalArgumentException("metrics is null");
+        }
+        if (metrics.getSensorId() == null || metrics.getSensorId().isBlank()) {
+            throw new IllegalArgumentException("metrics sensorId is null or blank");
+        }
+        if (metrics.getTimestamp() == null) {
+            throw new IllegalArgumentException("metrics timestamp is null");
+        }
+        if (metrics.getCpuPercentage() < 0 || metrics.getCpuPercentage() > 100) {
+            throw new IllegalArgumentException("metrics cpuPercentage out of range [0, 100]");
+        }
+        if (metrics.getMemoryPercentage() < 0) {
+            throw new IllegalArgumentException("metrics memoryPercentage is negative");
+        }
+        if (metrics.getQueueSize() < 0) {
+            throw new IllegalArgumentException("metrics queue size is negative");
+        }
+        if (metrics.getSent() < 0) {
+            throw new IllegalArgumentException("metrics sent is negative");
+        }
+        if (metrics.getDropped() < 0) {
+            throw new IllegalArgumentException("metrics dropped is negative");
+        }
+        if (metrics.getAvgProcessTime() < 0) {
+            throw new IllegalArgumentException("metrics avgProcessTime is negative");
+        }
+    }
+
+    private void assignTimestampIfMissing(MetricsData metrics) {
+       if (metrics.getTimestamp() == null) {
+           metrics.setTimestamp(Instant.now());
+       }
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/database/service/MetricsService.java
+++ b/backend/src/main/java/com/occupi/feature/database/service/MetricsService.java
@@ -1,0 +1,36 @@
+package com.occupi.feature.database.service;
+
+import com.occupi.feature.database.model.MetricsData;
+import com.occupi.feature.database.repository.MetricsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MetricsService {
+
+    private final MetricsRepository metricsRepository;
+
+    public void recordMetrics(MetricsData metricsData) {
+        metricsRepository.save(metricsData);
+        log.info("Recording metrics: sensor={}, cpu={}, memory={}, queueSize={}, sent={}, dropped={}, avgProcessTime={}",
+                metricsData.getSensorId(),
+                metricsData.getCpuPercentage(),
+                metricsData.getMemoryPercentage(),
+                metricsData.getQueueSize(),
+                metricsData.getSent(),
+                metricsData.getDropped(),
+                metricsData.getAvgProcessTime()
+                );
+
+    }
+
+    public void recordMetricsBatch(List<MetricsData> metricsData) {
+        log.info("Recording batch of {} metrics", metricsData.size());
+        metricsRepository.saveBatch(metricsData);
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/receiver/MetricsReceiver.java
+++ b/backend/src/main/java/com/occupi/feature/receiver/MetricsReceiver.java
@@ -1,0 +1,33 @@
+package com.occupi.feature.receiver;
+
+import com.occupi.feature.receiver.dto.Metrics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+/**
+ * STOMP controller that receives Pi health metrics from Raspberry Pi devices.
+ *
+ * Pi clients send to: /app/metrics
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class MetricsReceiver {
+
+    private final PiMetricsService piMetricsService;
+
+    /**
+     * Listens for incoming Pi metrics via STOMP and forwards them to the service.
+     */
+    @MessageMapping("/metrics")
+    public void receive(Metrics metrics) {
+        if (metrics == null) {
+            log.warn("Received null PiMetrics, ignoring");
+            return;
+        }
+        log.debug("Received metrics from sensor={}", metrics.sensorId());
+        piMetricsService.process(metrics);
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/receiver/MetricsService.java
+++ b/backend/src/main/java/com/occupi/feature/receiver/MetricsService.java
@@ -1,0 +1,7 @@
+package com.occupi.feature.receiver;
+
+import com.occupi.feature.receiver.dto.Metrics;
+
+public interface MetricsService {
+    void process(Metrics metrics);
+}

--- a/backend/src/main/java/com/occupi/feature/receiver/PiMetricsService.java
+++ b/backend/src/main/java/com/occupi/feature/receiver/PiMetricsService.java
@@ -2,6 +2,6 @@ package com.occupi.feature.receiver;
 
 import com.occupi.feature.receiver.dto.Metrics;
 
-public interface MetricsService {
+public interface PiMetricsService {
     void process(Metrics metrics);
 }

--- a/backend/src/main/java/com/occupi/feature/receiver/PiMetricsServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/receiver/PiMetricsServiceImpl.java
@@ -1,0 +1,77 @@
+package com.occupi.feature.receiver;
+
+import com.occupi.feature.database.model.MetricsData;
+import com.occupi.feature.database.service.MetricsService;
+import com.occupi.feature.receiver.dto.Metrics;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * Implementation of {@link PiMetricsService}.
+ *
+ * Transforms incoming Pi metrics from the Raspberry Pi into metrics records
+ * and persists them via the database layer.
+ *
+ * Responsibilities:
+ * - Map {@link Metrics} (receiver DTO) to {@link MetricsData} (database model)
+ * - Delegate persistence to {@link MetricsService}
+ * - Handle null or invalid input gracefully
+ *
+ * Note: This service follows the Package by Feature pattern and communicates
+ * with the database feature only through {@link MetricsService}.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PiMetricsServiceImpl implements PiMetricsService {
+
+    private final MetricsService metricsService;
+
+    /**
+     * Processes incoming Pi metrics by mapping them to a metrics record
+     * and persisting it to the database.
+     *
+     * @param metrics the Pi metrics received via STOMP
+     *                If null, the data is silently ignored.
+     */
+    @Override
+    public void process(Metrics metrics) {
+        if (metrics == null) {
+            log.warn("Received null PiMetrics, ignoring");
+            return;
+        }
+
+        try {
+            MetricsData metricsData = mapToMetricsData(metrics);
+
+            metricsService.recordMetrics(metricsData);
+
+            log.debug("Successfully processed Pi metrics: sensor={}, cpu={}, memory={}, queueSize={}, dropped={}",
+                    metrics.sensorId(), metrics.cpuPercentage(), metrics.memoryPercentage(),
+                    metrics.queueSize(), metrics.dropped());
+        } catch (Exception e) {
+            log.error("Error processing Pi metrics for sensor={}", metrics.sensorId(), e);
+            throw e;
+        }
+    }
+
+    /**
+     * Maps a {@link Metrics} (receiver DTO) to {@link MetricsData} (database model).
+     *
+     * @param metrics the Pi metrics to map
+     * @return the mapped metrics data ready for persistence
+     */
+    private MetricsData mapToMetricsData(Metrics metrics) {
+        return MetricsData.builder()
+                .sensorId(metrics.sensorId())
+                .cpuPercentage(metrics.cpuPercentage())
+                .memoryPercentage(metrics.memoryPercentage())
+                .queueSize(metrics.queueSize())
+                .sent(metrics.sent())
+                .dropped(metrics.dropped())
+                .avgProcessTime(metrics.avgProcessTime())
+                .timestamp(metrics.timestamp())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/receiver/dto/Metrics.java
+++ b/backend/src/main/java/com/occupi/feature/receiver/dto/Metrics.java
@@ -3,7 +3,7 @@ package com.occupi.feature.receiver.dto;
 import java.time.Instant;
 
 public record Metrics(
-  String sensorID,
+  String sensorId,
   double cpuPercentage,
   double memoryPercentage,
   int queueSize,

--- a/backend/src/main/java/com/occupi/feature/receiver/dto/Metrics.java
+++ b/backend/src/main/java/com/occupi/feature/receiver/dto/Metrics.java
@@ -1,0 +1,14 @@
+package com.occupi.feature.receiver.dto;
+
+import java.time.Instant;
+
+public record Metrics(
+  String sensorID,
+  double cpuPercentage,
+  double memoryPercentage,
+  int queueSize,
+  int sent,
+  int dropped,
+  float avgProcessTime,
+  Instant timestamp
+) {}


### PR DESCRIPTION
## Summary

- Adds `PiMetricsService` interface and `PiMetricsServiceImpl` — receives Pi health metrics via STOMP, maps them to `MetricsData`, and persists them to InfluxDB under the `metrics` measurement
- Adds MetricsReceiver — STOMP controller listening on /app/metrics, delegates all processing to the service layer
- Adds `Metrics` DTO — record capturing CPU, memory, queue size, frames sent/dropped, and average processing time

## Files Added
| File | Usage|
| --- | --- |
| `Metrics.java` | DTO record for Pi health metrics received via STOMP |
| `PiMetricsService.java` | Interface defining the metrics processing contract |
| `PiMetricsServiceImpl.java` | Maps `Metrics` to `MetricsData` and delegates persistence to the database layer |
| `MetricsReceiver.java` | STOMP controller, listens on /app/metrics, delegates to `PiMetricsService` |
| `MetricsData.java` | Database model for Pi metrics |
| `MetricsRepository.java` | InfluxDB write implementation for `metrics` measurement |
| `MetricsService.java` | Database-layer service for persisting metrics |