### PR TITLE
fix: InfluxDB convert BigInteger nanos time to Instant #122

### DIFF
--- a/backend/src/main/java/com/occupi/feature/database/InfluxTime.java
+++ b/backend/src/main/java/com/occupi/feature/database/InfluxTime.java
@@ -1,0 +1,43 @@
+package com.occupi.feature.database;
+
+import java.math.BigInteger;
+import java.time.Instant;
+
+/**
+ * Converts the {@code time} column returned by InfluxDB 3 queries into {@link Instant}.
+ *
+ * The influxdb3-java client returns the timestamp as nanoseconds-since-epoch
+ * (typically a {@link BigInteger}) rather than an {@link Instant}, so a plain
+ * cast fails at runtime. This helper accepts the value defensively.
+ */
+public final class InfluxTime {
+
+    private InfluxTime() {
+    }
+
+    /**
+     * @param value the raw {@code time} value from a query row
+     * @return the corresponding {@link Instant}, or {@code null} if value is null
+     */
+    public static Instant toInstant(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Instant instant) {
+            return instant;
+        }
+        if (value instanceof BigInteger nanos) {
+            return ofEpochNanos(nanos.longValueExact());
+        }
+        if (value instanceof Number number) {
+            return ofEpochNanos(number.longValue());
+        }
+        throw new IllegalArgumentException(
+                "Unsupported InfluxDB time type: " + value.getClass().getName());
+    }
+
+    private static Instant ofEpochNanos(long nanos) {
+        return Instant.ofEpochSecond(Math.floorDiv(nanos, 1_000_000_000L),
+                Math.floorMod(nanos, 1_000_000_000L));
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
@@ -3,6 +3,7 @@ package com.occupi.feature.database.repository;
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.Point;
 import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.database.InfluxTime;
 import com.occupi.feature.database.model.OccupancyData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -125,7 +126,7 @@ public class OccupancyRepository {
                 .sensorId((String) row[1])
                 .count(((Number) row[2]).intValue())
                 .confidence(((Number) row[3]).doubleValue())
-                .timestamp((Instant) row[4])
+                .timestamp(InfluxTime.toInstant(row[4]))
                 .build();
     }
 

--- a/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
@@ -2,6 +2,7 @@ package com.occupi.feature.forecast;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.database.InfluxTime;
 import com.occupi.feature.forecast.dto.ForecastPoint;
 import com.occupi.feature.forecast.dto.ForecastResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -62,7 +63,7 @@ public class ForecastServiceImpl implements ForecastService {
 
             queryReadings(roomId, windowStart, windowEnd).forEach(row -> {
                 double count    = ((Number) row[0]).doubleValue();
-                Instant ts      = (Instant) row[1];
+                Instant ts      = InfluxTime.toInstant(row[1]);
                 long slotKey    = toSlotKey(ts);
 
                 double[] bucket = slotBuckets.computeIfAbsent(slotKey, k -> new double[]{0.0, 0.0});

--- a/backend/src/test/java/com/occupi/feature/database/InfluxTimeTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/InfluxTimeTest.java
@@ -1,0 +1,51 @@
+package com.occupi.feature.database;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("InfluxTime")
+class InfluxTimeTest {
+
+    @Test
+    @DisplayName("converts nanosecond BigInteger (as returned by InfluxDB 3) to Instant")
+    void convertsBigIntegerNanos() {
+        Instant expected = Instant.parse("2026-06-14T10:00:00.123456789Z");
+        BigInteger nanos = BigInteger.valueOf(expected.getEpochSecond())
+                .multiply(BigInteger.valueOf(1_000_000_000L))
+                .add(BigInteger.valueOf(expected.getNano()));
+
+        assertThat(InfluxTime.toInstant(nanos)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("passes through an Instant unchanged")
+    void passesThroughInstant() {
+        Instant t = Instant.parse("2026-06-14T10:00:00Z");
+        assertThat(InfluxTime.toInstant(t)).isEqualTo(t);
+    }
+
+    @Test
+    @DisplayName("converts a numeric nanosecond value to Instant")
+    void convertsLongNanos() {
+        assertThat(InfluxTime.toInstant(1_000_000_000L)).isEqualTo(Instant.ofEpochSecond(1));
+    }
+
+    @Test
+    @DisplayName("returns null for null input")
+    void nullInput() {
+        assertThat(InfluxTime.toInstant(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("rejects an unsupported type")
+    void unsupportedType() {
+        assertThatThrownBy(() -> InfluxTime.toInstant("not-a-time"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +35,13 @@ class OccupancyRepositoryTest {
     @BeforeEach
     void setUp() {
         repository = new OccupancyRepository(influxDBClient);
+    }
+
+    /** Mirrors how InfluxDB 3 returns the time column: nanoseconds since epoch. */
+    private static BigInteger nanos(Instant t) {
+        return BigInteger.valueOf(t.getEpochSecond())
+                .multiply(BigInteger.valueOf(1_000_000_000L))
+                .add(BigInteger.valueOf(t.getNano()));
     }
 
     @Nested
@@ -175,9 +183,10 @@ class OccupancyRepositoryTest {
         @DisplayName("should map the latest row to OccupancyData")
         void shouldMapLatestRow() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            // InfluxDB 3 returns the time column as nanoseconds (BigInteger), not Instant.
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                     .thenAnswer(inv -> Stream.<Object[]>of(
-                            new Object[]{"room-101", "sensor-A", 12L, 0.9, ts}));
+                            new Object[]{"room-101", "sensor-A", 12L, 0.9, nanos(ts)}));
 
             Optional<OccupancyData> result = repository.findLatestByRoom("room-101");
 
@@ -223,8 +232,8 @@ class OccupancyRepositoryTest {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                     .thenAnswer(inv -> Stream.<Object[]>of(
-                            new Object[]{"room-101", "sensor-A", 5L, 0.8, ts},
-                            new Object[]{"room-202", "sensor-B", 20L, 0.95, ts}));
+                            new Object[]{"room-101", "sensor-A", 5L, 0.8, nanos(ts)},
+                            new Object[]{"room-202", "sensor-B", 20L, 0.95, nanos(ts)}));
 
             List<OccupancyData> result = repository.findAllLatest();
 

--- a/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.math.BigInteger;
 import java.time.Instant;
 import java.util.stream.Stream;
 
@@ -29,6 +30,13 @@ class ForecastServiceImplTest {
     // Fixed timestamp well away from slot boundaries and midnight
     private static final Instant FIXED_TS = Instant.parse("2025-01-13T10:15:00Z");
 
+    /** Mirrors how InfluxDB 3 returns the time column: nanoseconds since epoch. */
+    private static BigInteger nanos(Instant t) {
+        return BigInteger.valueOf(t.getEpochSecond())
+                .multiply(BigInteger.valueOf(1_000_000_000L))
+                .add(BigInteger.valueOf(t.getNano()));
+    }
+
     @BeforeEach
     void setUp() {
         service = new ForecastServiceImpl(influxDBClient);
@@ -46,10 +54,10 @@ class ForecastServiceImplTest {
         // weighted avg = (2×1.0 + 4×0.5 + 4×0.25 + 6×0.125) / (1.0+0.5+0.25+0.125)
         //              = (2 + 2 + 1 + 0.75) / 1.875 = 5.75 / 1.875 ≈ 3.067
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{2.0, FIXED_TS}))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, FIXED_TS}))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, FIXED_TS}))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{6.0, FIXED_TS}));
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{2.0, nanos(FIXED_TS)}))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, nanos(FIXED_TS)}))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, nanos(FIXED_TS)}))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{6.0, nanos(FIXED_TS)}));
 
         ForecastResponse response = service.forecast("room-1", 2);
 
