### PR TITLE
refactor: Docker base + local/server overlays with prod hardening #128

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,18 +1,22 @@
-# Copy to docker/.env and adjust for your environment.
-
-# ── Backend ──────────────────────────────────────────────────────────────────
-# 'prod' enforces Keycloak JWT auth; set to 'dev' for an open local stack.
-SPRING_PROFILES_ACTIVE=prod
+# Copy to docker/.env and adjust. docker/.env is git-ignored (never commit secrets).
+#
+# Local dev: the defaults in the compose files are enough — you can run without
+#            a .env at all. Set values here only to override.
+# Server:    a .env with real secrets + KC_HOSTNAME is REQUIRED.
 
 # ── PostgreSQL (shared by the backend 'occupi' DB and Keycloak's 'keycloak' DB) ─
 POSTGRES_USER=occupi
 POSTGRES_PASSWORD=change_me
 
-# ── Keycloak Admin Console ───────────────────────────────────────────────────
+# ── Keycloak admin console bootstrap ─────────────────────────────────────────
 KEYCLOAK_ADMIN=admin
 KEYCLOAK_ADMIN_PASSWORD=change_me
 
-# ── Keycloak Hostname ────────────────────────────────────────────────────────
-# For production set to occupi.mi.hdm-stuttgart.de
-KC_HOSTNAME=localhost
-KC_HOSTNAME_PORT=8180
+# ── Server only ──────────────────────────────────────────────────────────────
+# Public host of the deployment (used by Keycloak in the prod overlay).
+# Required when running with docker-compose.prod.yml.
+KC_HOSTNAME=occupi.mi.hdm-stuttgart.de
+
+# Optional: override the backend Spring profile (local overlay defaults to 'dev',
+# prod overlay forces 'prod' — normally you do NOT need to set this).
+# SPRING_PROFILES_ACTIVE=dev

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,58 @@
+# OccuPi — Docker
+
+One base + two overlays. The base (`docker-compose.yml`) is never run alone.
+
+```
+docker-compose.yml           # base: shared services + internal network (no host ports)
+docker-compose.override.yml  # LOCAL: dev profile, all ports on host, Keycloak start-dev
+docker-compose.prod.yml      # SERVER: prod profile, 127.0.0.1-only ports, Keycloak hardened
+.env / .env.example          # secrets & host config (.env is git-ignored)
+keycloak/realm-occupi.json   # realm import (clients, HdM-LDAP federation, roles)
+postgres/init/               # creates the 'keycloak' database on first start
+```
+
+## Local
+
+`docker compose` automatically merges `docker-compose.yml` + `docker-compose.override.yml`:
+
+```bash
+cd docker
+docker compose up -d                 # full stack (builds the backend image)
+docker compose up -d influxdb postgres keycloak   # infra only (run backend via ./mvnw)
+docker compose down                  # stop (add -v to also drop data volumes)
+```
+
+Exposed locally: backend `:8080`, Keycloak `:8180`, InfluxDB `:8181`, Postgres `:5432`.
+Backend runs in the open **dev** profile (no auth). To test auth locally:
+`SPRING_PROFILES_ACTIVE=prod docker compose up -d`.
+
+## Server
+
+```bash
+cd docker
+cp .env.example .env        # then set real POSTGRES_PASSWORD, KEYCLOAK_ADMIN_PASSWORD, KC_HOSTNAME
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
+```
+
+In prod:
+- Backend runs in the **prod** profile → every request needs a valid Keycloak JWT.
+- Only **backend** (`127.0.0.1:8080`) and **keycloak** (`127.0.0.1:8180`) are published, for the
+  host's existing Nginx to reverse-proxy. **InfluxDB and Postgres are not exposed** to the host.
+- Keycloak runs with `KC_HOSTNAME` / `KC_HOSTNAME_STRICT=true` / `KC_PROXY_HEADERS=xforwarded`
+  (TLS terminated by the host Nginx).
+
+### Host Nginx (already present on the server)
+The reverse proxy lives on the host (not in Compose). It must:
+- terminate TLS for the public domain,
+- proxy the backend (`/api`, and `/ws` **with** WebSocket `Upgrade`/`Connection` headers) to `127.0.0.1:8080`,
+- expose Keycloak (subpath or subdomain) to `127.0.0.1:8180` forwarding `X-Forwarded-*`.
+
+> The exact Nginx config is aligned against the live server separately (server inspection pending).
+
+### Hardening still open (tracked)
+- **InfluxDB auth/token:** currently `--without-auth`; in prod it is at least network-isolated
+  (no host port). Enabling token auth is a follow-up (create an admin token, set `influxdb.token`).
+- **Keycloak optimized image:** `start` auto-builds on first run; a pre-built `--optimized`
+  image speeds up restarts (follow-up).
+- **DB migrations:** backend still uses JPA `ddl-auto=update` (follow-up: Flyway).

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,0 +1,34 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# LOCAL development overlay — applied automatically by `docker compose up`.
+#
+# Publishes all service ports to the host for convenience (REST, test pages,
+# Pi simulation, direct DB access) and runs in the open 'dev' profile.
+#
+# Tip: for active backend development you can run only the infra here
+# (docker compose up -d influxdb postgres keycloak) and start the backend
+# locally with `./mvnw spring-boot:run` against these ports.
+# ─────────────────────────────────────────────────────────────────────────────
+services:
+  backend:
+    environment:
+      # 'dev' = all endpoints open (no auth). Override to 'prod' to test auth locally.
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
+    ports:
+      - "8080:8080"
+
+  influxdb:
+    ports:
+      - "8181:8181"
+
+  postgres:
+    ports:
+      - "5432:5432"
+
+  keycloak:
+    environment:
+      KC_HOSTNAME: localhost
+      KC_HOSTNAME_PORT: "8180"
+      KC_HOSTNAME_STRICT: "false"
+    command: start-dev --import-realm
+    ports:
+      - "8180:8080"

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,0 +1,35 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SERVER / PRODUCTION overlay.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Assumes an Nginx reverse proxy ALREADY runs on the host and terminates TLS.
+# Therefore only backend + keycloak are published — bound to 127.0.0.1 so they
+# are reachable by the host Nginx but NOT from the public internet. InfluxDB and
+# PostgreSQL get NO host ports at all (internal Docker network only).
+#
+# Requires docker/.env with at least: POSTGRES_PASSWORD, KEYCLOAK_ADMIN_PASSWORD,
+# KC_HOSTNAME (the public https host, e.g. occupi.mi.hdm-stuttgart.de).
+# ─────────────────────────────────────────────────────────────────────────────
+services:
+  backend:
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m
+    ports:
+      - "127.0.0.1:8080:8080"   # host Nginx → backend
+
+  keycloak:
+    environment:
+      # Public host of Keycloak (behind the TLS-terminating host Nginx).
+      KC_HOSTNAME: ${KC_HOSTNAME:?set KC_HOSTNAME in docker/.env}
+      KC_HOSTNAME_STRICT: "true"
+      # Trust X-Forwarded-* from the host Nginx (TLS terminated there).
+      KC_PROXY_HEADERS: xforwarded
+    # 'start' (not start-dev) for production; auto-builds on first run.
+    command: start --import-realm
+    ports:
+      - "127.0.0.1:8180:8080"   # host Nginx → keycloak
+
+  # influxdb & postgres intentionally have NO 'ports' here:
+  # they stay on the internal Docker network and are not exposed to the host.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,19 +1,31 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# OccuPi — BASE compose (shared by local and server)
+#
+# This file is NOT run on its own. It is always combined with an overlay:
+#
+#   Local development:   docker compose up -d
+#                        (auto-merges docker-compose.override.yml)
+#
+#   Server / production: docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# The base defines the services and the internal Docker network wiring only.
+# Host port publishing and environment that differs between local and server
+# live in the overlays.
+# ─────────────────────────────────────────────────────────────────────────────
 services:
   backend:
     build:
       context: ../backend
       dockerfile: Dockerfile
     container_name: occupi-backend
