### PR TITLE
feat: enable browser/SPA access, CORS preflight + WebSocket origins #124

### DIFF
--- a/backend/src/main/java/com/occupi/app/CorsConfig.java
+++ b/backend/src/main/java/com/occupi/app/CorsConfig.java
@@ -2,33 +2,39 @@ package com.occupi.app;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 /**
  * Global CORS configuration for HTTP endpoints.
  *
- * Allows the frontend (Vite dev server and production builds) to access
- * backend REST APIs. WebSocket CORS is configured separately in WebSocketConfig.
+ * Exposes a single {@link CorsConfigurationSource} bean that is consumed by the
+ * Spring Security filter chains (via {@code http.cors()}), so that cross-origin
+ * preflight requests are allowed through before authentication. This is required
+ * for the browser-based frontend (different origin) to call the secured REST API.
+ *
+ * WebSocket CORS is configured separately in WebSocketConfig.
  */
 @Configuration
 public class CorsConfig {
 
     @Bean
-    public WebMvcConfigurer corsConfigurer() {
-        return new WebMvcConfigurer() {
-            @Override
-            public void addCorsMappings(CorsRegistry registry) {
-                registry.addMapping("/**")
-                        .allowedOrigins(
-                                "http://localhost:5173",               // Vite dev server (default)
-                                "http://localhost:3000",               // alternative dev
-                                "https://occupi.mi.hdm-stuttgart.de"  // production
-                        )
-                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                        .allowedHeaders("*")
-                        .allowCredentials(true);
-            }
-        };
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        // Any localhost port (dev servers, test pages) + the production domain.
+        config.setAllowedOriginPatterns(List.of(
+                "http://localhost:*",
+                "https://occupi.mi.hdm-stuttgart.de"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
     }
 }

--- a/backend/src/main/java/com/occupi/feature/authentication/DevSecurityConfig.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/DevSecurityConfig.java
@@ -3,6 +3,7 @@ package com.occupi.feature.authentication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -15,6 +16,7 @@ public class DevSecurityConfig {
     @Bean
     public SecurityFilterChain devFilterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().permitAll()

--- a/backend/src/main/java/com/occupi/feature/authentication/SecurityConfig.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
@@ -32,6 +33,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/ws/**", "/ws/occupancy/**").permitAll()

--- a/backend/src/main/java/com/occupi/feature/receiver/WebSocketConfig.java
+++ b/backend/src/main/java/com/occupi/feature/receiver/WebSocketConfig.java
@@ -118,18 +118,16 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // Raw WebSocket endpoint for native clients (Raspberry Pi / stomp.py)
         registry
                 .addEndpoint("/ws")
-                .setAllowedOrigins(
-                        "http://localhost:5173",
-                        "http://localhost:3000",
+                .setAllowedOriginPatterns(
+                        "http://localhost:*",
                         "https://occupi.mi.hdm-stuttgart.de"
                 );
 
         // SockJS endpoint for browser clients
         registry
                 .addEndpoint("/ws/occupancy")
-                .setAllowedOrigins(
-                        "http://localhost:5173",
-                        "http://localhost:3000",
+                .setAllowedOriginPatterns(
+                        "http://localhost:*",
                         "https://occupi.mi.hdm-stuttgart.de"
                 )
                 .withSockJS();


### PR DESCRIPTION
## Enable browser/SPA access to the secured API (#124)

A browser frontend on a different origin could not use the backend. Two fixes:

### CORS preflight through Spring Security
The MVC CORS config was not honoured by the security filter chain, so cross-origin requests with an `Authorization` header failed at the preflight `OPTIONS` (401) before reaching the controller.
- `CorsConfig` now exposes a single `CorsConfigurationSource` bean (`http://localhost:*` + production domain, credentials allowed).
- `http.cors(...)` enabled in both the prod (`SecurityConfig`) and dev (`DevSecurityConfig`) filter chains.

### WebSocket origins
`/ws` and `/ws/occupancy` used a fixed origin list, rejecting browser dev servers at the handshake. Now use `setAllowedOriginPatterns("http://localhost:*", "https://occupi.mi.hdm-stuttgart.de")`.

### Verified live
- Preflight `OPTIONS` to `/api/rooms` from a browser origin → 200 with the correct `Access-Control-Allow-*` headers.
- STOMP WebSocket handshake from a localhost origin → 101 Switching Protocols.
- 99 tests green.

Note: the `admin`/`user` realm roles referenced in the issue are already present in `realm-occupi.json` (added with #118), so no realm change is needed here.

Closes #124