@@ -76,9 +84,9 @@ class ForecastServiceImplTest {
         // week 1 (weight 1.0): count=4, week 3 (weight 0.25): count=8
         // weighted avg = (4×1.0 + 8×0.25) / (1.0+0.25) = 6.0 / 1.25 = 4.8
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, FIXED_TS}))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, nanos(FIXED_TS)}))
                 .thenAnswer(inv -> Stream.empty())
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{8.0, FIXED_TS}))
+                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{8.0, nanos(FIXED_TS)}))
                 .thenAnswer(inv -> Stream.empty());
 
         ForecastResponse response = service.forecast("room-1", 2);


### PR DESCRIPTION
## InfluxDB read fix (#122)

Reading occupancy from InfluxDB failed at runtime with HTTP 500:

```
java.lang.ClassCastException: class java.math.BigInteger cannot be cast to class java.time.Instant
```

InfluxDB 3 returns the `time` column as **nanoseconds since epoch (`BigInteger`)**, not `Instant`. The read code cast it directly, and the unit tests had mocked the client with `Instant` — so tests passed while the real integration broke.

### Changes
- New `InfluxTime.toInstant(...)` helper — accepts `Instant`, `BigInteger` and numeric nanosecond values.
- `OccupancyRepository` (read path) and `ForecastServiceImpl` now use it instead of casting.
- Tests corrected to return the time column as `BigInteger` nanoseconds (matching real InfluxDB); added `InfluxTimeTest`.

### Verification
Reproduced live (Pi simulator → InfluxDB → REST): `GET /api/occupancy/all` returned 500 before, returns 200 with data after. 104 tests green.

Closes #122
