### PR TITLE
test: InfluxDB read-path integration test with Testcontainers #126

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -31,7 +31,22 @@
 		<influxdb3.version>1.8.0</influxdb3.version>
 		<!-- Pin Netty to 4.1.x — arrow-memory-netty 18.x is incompatible with Netty 4.2.x -->
 		<netty.version>4.1.118.Final</netty.version>
+		<!-- Testcontainers is not managed by the Spring Boot 4 BOM -->
+		<testcontainers.version>1.20.6</testcontainers.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>testcontainers-bom</artifactId>
+				<version>${testcontainers.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -83,6 +98,17 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- Testcontainers — real InfluxDB 3 for the read-path integration test (#126) -->
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyInfluxIntegrationTest.java
@@ -1,0 +1,110 @@
+package com.occupi.feature.database.repository;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.occupi.feature.database.model.OccupancyData;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Integration test for the occupancy read path against a real InfluxDB 3 instance.
+ *
+ * This covers the gap that caused #122: the influxdb3-java client returns the
+ * {@code time} column as a {@code BigInteger} (nanoseconds), which a unit test
+ * with a mocked client cannot reproduce. Skipped automatically when Docker is
+ * unavailable.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("OccupancyRepository — real InfluxDB 3 (integration)")
+class OccupancyInfluxIntegrationTest {
+
+    @Container
+    static final GenericContainer<?> influxdb =
+            new GenericContainer<>(DockerImageName.parse("influxdb:3-core"))
+                    .withExposedPorts(8181)
+                    .withCommand("serve",
+                            "--host-id", "occupi-test",
+                            "--http-bind", "0.0.0.0:8181",
+                            "--object-store", "memory",
+                            "--without-auth")
+                    .waitingFor(Wait.forHttp("/health").forStatusCode(200)
+                            .withStartupTimeout(Duration.ofSeconds(90)));
+
+    private static InfluxDBClient client;
+    private OccupancyRepository repository;
+
+    @BeforeAll
+    static void initClient() {
+        String url = "http://" + influxdb.getHost() + ":" + influxdb.getMappedPort(8181);
+        client = InfluxDBClient.getInstance(url, null, "occupi");
+    }
+
+    @AfterAll
+    static void closeClient() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        repository = new OccupancyRepository(client);
+    }
+
+    @Test
+    @DisplayName("persists a reading and reads it back via findLatestByRoom (real BigInteger time)")
+    void writeThenReadLatestByRoom() {
+        Instant ts = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        repository.save(OccupancyData.builder()
+                .roomId("itroom-a").sensorId("itsensor")
+                .count(9).confidence(0.77).timestamp(ts)
+                .build());
+
+        await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    Optional<OccupancyData> latest = repository.findLatestByRoom("itroom-a");
+                    assertThat(latest).isPresent();
+                    OccupancyData data = latest.get();
+                    assertThat(data.getRoomId()).isEqualTo("itroom-a");
+                    assertThat(data.getCount()).isEqualTo(9);
+                    assertThat(data.getConfidence()).isCloseTo(0.77, within(0.0001));
+                    // The fix under test: time comes back as nanoseconds and maps to an Instant.
+                    assertThat(data.getTimestamp()).isNotNull();
+                    assertThat(data.getTimestamp()).isCloseTo(ts, within(Duration.ofSeconds(1)));
+                });
+    }
+
+    @Test
+    @DisplayName("returns the latest per room via findAllLatest")
+    void writeThenReadAllLatest() {
+        Instant ts = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        repository.save(OccupancyData.builder()
+                .roomId("itroom-b1").sensorId("s").count(3).confidence(0.9).timestamp(ts).build());
+        repository.save(OccupancyData.builder()
+                .roomId("itroom-b2").sensorId("s").count(15).confidence(0.8).timestamp(ts).build());
+
+        await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    List<OccupancyData> all = repository.findAllLatest();
+                    assertThat(all).extracting(OccupancyData::getRoomId)
+                            .contains("itroom-b1", "itroom-b2");
+                });
+    }
+}


### PR DESCRIPTION
## InfluxDB read-path integration test (#126)

Closes the test-vs-reality gap that caused #122: the unit tests mocked the InfluxDB client, so they couldn't reveal that the real client returns the `time` column as `BigInteger` nanoseconds. This adds a real integration test.

### Changes
- Testcontainers (`testcontainers` + `junit-jupiter`, BOM pinned to 1.20.6 since Spring Boot 4 does not manage it).
- `OccupancyInfluxIntegrationTest` spins up a real **InfluxDB 3** container (`influxdb:3-core`, in-memory object store) and exercises the read path end-to-end:
  - write an `OccupancyData`, then read it back via `findLatestByRoom` (asserts roomId, count, confidence and the **timestamp mapped from nanoseconds**)
  - write two rooms, then assert `findAllLatest` returns both (covers the `ROW_NUMBER()` query against the real engine)
- Annotated `@Testcontainers(disabledWithoutDocker = true)` → skips cleanly where Docker is unavailable.

### CI
The class name ends in `Test`, so it runs as part of `./mvnw test`. The GitHub Actions runner has Docker, so it executes there automatically — no workflow change needed.

### Verification
Ran locally against a real InfluxDB 3 container — both integration tests pass; full suite **106 green**.

Closes #126
