### PR TITLE
add: Keycloak OAuth2 Resource Server authentication with tests #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ build/
 .vscode/
 
 docker/seed.py
+
+### Local secrets ###
+docker/.env

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -57,6 +57,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		<!-- OAuth2 Resource Server — validates Keycloak-issued JWTs (#34) -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+		</dependency>
 
 		<!-- JPA + PostgreSQL for room metadata persistence (#58) -->
 		<dependency>

--- a/backend/src/main/java/com/occupi/feature/authentication/AuthController.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/AuthController.java
@@ -1,0 +1,33 @@
+package com.occupi.feature.authentication;
+
+import com.occupi.feature.authentication.dto.UserInfoResponse;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes the authenticated user's details. Login itself is handled entirely by
+ * Keycloak — there is no custom login endpoint; this backend only validates the
+ * bearer token and reflects its claims back to the frontend.
+ *
+ * <pre>
+ * GET /api/auth/userinfo  → 200 with username/email/roles, or 401 without a token
+ * </pre>
+ */
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @GetMapping("/userinfo")
+    public UserInfoResponse userInfo(@AuthenticationPrincipal Jwt jwt) {
+        return authService.getUserInfo(jwt);
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/authentication/AuthService.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/AuthService.java
@@ -1,0 +1,18 @@
+package com.occupi.feature.authentication;
+
+import com.occupi.feature.authentication.dto.UserInfoResponse;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Extracts authenticated-user details from a validated Keycloak JWT.
+ */
+public interface AuthService {
+
+    /**
+     * Builds a {@link UserInfoResponse} from the claims of a validated token.
+     *
+     * @param jwt the authenticated Keycloak JWT
+     * @return username, email and realm roles extracted from the token
+     */
+    UserInfoResponse getUserInfo(Jwt jwt);
+}

--- a/backend/src/main/java/com/occupi/feature/authentication/AuthServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/AuthServiceImpl.java
@@ -1,0 +1,39 @@
+package com.occupi.feature.authentication;
+
+import com.occupi.feature.authentication.dto.UserInfoResponse;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default {@link AuthService} — reads standard Keycloak claims from the JWT.
+ * No credentials are handled here; token validation is done by the resource
+ * server filter chain before this code runs.
+ */
+@Service
+public class AuthServiceImpl implements AuthService {
+
+    @Override
+    public UserInfoResponse getUserInfo(Jwt jwt) {
+        return new UserInfoResponse(
+                jwt.getClaimAsString("preferred_username"),
+                jwt.getClaimAsString("email"),
+                extractRealmRoles(jwt)
+        );
+    }
+
+    private List<String> extractRealmRoles(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+        if (realmAccess == null) {
+            return List.of();
+        }
+        Object roles = realmAccess.get("roles");
+        if (!(roles instanceof Collection<?> roleList)) {
+            return List.of();
+        }
+        return roleList.stream().map(Object::toString).toList();
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/authentication/KeycloakRealmRoleConverter.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/KeycloakRealmRoleConverter.java
@@ -1,0 +1,37 @@
+package com.occupi.feature.authentication;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps Keycloak realm roles from the {@code realm_access.roles} claim to Spring
+ * Security authorities, prefixing each with {@code ROLE_} so that
+ * {@code hasRole("ADMIN")} matches a Keycloak role named {@code admin}.
+ *
+ * Missing or malformed claims yield no authorities (never throws).
+ */
+public class KeycloakRealmRoleConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+
+    @Override
+    public Collection<GrantedAuthority> convert(Jwt jwt) {
+        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+        if (realmAccess == null) {
+            return List.of();
+        }
+        Object roles = realmAccess.get("roles");
+        if (!(roles instanceof Collection<?> roleList)) {
+            return List.of();
+        }
+        return roleList.stream()
+                .map(Object::toString)
+                .map(role -> "ROLE_" + role.toUpperCase())
+                .map(authority -> (GrantedAuthority) new SimpleGrantedAuthority(authority))
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/authentication/SecurityConfig.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/SecurityConfig.java
@@ -3,10 +3,27 @@ package com.occupi.feature.authentication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * Security configuration for the OAuth2 Resource Server.
+ *
+ * Validates Keycloak-issued JWTs on every request. Active in all profiles
+ * except {@code dev} (which permits everything for local development) and
+ * {@code test} (where slice tests import this config explicitly).
+ *
+ * Authorization rules:
+ * <ul>
+ *   <li>{@code /ws/**} — public (Raspberry Pi STOMP ingestion)</li>
+ *   <li>OpenAPI / Swagger UI — public</li>
+ *   <li>Room mutations (POST/PUT/DELETE {@code /api/rooms/**}) — {@code ADMIN} only</li>
+ *   <li>everything else — any authenticated user with a valid JWT</li>
+ * </ul>
+ */
 @Profile("!test & !dev")
 @Configuration
 @EnableWebSecurity
@@ -17,9 +34,26 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/ws/**", "/ws/occupancy/**", "/api/rooms/**").permitAll()
+                        .requestMatchers("/ws/**", "/ws/occupancy/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/rooms/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/rooms/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/rooms/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter()))
                 );
         return http.build();
+    }
+
+    /**
+     * Builds a {@link JwtAuthenticationConverter} that derives Spring authorities
+     * from Keycloak realm roles via {@link KeycloakRealmRoleConverter}.
+     */
+    private JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(new KeycloakRealmRoleConverter());
+        return converter;
     }
 }

--- a/backend/src/main/java/com/occupi/feature/authentication/dto/UserInfoResponse.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/dto/UserInfoResponse.java
@@ -1,0 +1,12 @@
+package com.occupi.feature.authentication.dto;
+
+import java.util.List;
+
+/**
+ * Authenticated user's details extracted from the Keycloak JWT.
+ *
+ * @param username the {@code preferred_username} claim
+ * @param email    the {@code email} claim (may be null if not present in the token)
+ * @param roles    realm roles from the {@code realm_access.roles} claim
+ */
+public record UserInfoResponse(String username, String email, List<String> roles) {}

--- a/backend/src/main/resources/application-prod.yaml
+++ b/backend/src/main/resources/application-prod.yaml
@@ -1,5 +1,17 @@
 # Production profile — activated via SPRING_PROFILES_ACTIVE=prod on the server.
-# SecurityConfig is active in this profile (all requests require authentication).
+# SecurityConfig is active in this profile (all requests require a valid Keycloak JWT).
+#
+# JWT validation uses the realm's JWK set. We deliberately use jwk-set-uri (not
+# issuer-uri) so that validation works inside the Docker network where the
+# backend reaches Keycloak via the internal hostname while tokens carry the
+# external issuer (KC_HOSTNAME) — issuer-uri discovery would reject the mismatch.
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://localhost:8180/realms/occupi/protocol/openid-connect/certs}
+
 logging:
   level:
     com.occupi: INFO

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -9,6 +9,9 @@ spring:
   docker:
     compose:
       enabled: false
+  # No form-login / default in-memory user — auth is delegated to Keycloak (prod).
+  autoconfigure:
+    exclude: org.springframework.boot.security.autoconfigure.UserDetailsServiceAutoConfiguration
   datasource:
     url: ${POSTGRES_URL:jdbc:postgresql://localhost:5432/occupi}
     username: ${POSTGRES_USER:occupi}

--- a/backend/src/test/java/com/occupi/feature/authentication/AuthControllerTest.java
+++ b/backend/src/test/java/com/occupi/feature/authentication/AuthControllerTest.java
@@ -1,0 +1,67 @@
+package com.occupi.feature.authentication;
+
+import com.occupi.feature.authentication.dto.UserInfoResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@Import(SecurityConfig.class)
+@ActiveProfiles("prod")
+@DisplayName("AuthController (security slice)")
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private AuthService authService;
+
+    // Required by the OAuth2 resource server filter chain; we never hit Keycloak in tests.
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    @DisplayName("returns 200 with user info for a valid Keycloak JWT")
+    void userinfo_withJwt_returns200() throws Exception {
+        when(authService.getUserInfo(any()))
+                .thenReturn(new UserInfoResponse("alice", "alice@hdm-stuttgart.de", List.of("user")));
+
+        mvc.perform(get("/api/auth/userinfo").with(jwt()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value("alice"))
+                .andExpect(jsonPath("$.roles[0]").value("user"));
+    }
+
+    @Test
+    @DisplayName("returns 401 when no token is present")
+    void userinfo_noToken_returns401() throws Exception {
+        mvc.perform(get("/api/auth/userinfo"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("returns 401 for an invalid or expired bearer token")
+    void userinfo_invalidToken_returns401() throws Exception {
+        when(jwtDecoder.decode("bad-token")).thenThrow(new BadJwtException("expired"));
+
+        mvc.perform(get("/api/auth/userinfo").header("Authorization", "Bearer bad-token"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/authentication/AuthServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/authentication/AuthServiceImplTest.java
@@ -1,0 +1,68 @@
+package com.occupi.feature.authentication;
+
+import com.occupi.feature.authentication.dto.UserInfoResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AuthServiceImpl — Keycloak token extraction")
+class AuthServiceImplTest {
+
+    private final AuthServiceImpl service = new AuthServiceImpl();
+
+    private Jwt.Builder baseJwt() {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .subject("user-1");
+    }
+
+    @Test
+    @DisplayName("extracts username from preferred_username and roles from realm_access.roles")
+    void extractsUsernameAndRoles() {
+        Jwt jwt = baseJwt()
+                .claim("preferred_username", "alice")
+                .claim("email", "alice@hdm-stuttgart.de")
+                .claim("realm_access", Map.of("roles", List.of("admin", "user")))
+                .build();
+
+        UserInfoResponse info = service.getUserInfo(jwt);
+
+        assertThat(info.username()).isEqualTo("alice");
+        assertThat(info.email()).isEqualTo("alice@hdm-stuttgart.de");
+        assertThat(info.roles()).containsExactlyInAnyOrder("admin", "user");
+    }
+
+    @Test
+    @DisplayName("handles a missing email claim gracefully")
+    void missingEmail() {
+        Jwt jwt = baseJwt()
+                .claim("preferred_username", "bob")
+                .claim("realm_access", Map.of("roles", List.of("user")))
+                .build();
+
+        UserInfoResponse info = service.getUserInfo(jwt);
+
+        assertThat(info.username()).isEqualTo("bob");
+        assertThat(info.email()).isNull();
+        assertThat(info.roles()).containsExactly("user");
+    }
+
+    @Test
+    @DisplayName("returns empty roles when realm_access is absent")
+    void missingRealmAccess() {
+        Jwt jwt = baseJwt().claim("preferred_username", "carol").build();
+
+        UserInfoResponse info = service.getUserInfo(jwt);
+
+        assertThat(info.username()).isEqualTo("carol");
+        assertThat(info.roles()).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/authentication/KeycloakRealmRoleConverterTest.java
+++ b/backend/src/test/java/com/occupi/feature/authentication/KeycloakRealmRoleConverterTest.java
@@ -1,0 +1,58 @@
+package com.occupi.feature.authentication;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("KeycloakRealmRoleConverter")
+class KeycloakRealmRoleConverterTest {
+
+    private final KeycloakRealmRoleConverter converter = new KeycloakRealmRoleConverter();
+
+    private Jwt.Builder baseJwt() {
+        return Jwt.withTokenValue("token")
+                .header("alg", "none")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .subject("user-1");
+    }
+
+    @Test
+    @DisplayName("maps realm_access.roles to ROLE_ authorities in upper case")
+    void mapsRealmRoles() {
+        Jwt jwt = baseJwt()
+                .claim("realm_access", Map.of("roles", List.of("admin", "user")))
+                .build();
+
+        Collection<GrantedAuthority> authorities = converter.convert(jwt);
+
+        assertThat(authorities).extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder("ROLE_ADMIN", "ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("returns no authorities when realm_access claim is missing")
+    void missingRealmAccess() {
+        Jwt jwt = baseJwt().build();
+
+        assertThat(converter.convert(jwt)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns no authorities when roles entry is missing or malformed")
+    void malformedRoles() {
+        Jwt jwt = baseJwt()
+                .claim("realm_access", Map.of("notRoles", "x"))
+                .build();
+
+        assertThat(converter.convert(jwt)).isEmpty();
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/authentication/SecurityConfigTest.java
+++ b/backend/src/test/java/com/occupi/feature/authentication/SecurityConfigTest.java
@@ -1,0 +1,79 @@
+package com.occupi.feature.authentication;
+
+import com.occupi.feature.room.RoomController;
+import com.occupi.feature.room.RoomService;
+import com.occupi.feature.room.dto.RoomResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies the OAuth2 Resource Server authorization rules in {@link SecurityConfig}
+ * against the room endpoints (read = any authenticated user, mutations = ADMIN).
+ */
+@WebMvcTest(RoomController.class)
+@Import(SecurityConfig.class)
+@ActiveProfiles("prod")
+@DisplayName("SecurityConfig authorization rules")
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private RoomService roomService;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    @DisplayName("rejects an unauthenticated request with 401")
+    void getRooms_noToken_returns401() throws Exception {
+        mvc.perform(get("/api/rooms"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("allows a read for any authenticated user")
+    void getRooms_authenticated_returns200() throws Exception {
+        mvc.perform(get("/api/rooms").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("rejects a room mutation with 403 when the token lacks ADMIN")
+    void createRoom_nonAdmin_returns403() throws Exception {
+        mvc.perform(post("/api/rooms")
+                        .contentType("application/json")
+                        .content("{\"roomId\":\"room-1\",\"name\":\"X\",\"building\":\"M\",\"floor\":1,\"capacity\":10}")
+                        .with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("allows a room mutation for an ADMIN token")
+    void createRoom_admin_returns201() throws Exception {
+        when(roomService.createRoom(any()))
+                .thenReturn(new RoomResponse("room-1", "X", "M", 1, 10));
+
+        mvc.perform(post("/api/rooms")
+                        .contentType("application/json")
+                        .content("{\"roomId\":\"room-1\",\"name\":\"X\",\"building\":\"M\",\"floor\":1,\"capacity\":10}")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isCreated());
+    }
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,18 @@
+# Copy to docker/.env and adjust for your environment.
+
+# ── Backend ──────────────────────────────────────────────────────────────────
+# 'prod' enforces Keycloak JWT auth; set to 'dev' for an open local stack.
+SPRING_PROFILES_ACTIVE=prod
+
+# ── PostgreSQL (shared by the backend 'occupi' DB and Keycloak's 'keycloak' DB) ─
+POSTGRES_USER=occupi
+POSTGRES_PASSWORD=change_me
+
+# ── Keycloak Admin Console ───────────────────────────────────────────────────
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=change_me
+
+# ── Keycloak Hostname ────────────────────────────────────────────────────────
+# For production set to occupi.mi.hdm-stuttgart.de
+KC_HOSTNAME=localhost
+KC_HOSTNAME_PORT=8180

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,15 +7,20 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SPRING_PROFILES_ACTIVE: dev
+      # 'prod' enforces Keycloak JWT auth. Override to 'dev' for an open local stack.
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
       INFLUXDB_URL: http://influxdb:8181
       POSTGRES_URL: jdbc:postgresql://postgres:5432/occupi
-      POSTGRES_USER: occupi
-      POSTGRES_PASSWORD: occupi
+      POSTGRES_USER: ${POSTGRES_USER:-occupi}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-occupi}
+      # JWKS reached via the internal hostname (avoids issuer-uri host mismatch).
+      KEYCLOAK_JWK_SET_URI: http://keycloak:8080/realms/occupi/protocol/openid-connect/certs
     depends_on:
       influxdb:
         condition: service_healthy
       postgres:
+        condition: service_healthy
+      keycloak:
         condition: service_healthy
     restart: unless-stopped
 
@@ -47,7 +52,8 @@ services:
       retries: 5
     restart: unless-stopped
 
-  # PostgreSQL — stores room metadata (and will back Keycloak, see #113)
+  # PostgreSQL — hosts two databases: 'occupi' (room metadata) and 'keycloak'.
+  # The 'keycloak' database is created on first start by ./postgres/init.
   postgres:
     image: postgres:17-alpine
     container_name: occupi-postgres
@@ -55,15 +61,48 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_DB: occupi
-      POSTGRES_USER: occupi
-      POSTGRES_PASSWORD: occupi
+      POSTGRES_USER: ${POSTGRES_USER:-occupi}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-occupi}
     volumes:
       - postgres-data:/var/lib/postgresql/data
+      - ./postgres/init:/docker-entrypoint-initdb.d:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U occupi -d occupi"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-occupi}"]
       interval: 5s
       timeout: 3s
       retries: 5
+    restart: unless-stopped
+
+  # Keycloak — OIDC provider federating the HdM LDAP; imports the occupi realm.
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.2
+    container_name: occupi-keycloak
+    ports:
+      - "8180:8080"
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_HOSTNAME: ${KC_HOSTNAME:-localhost}
+      KC_HOSTNAME_PORT: ${KC_HOSTNAME_PORT:-8180}
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
+      KC_DB_USERNAME: ${POSTGRES_USER:-occupi}
+      KC_DB_PASSWORD: ${POSTGRES_PASSWORD:-occupi}
+    volumes:
+      - ./keycloak/realm-occupi.json:/opt/keycloak/data/import/realm-occupi.json:ro
+    command: start-dev --import-realm
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.0\\r\\n\\r\\n' >&3 && grep -q 'UP' <&3"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
     restart: unless-stopped
 
 volumes:

--- a/docker/keycloak/realm-occupi.json
+++ b/docker/keycloak/realm-occupi.json
@@ -1,0 +1,140 @@
+{
+  "realm": "occupi",
+  "enabled": true,
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": true,
+  "sslRequired": "external",
+  "roles": {
+    "realm": [
+      {
+        "name": "admin",
+        "description": "OccuPi administrator — may manage rooms (create/update/delete)"
+      },
+      {
+        "name": "user",
+        "description": "Standard OccuPi user — read access"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "occupi-backend",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "bearerOnly": true,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false
+    },
+    {
+      "clientId": "occupi-frontend",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "bearerOnly": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": [
+        "http://localhost:3000/*",
+        "http://localhost:5173/*",
+        "https://occupi.mi.hdm-stuttgart.de/*"
+      ],
+      "webOrigins": [
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "https://occupi.mi.hdm-stuttgart.de"
+      ]
+    }
+  ],
+  "components": {
+    "org.keycloak.storage.UserStorageProvider": [
+      {
+        "name": "hdm-ldap",
+        "providerId": "ldap",
+        "subComponents": {
+          "org.keycloak.storage.ldap.mappers.LDAPStorageMapper": [
+            {
+              "name": "username",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": ["uid"],
+                "user.model.attribute": ["username"],
+                "always.read.value.from.ldap": ["false"],
+                "is.mandatory.in.ldap": ["true"],
+                "read.only": ["true"],
+                "attribute.force.default": ["false"],
+                "is.binary.attribute": ["false"]
+              }
+            },
+            {
+              "name": "email",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": ["mail"],
+                "user.model.attribute": ["email"],
+                "always.read.value.from.ldap": ["false"],
+                "is.mandatory.in.ldap": ["false"],
+                "read.only": ["true"],
+                "attribute.force.default": ["false"],
+                "is.binary.attribute": ["false"]
+              }
+            },
+            {
+              "name": "first name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": ["givenName"],
+                "user.model.attribute": ["firstName"],
+                "always.read.value.from.ldap": ["false"],
+                "is.mandatory.in.ldap": ["false"],
+                "read.only": ["true"],
+                "attribute.force.default": ["false"],
+                "is.binary.attribute": ["false"]
+              }
+            },
+            {
+              "name": "last name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": ["sn"],
+                "user.model.attribute": ["lastName"],
+                "always.read.value.from.ldap": ["false"],
+                "is.mandatory.in.ldap": ["false"],
+                "read.only": ["true"],
+                "attribute.force.default": ["false"],
+                "is.binary.attribute": ["false"]
+              }
+            }
+          ]
+        },
+        "config": {
+          "enabled": ["true"],
+          "priority": ["0"],
+          "editMode": ["READ_ONLY"],
+          "syncRegistrations": ["false"],
+          "vendor": ["other"],
+          "usernameLDAPAttribute": ["uid"],
+          "rdnLDAPAttribute": ["uid"],
+          "uuidLDAPAttribute": ["uid"],
+          "userObjectClasses": ["inetOrgPerson"],
+          "connectionUrl": ["ldap://ldap.hdm-stuttgart.de:389"],
+          "usersDn": ["ou=userlist,dc=hdm-stuttgart,dc=de"],
+          "authType": ["none"],
+          "importEnabled": ["false"],
+          "batchSizeForSync": ["1000"],
+          "fullSyncPeriod": ["-1"],
+          "changedSyncPeriod": ["-1"],
+          "debug": ["false"],
+          "searchScope": ["1"],
+          "validatePasswordPolicy": ["false"],
+          "trustEmail": ["false"],
+          "connectionPooling": ["true"],
+          "pagination": ["true"]
+        }
+      }
+    ]
+  }
+}

--- a/docker/postgres/init/01-create-keycloak-db.sql
+++ b/docker/postgres/init/01-create-keycloak-db.sql
@@ -1,0 +1,4 @@
+-- Runs once on first PostgreSQL startup (empty data dir).
+-- Creates the dedicated database Keycloak uses; the 'occupi' database for room
+-- metadata is created by POSTGRES_DB. Both are owned by the POSTGRES_USER.
+CREATE DATABASE keycloak;


### PR DESCRIPTION
## Authentication — Keycloak OAuth2 Resource Server (#20, #34, #35, #37, #113)

Secures the backend with Keycloak. Students log in via Keycloak (HdM LDAP federation); the backend validates the issued JWTs as an OAuth2 Resource Server. No passwords are handled here.

Builds on the earlier work on `feature/keycloak-ldap-auth-#113`, re-based onto current `develop` and completed with the missing **tests** and **role-based authorization**.

### Backend (#34 / #35 / #20)
- `spring-boot-starter-oauth2-resource-server` dependency.
- `SecurityConfig` (OAuth2 Resource Server, profile `!test & !dev`):
  - public: `/ws/**`, OpenAPI/Swagger UI
  - **ADMIN only**: `POST/PUT/DELETE /api/rooms/**` (wires up the admin-only room endpoints from #58)
  - everything else: authenticated
  - JWT auth via a `JwtAuthenticationConverter` using `KeycloakRealmRoleConverter` (maps `realm_access.roles` → `ROLE_*`).
- `AuthController` `GET /api/auth/userinfo` → username / email / roles (401 without a token — fixed the previous `permitAll` on `/api/auth/**` that would NPE).
- `AuthService` / `AuthServiceImpl` — testable Keycloak claim extraction; `UserInfoResponse` DTO.
- Config: `jwk-set-uri` in `application-prod.yaml` (chosen over `issuer-uri` to avoid the issuer-host mismatch inside the Docker network); default in-memory user disabled.

### Tests (#37) 
- `KeycloakRealmRoleConverterTest` (3) — realm-role mapping, missing/malformed claims
- `AuthServiceImplTest` (3) — username/email/roles extraction, missing email, missing `realm_access`
- `AuthControllerTest` (3, `@WebMvcTest`) — 200 with JWT, 401 without, 401 on invalid/expired token
- `SecurityConfigTest` (4, `@WebMvcTest`) — 401 unauthenticated, 200 authenticated read, **403 non-admin** mutation, 201 admin mutation

### Keycloak infra (#113)
- `keycloak` service (26.2) in `docker-compose.yml`, realm auto-import.
- **Single PostgreSQL** now hosts both `occupi` (rooms) and `keycloak` DBs (init script creates the second) — reconciled with the Room CRUD Postgres.
- `realm-occupi.json`: `occupi` realm, `occupi-backend` (bearer-only) + `occupi-frontend` clients, **HdM LDAP user federation**, and `admin` / `user` realm roles.
- `.env.example`; `docker/.env` git-ignored.

### Notes / left open on #113
- End-to-end login with real student credentials and "students can authenticate" need a running stack against the live HdM LDAP — left unchecked on #113, so this PR references but does not close it.
- Admin users must be granted the `admin` realm role in Keycloak to manage rooms.

Closes #20
Closes #34
Closes #35
Closes #37
Refs #113