-    ports:
-      - "8080:8080"
     environment:
-      # 'prod' enforces Keycloak JWT auth. Override to 'dev' for an open local stack.
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-prod}
+      # Internal service-to-service URLs (same in every environment).
       INFLUXDB_URL: http://influxdb:8181
       POSTGRES_URL: jdbc:postgresql://postgres:5432/occupi
       POSTGRES_USER: ${POSTGRES_USER:-occupi}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-occupi}
-      # JWKS reached via the internal hostname (avoids issuer-uri host mismatch).
+      # JWKS reached via the internal hostname (works regardless of the external
+      # Keycloak hostname — that's why the backend uses jwk-set-uri, not issuer-uri).
       KEYCLOAK_JWK_SET_URI: http://keycloak:8080/realms/occupi/protocol/openid-connect/certs
     depends_on:
       influxdb:
@@ -24,27 +36,14 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
-  # frontend:
-  #   build:
-  #     context: ../frontend
-  #     dockerfile: Dockerfile
-  #   container_name: occupi-frontend
-  #   ports:
-  #     - "3000:80"
-  #   depends_on:
-  #     - backend
-  #   restart: unless-stopped
-
   influxdb:
     image: influxdb:3-core
     container_name: occupi-influxdb3
-    ports:
-      - "8181:8181"
-    volumes:
-      - influxdb3-data:/var/lib/influxdb3
     environment:
       - INFLUXDB3_HOST_ID=occupi-prod
     command: serve --host-id occupi-prod --http-bind 0.0.0.0:8181 --object-store file --data-dir /var/lib/influxdb3 --without-auth
