### PR TITLE
test: add tests for the Pi metrics pipeline #3

### DIFF
--- a/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
@@ -1,0 +1,131 @@
+package com.occupi.feature.database.repository;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.Point;
+import com.occupi.feature.database.model.MetricsData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MetricsRepository")
+class MetricsRepositoryTest {
+
+    @Mock
+    private InfluxDBClient influxDBClient;
+
+    private MetricsRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new MetricsRepository(influxDBClient);
+    }
+
+    private MetricsData.MetricsDataBuilder validBuilder() {
+        return MetricsData.builder()
+                .sensorId("sensor-A")
+                .cpuPercentage(42.0)
+                .memoryPercentage(60.0)
+                .queueSize(3)
+                .sent(100)
+                .dropped(1)
+                .avgProcessTime(12.5f)
+                .timestamp(Instant.parse("2026-06-14T10:00:00Z"));
+    }
+
+    @Nested
+    @DisplayName("save()")
+    class Save {
+
+        @Test
+        @DisplayName("should write a point to InfluxDB for valid metrics")
+        void shouldWritePoint() {
+            repository.save(validBuilder().build());
+
+            verify(influxDBClient).writePoint(any(Point.class));
+        }
+
+        @Test
+        @DisplayName("should reject null metrics")
+        void shouldRejectNull() {
+            assertThrows(IllegalArgumentException.class, () -> repository.save(null));
+        }
+
+        @Test
+        @DisplayName("should reject blank sensorId")
+        void shouldRejectBlankSensorId() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.save(validBuilder().sensorId("  ").build()));
+        }
+
+        @Test
+        @DisplayName("should reject null timestamp")
+        void shouldRejectNullTimestamp() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.save(validBuilder().timestamp(null).build()));
+        }
+
+        @Test
+        @DisplayName("should reject cpuPercentage outside 0-100")
+        void shouldRejectCpuOutOfRange() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.save(validBuilder().cpuPercentage(150.0).build()));
+        }
+
+        @Test
+        @DisplayName("should reject negative queueSize")
+        void shouldRejectNegativeQueueSize() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.save(validBuilder().queueSize(-1).build()));
+        }
+
+        @Test
+        @DisplayName("should reject negative avgProcessTime")
+        void shouldRejectNegativeAvgProcessTime() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.save(validBuilder().avgProcessTime(-1f).build()));
+        }
+    }
+
+    @Nested
+    @DisplayName("saveBatch()")
+    class SaveBatch {
+
+        @Test
+        @DisplayName("should write multiple points in a single batch")
+        void shouldWriteBatch() {
+            List<MetricsData> batch = List.of(
+                    validBuilder().build(),
+                    validBuilder().sensorId("sensor-B").build()
+            );
+
+            repository.saveBatch(batch);
+
+            verify(influxDBClient).writePoints(anyList());
+        }
+
+        @Test
+        @DisplayName("should reject an empty batch")
+        void shouldRejectEmptyBatch() {
+            assertThrows(IllegalArgumentException.class, () -> repository.saveBatch(List.of()));
+        }
+
+        @Test
+        @DisplayName("should reject a null batch")
+        void shouldRejectNullBatch() {
+            assertThrows(IllegalArgumentException.class, () -> repository.saveBatch(null));
+        }
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/database/service/MetricsServiceTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/service/MetricsServiceTest.java
@@ -1,0 +1,76 @@
+package com.occupi.feature.database.service;
+
+import com.occupi.feature.database.model.MetricsData;
+import com.occupi.feature.database.repository.MetricsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MetricsService")
+class MetricsServiceTest {
+
+    @Mock
+    private MetricsRepository metricsRepository;
+
+    private MetricsService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MetricsService(metricsRepository);
+    }
+
+    private MetricsData sample(String sensorId) {
+        return MetricsData.builder()
+                .sensorId(sensorId)
+                .cpuPercentage(42.0)
+                .memoryPercentage(60.0)
+                .queueSize(3)
+                .sent(100)
+                .dropped(1)
+                .avgProcessTime(12.5f)
+                .timestamp(Instant.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("recordMetrics delegates to repository with the same data")
+    void recordMetrics_delegates() {
+        service.recordMetrics(sample("sensor-A"));
+
+        ArgumentCaptor<MetricsData> captor = ArgumentCaptor.forClass(MetricsData.class);
+        verify(metricsRepository).save(captor.capture());
+        assertEquals("sensor-A", captor.getValue().getSensorId());
+    }
+
+    @Test
+    @DisplayName("recordMetrics propagates repository exceptions")
+    void recordMetrics_propagates() {
+        doThrow(new IllegalArgumentException("invalid")).when(metricsRepository).save(any());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.recordMetrics(sample("sensor-A")));
+    }
+
+    @Test
+    @DisplayName("recordMetricsBatch delegates the batch to the repository")
+    void recordMetricsBatch_delegates() {
+        List<MetricsData> batch = List.of(sample("sensor-A"), sample("sensor-B"));
+
+        service.recordMetricsBatch(batch);
+
+        verify(metricsRepository).saveBatch(batch);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/receiver/MetricsReceiverTest.java
+++ b/backend/src/test/java/com/occupi/feature/receiver/MetricsReceiverTest.java
@@ -1,0 +1,43 @@
+package com.occupi.feature.receiver;
+
+import com.occupi.feature.receiver.dto.Metrics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MetricsReceiver")
+class MetricsReceiverTest {
+
+    @Mock
+    private PiMetricsService piMetricsService;
+
+    @InjectMocks
+    private MetricsReceiver receiver;
+
+    @Test
+    @DisplayName("forwards received metrics to the service")
+    void receive_forwardsToService() {
+        Metrics metrics = new Metrics("sensor-A", 42.0, 60.0, 3, 100, 1, 12.5f, Instant.now());
+
+        receiver.receive(metrics);
+
+        verify(piMetricsService).process(metrics);
+    }
+
+    @Test
+    @DisplayName("ignores a null message without forwarding")
+    void receive_null_ignored() {
+        receiver.receive(null);
+
+        verifyNoInteractions(piMetricsService);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/receiver/PiMetricsServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/receiver/PiMetricsServiceImplTest.java
@@ -1,0 +1,70 @@
+package com.occupi.feature.receiver;
+
+import com.occupi.feature.database.model.MetricsData;
+import com.occupi.feature.database.service.MetricsService;
+import com.occupi.feature.receiver.dto.Metrics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PiMetricsServiceImpl")
+class PiMetricsServiceImplTest {
+
+    @Mock
+    private MetricsService metricsService;
+
+    @InjectMocks
+    private PiMetricsServiceImpl service;
+
+    private Metrics sample() {
+        return new Metrics("sensor-A", 42.0, 60.0, 3, 100, 1, 12.5f,
+                Instant.parse("2026-06-14T10:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("maps Metrics to MetricsData and records it")
+    void process_mapsAndRecords() {
+        service.process(sample());
+
+        ArgumentCaptor<MetricsData> captor = ArgumentCaptor.forClass(MetricsData.class);
+        verify(metricsService).recordMetrics(captor.capture());
+
+        MetricsData recorded = captor.getValue();
+        assertEquals("sensor-A", recorded.getSensorId());
+        assertEquals(42.0, recorded.getCpuPercentage());
+        assertEquals(60.0, recorded.getMemoryPercentage());
+        assertEquals(3, recorded.getQueueSize());
+        assertEquals(100, recorded.getSent());
+        assertEquals(1, recorded.getDropped());
+        assertEquals(12.5f, recorded.getAvgProcessTime());
+        assertEquals(Instant.parse("2026-06-14T10:00:00Z"), recorded.getTimestamp());
+    }
+
+    @Test
+    @DisplayName("ignores null metrics without touching the database")
+    void process_null_ignored() {
+        service.process(null);
+
+        verifyNoInteractions(metricsService);
+    }
+
+    @Test
+    @DisplayName("propagates exceptions from the database layer")
+    void process_propagatesException() {
+        doThrow(new RuntimeException("db down")).when(metricsService).recordMetrics(any());
+
+        assertThrows(RuntimeException.class, () -> service.process(sample()));
+    }
+}


### PR DESCRIPTION
## Metrics pipeline tests (#3)

Per the decision to satisfy #3 by writing tests (no coverage tool), this fills the remaining backend test gap: the **Pi metrics pipeline** was the only feature path without tests (#106 had skipped them as "basically the same" as the occupancy path).

### New tests (+18, total 86 green)
- `MetricsReceiverTest` (2) — STOMP forward to service, null ignored
- `PiMetricsServiceImplTest` (3) — `Metrics` → `MetricsData` mapping, null ignored, exception propagation
- `MetricsServiceTest` (3) — delegates record/recordBatch to the repository, propagates errors
- `MetricsRepositoryTest` (10) — point write, batch write, and validation guards (null, blank sensorId, null timestamp, CPU out of range, negatives, empty/null batch)

No production code changed; mirrors the style of the existing occupancy/receiver tests.

Refs #3
