### PR TITLE
add: Provider REST API for querying room occupancy #24

### DIFF
--- a/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
@@ -2,13 +2,17 @@ package com.occupi.feature.database.repository;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.Point;
+import com.influxdb.v3.client.query.QueryOptions;
 import com.occupi.feature.database.model.OccupancyData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Repository for persisting anonymized occupancy measurements to InfluxDB 3.x.
@@ -62,6 +66,76 @@ public class OccupancyRepository {
         influxDBClient.writePoints(points);
 
         log.debug("Saved batch of {} occupancy measurements", batch.size());
+    }
+
+    /**
+     * Returns the most recent occupancy measurement for a single room.
+     *
+     * @param roomId the room to look up (alphanumeric and dashes only)
+     * @return the latest measurement, or empty if the room has no data
+     * @throws IllegalArgumentException if roomId is null, blank or malformed
+     */
+    public Optional<OccupancyData> findLatestByRoom(String roomId) {
+        validateRoomId(roomId);
+
+        String sql = """
+                SELECT "roomId", "sensorId", "count", "confidence", time
+                FROM "%s"
+                WHERE "roomId" = '%s'
+                ORDER BY time DESC
+                LIMIT 1
+                """.formatted(MEASUREMENT_NAME, roomId);
+
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            return rows.map(this::toOccupancyData).findFirst();
+        }
+    }
+
+    /**
+     * Returns the most recent occupancy measurement for every known room.
+     * Uses a window function to pick the latest row per roomId in a single query.
+     *
+     * @return one latest measurement per room (empty list if no data exists)
+     */
+    public List<OccupancyData> findAllLatest() {
+        String sql = """
+                SELECT "roomId", "sensorId", "count", "confidence", time
+                FROM (
+                    SELECT "roomId", "sensorId", "count", "confidence", time,
+                           ROW_NUMBER() OVER (PARTITION BY "roomId" ORDER BY time DESC) AS rn
+                    FROM "%s"
+                )
+                WHERE rn = 1
+                """.formatted(MEASUREMENT_NAME);
+
+        List<OccupancyData> result = new ArrayList<>();
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            rows.forEach(row -> result.add(toOccupancyData(row)));
+        }
+        return result;
+    }
+
+    /**
+     * Maps a query result row to an OccupancyData object.
+     * Expected column order: roomId, sensorId, count, confidence, time.
+     */
+    private OccupancyData toOccupancyData(Object[] row) {
+        return OccupancyData.builder()
+                .roomId((String) row[0])
+                .sensorId((String) row[1])
+                .count(((Number) row[2]).intValue())
+                .confidence(((Number) row[3]).doubleValue())
+                .timestamp((Instant) row[4])
+                .build();
+    }
+
+    private void validateRoomId(String roomId) {
+        if (roomId == null || roomId.isBlank()) {
+            throw new IllegalArgumentException("roomId must not be null or blank");
+        }
+        if (!roomId.matches("[a-zA-Z0-9\\-]+")) {
+            throw new IllegalArgumentException("roomId contains invalid characters: " + roomId);
+        }
     }
 
     /**

--- a/backend/src/main/java/com/occupi/feature/provider/OccupancyProviderController.java
+++ b/backend/src/main/java/com/occupi/feature/provider/OccupancyProviderController.java
@@ -1,0 +1,57 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.provider.dto.OccupancyResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Read-only REST API exposing current room occupancy to the frontend.
+ * Single point of contact between backend and frontend for occupancy data.
+ *
+ * <pre>
+ * GET /api/occupancy?roomId=room-101  → latest occupancy for one room
+ * GET /api/occupancy/all              → latest occupancy for all rooms
+ * </pre>
+ */
+@RestController
+@RequestMapping("/api/occupancy")
+public class OccupancyProviderController {
+
+    private final OccupancyProviderService providerService;
+
+    public OccupancyProviderController(OccupancyProviderService providerService) {
+        this.providerService = providerService;
+    }
+
+    /**
+     * Returns the latest occupancy for the given room.
+     *
+     * @param roomId the room identifier (required)
+     * @return 200 OK with {@link OccupancyResponse}, 400 if roomId is blank,
+     *         or 404 if the room has no data
+     */
+    @GetMapping
+    public ResponseEntity<OccupancyResponse> getOccupancy(@RequestParam String roomId) {
+        if (roomId == null || roomId.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        return providerService.getLatestForRoom(roomId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Returns the latest occupancy for all known rooms.
+     *
+     * @return 200 OK with a list of {@link OccupancyResponse} (possibly empty)
+     */
+    @GetMapping("/all")
+    public ResponseEntity<List<OccupancyResponse>> getAllOccupancy() {
+        return ResponseEntity.ok(providerService.getLatestForAllRooms());
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/provider/OccupancyProviderService.java
+++ b/backend/src/main/java/com/occupi/feature/provider/OccupancyProviderService.java
@@ -1,0 +1,28 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.provider.dto.OccupancyResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Read-only service exposing current room occupancy to the frontend.
+ * Maps persisted measurements to {@link OccupancyResponse} DTOs and never writes.
+ */
+public interface OccupancyProviderService {
+
+    /**
+     * Returns the latest occupancy for a single room.
+     *
+     * @param roomId the room identifier
+     * @return the latest occupancy, or empty if the room has no data
+     */
+    Optional<OccupancyResponse> getLatestForRoom(String roomId);
+
+    /**
+     * Returns the latest occupancy for all known rooms.
+     *
+     * @return one entry per room (empty list if no data exists)
+     */
+    List<OccupancyResponse> getLatestForAllRooms();
+}

--- a/backend/src/main/java/com/occupi/feature/provider/OccupancyProviderServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/provider/OccupancyProviderServiceImpl.java
@@ -1,0 +1,47 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.database.model.OccupancyData;
+import com.occupi.feature.database.repository.OccupancyRepository;
+import com.occupi.feature.provider.dto.OccupancyResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Default {@link OccupancyProviderService} implementation.
+ * Reads the latest occupancy from {@link OccupancyRepository} and maps it to
+ * the public {@link OccupancyResponse} DTO. Read-only — performs no writes.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OccupancyProviderServiceImpl implements OccupancyProviderService {
+
+    private final OccupancyRepository occupancyRepository;
+
+    @Override
+    public Optional<OccupancyResponse> getLatestForRoom(String roomId) {
+        log.debug("Fetching latest occupancy for room={}", roomId);
+        return occupancyRepository.findLatestByRoom(roomId).map(this::toResponse);
+    }
+
+    @Override
+    public List<OccupancyResponse> getLatestForAllRooms() {
+        log.debug("Fetching latest occupancy for all rooms");
+        return occupancyRepository.findAllLatest().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private OccupancyResponse toResponse(OccupancyData data) {
+        return new OccupancyResponse(
+                data.getRoomId(),
+                data.getCount(),
+                data.getConfidence(),
+                data.getTimestamp()
+        );
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/provider/dto/OccupancyResponse.java
+++ b/backend/src/main/java/com/occupi/feature/provider/dto/OccupancyResponse.java
@@ -1,0 +1,20 @@
+package com.occupi.feature.provider.dto;
+
+import java.time.Instant;
+
+/**
+ * Read-only response DTO exposing the latest occupancy for a room to the frontend.
+ * Deliberately decoupled from the internal {@code OccupancyData} model — never
+ * exposes raw InfluxDB structures or sensor identifiers beyond what the UI needs.
+ *
+ * @param roomId     the room the measurement belongs to
+ * @param count      the latest anonymized headcount
+ * @param confidence confidence score of the measurement in [0.0, 1.0]
+ * @param timestamp  when the measurement was captured
+ */
+public record OccupancyResponse(
+        String roomId,
+        int count,
+        double confidence,
+        Instant timestamp
+) {}

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
@@ -2,21 +2,24 @@ package com.occupi.feature.database.repository;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.Point;
+import com.influxdb.v3.client.query.QueryOptions;
 import com.occupi.feature.database.model.OccupancyData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -161,6 +164,84 @@ class OccupancyRepositoryTest {
         @DisplayName("should reject empty batch")
         void shouldRejectEmptyBatch() {
             assertThrows(IllegalArgumentException.class, () -> repository.saveBatch(List.of()));
+        }
+    }
+
+    @Nested
+    @DisplayName("findLatestByRoom()")
+    class FindLatestByRoom {
+
+        @Test
+        @DisplayName("should map the latest row to OccupancyData")
+        void shouldMapLatestRow() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            new Object[]{"room-101", "sensor-A", 12L, 0.9, ts}));
+
+            Optional<OccupancyData> result = repository.findLatestByRoom("room-101");
+
+            assertTrue(result.isPresent());
+            OccupancyData data = result.get();
+            assertEquals("room-101", data.getRoomId());
+            assertEquals("sensor-A", data.getSensorId());
+            assertEquals(12, data.getCount());
+            assertEquals(0.9, data.getConfidence());
+            assertEquals(ts, data.getTimestamp());
+        }
+
+        @Test
+        @DisplayName("should return empty when no rows are found")
+        void shouldReturnEmptyWhenNoRows() {
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty());
+
+            assertTrue(repository.findLatestByRoom("ghost").isEmpty());
+        }
+
+        @Test
+        @DisplayName("should reject blank roomId")
+        void shouldRejectBlankRoomId() {
+            assertThrows(IllegalArgumentException.class, () -> repository.findLatestByRoom("  "));
+        }
+
+        @Test
+        @DisplayName("should reject roomId with invalid characters (SQL injection guard)")
+        void shouldRejectInvalidRoomId() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.findLatestByRoom("room'; DROP TABLE--"));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllLatest()")
+    class FindAllLatest {
+
+        @Test
+        @DisplayName("should map every returned row to OccupancyData")
+        void shouldMapAllRows() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            new Object[]{"room-101", "sensor-A", 5L, 0.8, ts},
+                            new Object[]{"room-202", "sensor-B", 20L, 0.95, ts}));
+
+            List<OccupancyData> result = repository.findAllLatest();
+
+            assertEquals(2, result.size());
+            assertEquals("room-101", result.get(0).getRoomId());
+            assertEquals(5, result.get(0).getCount());
+            assertEquals("room-202", result.get(1).getRoomId());
+            assertEquals(20, result.get(1).getCount());
+        }
+
+        @Test
+        @DisplayName("should return an empty list when no data exists")
+        void shouldReturnEmptyList() {
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty());
+
+            assertTrue(repository.findAllLatest().isEmpty());
         }
     }
 }