+    volumes:
+      - influxdb3-data:/var/lib/influxdb3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8181/health"]
       interval: 5s
@@ -52,13 +51,11 @@ services:
       retries: 5
     restart: unless-stopped
 
-  # PostgreSQL — hosts two databases: 'occupi' (room metadata) and 'keycloak'.
-  # The 'keycloak' database is created on first start by ./postgres/init.
+  # PostgreSQL hosts two databases: 'occupi' (room metadata) and 'keycloak'
+  # (created on first start by ./postgres/init).
   postgres:
     image: postgres:16
     container_name: occupi-postgres
-    ports:
-      - "5432:5432"
     environment:
       POSTGRES_DB: occupi
       POSTGRES_USER: ${POSTGRES_USER:-occupi}
@@ -73,18 +70,12 @@ services:
       retries: 5
     restart: unless-stopped
 
-  # Keycloak — OIDC provider federating the HdM LDAP; imports the occupi realm.
   keycloak:
     image: quay.io/keycloak/keycloak:26.2
     container_name: occupi-keycloak
-    ports:
-      - "8180:8080"
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
-      KC_HOSTNAME: ${KC_HOSTNAME:-localhost}
-      KC_HOSTNAME_PORT: ${KC_HOSTNAME_PORT:-8180}
-      KC_HOSTNAME_STRICT: "false"
       KC_HTTP_ENABLED: "true"
       KC_HEALTH_ENABLED: "true"
       KC_DB: postgres
@@ -93,7 +84,6 @@ services:
       KC_DB_PASSWORD: ${POSTGRES_PASSWORD:-occupi}
     volumes:
       - ./keycloak/realm-occupi.json:/opt/keycloak/data/import/realm-occupi.json:ro
-    command: start-dev --import-realm
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Docker: one base, two overlays (local + server) + prod hardening (#128)

Restructures all Docker config so a single base serves both local development and the server, and hardens the server variant.

### Structure
- **`docker-compose.yml`** — base: shared service definitions + internal Docker network only (no host ports). Not run alone.
- **`docker-compose.override.yml`** — **local**, auto-applied by `docker compose up`: `dev` profile, all ports on host (8080/8180/8181/5432), Keycloak `start-dev`.
- **`docker-compose.prod.yml`** — **server**, explicit (`-f … prod.yml`): `prod` profile, only **backend** + **keycloak** published on `127.0.0.1` for the host Nginx, **InfluxDB + Postgres not exposed**, Keycloak `KC_HOSTNAME`/`KC_HOSTNAME_STRICT=true`/`KC_PROXY_HEADERS=xforwarded` + `start`, JVM mem limits.
- **`docker/README.md`** — run instructions (local vs server) + hardening notes.
- **`.env.example`** — local vs server variables; `KC_HOSTNAME` required for server (fail-fast guard).

### Verified
- `docker compose config` valid for **both** modes.
- Local merge → dev profile, all host ports, `start-dev`.
- Prod merge → prod profile, only `127.0.0.1:8080`/`:8180`, no influx/postgres host ports, `start`.
- New structure reconciles the running local stack **without recreation** (containers stay up, data intact: 239 occupancy rows, realm reachable).

### Addresses (Audit P1, Docker-near)
- Base/override/prod split; backend fully containerized; internal services not exposed in prod; secrets via `.env` (defaults local-only); Keycloak prod-fest.

### Out of scope (follow-ups)
- Host **Nginx/TLS** config — Nginx already runs on the server; exact config aligned during a separate server inspection.
- InfluxDB token auth (now network-isolated in prod), Keycloak `--optimized` image, Flyway, Grafana provisioning — see README notes.

Refs #96
Closes #128
