### PR TITLE
fix: pin PostgreSQL to 16 to match the tested Keycloak stack #113

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,7 +55,7 @@ services:
   # PostgreSQL — hosts two databases: 'occupi' (room metadata) and 'keycloak'.
   # The 'keycloak' database is created on first start by ./postgres/init.
   postgres:
-    image: postgres:17-alpine
+    image: postgres:16
     container_name: occupi-postgres
     ports:
       - "5432:5432"


### PR DESCRIPTION
## Pin PostgreSQL to 16 (#113)

The merged docker-compose used `postgres:17-alpine` (carried over from the Room CRUD PR), but the working Keycloak stack was set up and tested on **PostgreSQL 16**. A v16 data volume is incompatible with a v17 server:

```
FATAL: database files are incompatible with server
DETAIL: The data directory was initialized by PostgreSQL version 16, which is not compatible with this version 17.10.
```

This aligns the image back to `postgres:16` so the single shared Postgres (occupi + keycloak DBs) matches the tested setup.

### Verified end-to-end locally (docker compose)
With a fresh v16 volume:
- Postgres creates **both** databases (`occupi` + `keycloak` via the init script)
- Keycloak imports the `occupi` realm — `/realms/occupi`, JWKS and OIDC discovery all return 200
- Backend boots with the `prod` profile, connects to Postgres, and the OAuth2 Resource Server rejects unauthenticated / invalid-token requests with **401** on `/api/rooms`, `/api/auth/userinfo`, `/api/occupancy/all`

Refs #113