--- a/backend/src/test/java/com/occupi/feature/provider/OccupancyProviderControllerTest.java
+++ b/backend/src/test/java/com/occupi/feature/provider/OccupancyProviderControllerTest.java
@@ -1,0 +1,88 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.provider.dto.OccupancyResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OccupancyProviderController")
+class OccupancyProviderControllerTest {
+
+    @Mock
+    private OccupancyProviderService providerService;
+
+    @InjectMocks
+    private OccupancyProviderController controller;
+
+    private static final OccupancyResponse SAMPLE =
+            new OccupancyResponse("room-101", 12, 0.9, Instant.parse("2026-06-14T10:00:00Z"));
+
+    @Test
+    @DisplayName("returns 200 with occupancy for a known room")
+    void getOccupancy_known_returns200() {
+        when(providerService.getLatestForRoom("room-101")).thenReturn(Optional.of(SAMPLE));
+
+        ResponseEntity<OccupancyResponse> response = controller.getOccupancy("room-101");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(SAMPLE);
+    }
+
+    @Test
+    @DisplayName("returns 404 when the room has no data")
+    void getOccupancy_unknown_returns404() {
+        when(providerService.getLatestForRoom("ghost")).thenReturn(Optional.empty());
+
+        ResponseEntity<OccupancyResponse> response = controller.getOccupancy("ghost");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("returns 400 when roomId is blank")
+    void getOccupancy_blank_returns400() {
+        ResponseEntity<OccupancyResponse> response = controller.getOccupancy("  ");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(providerService);
+    }
+
+    @Test
+    @DisplayName("returns 200 with the list of all rooms' occupancy")
+    void getAllOccupancy_returns200() {
+        List<OccupancyResponse> all = List.of(
+                SAMPLE,
+                new OccupancyResponse("room-202", 20, 0.95, Instant.parse("2026-06-14T10:05:00Z"))
+        );
+        when(providerService.getLatestForAllRooms()).thenReturn(all);
+
+        ResponseEntity<List<OccupancyResponse>> response = controller.getAllOccupancy();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2).isEqualTo(all);
+    }
+
+    @Test
+    @DisplayName("returns 200 with an empty list when no rooms have data")
+    void getAllOccupancy_empty_returns200() {
+        when(providerService.getLatestForAllRooms()).thenReturn(List.of());
+
+        ResponseEntity<List<OccupancyResponse>> response = controller.getAllOccupancy();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/provider/OccupancyProviderServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/provider/OccupancyProviderServiceImplTest.java
@@ -1,0 +1,87 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.database.model.OccupancyData;
+import com.occupi.feature.database.repository.OccupancyRepository;
+import com.occupi.feature.provider.dto.OccupancyResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OccupancyProviderServiceImpl")
+class OccupancyProviderServiceImplTest {
+
+    @Mock
+    private OccupancyRepository occupancyRepository;
+
+    @InjectMocks
+    private OccupancyProviderServiceImpl service;
+
+    private static final Instant TS = Instant.parse("2026-06-14T10:00:00Z");
+
+    private OccupancyData data(String roomId, int count, double confidence) {
+        return OccupancyData.builder()
+                .roomId(roomId).sensorId("sensor-A")
+                .count(count).confidence(confidence).timestamp(TS)
+                .build();
+    }
+
+    @Test
+    @DisplayName("maps the latest measurement to a response DTO for a known room")
+    void getLatestForRoom_known_returnsMappedDto() {
+        when(occupancyRepository.findLatestByRoom("room-101"))
+                .thenReturn(Optional.of(data("room-101", 12, 0.9)));
+
+        Optional<OccupancyResponse> result = service.getLatestForRoom("room-101");
+
+        assertThat(result).isPresent();
+        OccupancyResponse r = result.get();
+        assertThat(r.roomId()).isEqualTo("room-101");
+        assertThat(r.count()).isEqualTo(12);
+        assertThat(r.confidence()).isEqualTo(0.9);
+        assertThat(r.timestamp()).isEqualTo(TS);
+    }
+
+    @Test
+    @DisplayName("returns empty when the room has no data")
+    void getLatestForRoom_unknown_returnsEmpty() {
+        when(occupancyRepository.findLatestByRoom("ghost")).thenReturn(Optional.empty());
+
+        assertThat(service.getLatestForRoom("ghost")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("maps every room's latest measurement for the all-rooms query")
+    void getLatestForAllRooms_returnsMappedList() {
+        when(occupancyRepository.findAllLatest()).thenReturn(List.of(
+                data("room-101", 5, 0.8),
+                data("room-202", 20, 0.95)
+        ));
+
+        List<OccupancyResponse> result = service.getLatestForAllRooms();
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(OccupancyResponse::roomId)
+                .containsExactly("room-101", "room-202");
+        assertThat(result).extracting(OccupancyResponse::count)
+                .containsExactly(5, 20);
+    }
+
+    @Test
+    @DisplayName("returns an empty list when no rooms have data")
+    void getLatestForAllRooms_noData_returnsEmptyList() {
+        when(occupancyRepository.findAllLatest()).thenReturn(List.of());
+
+        assertThat(service.getLatestForAllRooms()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Provider REST API (#24)

Implements the read-only Provider feature — the single point of contact between backend and frontend for querying current room occupancy.

### Changes
- **`OccupancyRepository`**: new read methods (repository was previously write-only)
  - `findLatestByRoom(roomId)` — latest measurement for one room, with SQL-injection guard on `roomId`
  - `findAllLatest()` — latest measurement per room via `ROW_NUMBER() OVER (PARTITION BY roomId ...)` in a single query
- **`feature/provider/`** (Package by Feature):
  - `dto/OccupancyResponse` — record (roomId, count, confidence, timestamp), decoupled from internal InfluxDB model
  - `OccupancyProviderService` / `OccupancyProviderServiceImpl` — read-only, maps to DTO
  - `OccupancyProviderController`:
    - `GET /api/occupancy?roomId=X` → 200 / 400 (blank) / 404 (no data)
    - `GET /api/occupancy/all` → 200 with list

### Tests (+15, total 51 green)
- `OccupancyProviderServiceImplTest` (4) — mapping, empty cases
- `OccupancyProviderControllerTest` (5) — 200/400/404, all-rooms, empty list
- `OccupancyRepositoryTest` (+6) — read mapping, empty results, injection guard

### Acceptance criteria (all met)
- [x] `GET /api/occupancy?roomId=X` returns latest occupancy for a room
- [x] `GET /api/occupancy/all` returns latest occupancy for all rooms
- [x] Returns `OccupancyResponse` DTO
- [x] 404 when roomId not found
- [x] Unit tests with JUnit 5 + Mockito
- [x] Read-only — no writes; never exposes raw InfluxDB data

Closes #24
