### PR TITLE
add: production Nginx config + Keycloak /auth path #130

### DIFF
--- a/deploy/nginx/occupi.conf
+++ b/deploy/nginx/occupi.conf
@@ -1,0 +1,52 @@
+# OccuPi — production Nginx site (host reverse proxy, TLS termination).
+# Deploy to /etc/nginx/sites-available/occupi and symlink into sites-enabled.
+# Matches the prod Docker overlay: backend on 127.0.0.1:8080, Keycloak on
+# 127.0.0.1:8180 (served under /auth). InfluxDB/Postgres are NOT proxied.
+
+server {
+    listen 80;
+    server_name occupi.mi.hdm-stuttgart.de;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name occupi.mi.hdm-stuttgart.de;
+
+    ssl_certificate     /etc/letsencrypt/live/occupi.mi.hdm-stuttgart.de/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/occupi.mi.hdm-stuttgart.de/privkey.pem;
+
+    # Keycloak (served under /auth — KC_HTTP_RELATIVE_PATH=/auth)
+    location /auth {
+        proxy_pass http://127.0.0.1:8180;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+    }
+
+    # Backend REST API
+    location /api/ {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Raspberry Pi STOMP ingestion (WebSocket upgrade required)
+    location /ws {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 3600s;
+    }
+
+    # Frontend (SPA) — add a root location here once a frontend is deployed.
+}

--- a/docker/README.md
+++ b/docker/README.md
@@ -40,15 +40,21 @@ In prod:
 - Only **backend** (`127.0.0.1:8080`) and **keycloak** (`127.0.0.1:8180`) are published, for the
   host's existing Nginx to reverse-proxy. **InfluxDB and Postgres are not exposed** to the host.
 - Keycloak runs with `KC_HOSTNAME` / `KC_HOSTNAME_STRICT=true` / `KC_PROXY_HEADERS=xforwarded`
-  (TLS terminated by the host Nginx).
+  and is served under **`/auth`** (`KC_HTTP_RELATIVE_PATH=/auth`), behind the host Nginx.
 
 ### Host Nginx (already present on the server)
-The reverse proxy lives on the host (not in Compose). It must:
-- terminate TLS for the public domain,
-- proxy the backend (`/api`, and `/ws` **with** WebSocket `Upgrade`/`Connection` headers) to `127.0.0.1:8080`,
-- expose Keycloak (subpath or subdomain) to `127.0.0.1:8180` forwarding `X-Forwarded-*`.
+The reverse proxy lives on the host (not in Compose). The versioned config is
+[`../deploy/nginx/occupi.conf`](../deploy/nginx/occupi.conf):
+- terminates TLS (Let's Encrypt) for `occupi.mi.hdm-stuttgart.de`,
+- `/api/` and `/ws` (with WebSocket `Upgrade`/`Connection` headers) → `127.0.0.1:8080`,
+- `/auth` → `127.0.0.1:8180` (Keycloak), forwarding `X-Forwarded-*`.
 
-> The exact Nginx config is aligned against the live server separately (server inspection pending).
+Deploy it with:
+```bash
+sudo cp deploy/nginx/occupi.conf /etc/nginx/sites-available/occupi
+sudo ln -sf /etc/nginx/sites-available/occupi /etc/nginx/sites-enabled/occupi
+sudo nginx -t && sudo systemctl reload nginx
+```
 
 ### Hardening still open (tracked)
 - **InfluxDB auth/token:** currently `--without-auth`; in prod it is at least network-isolated

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -16,6 +16,9 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: prod
       JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m
+      # Keycloak is served under /auth in prod (see KC_HTTP_RELATIVE_PATH below),
+      # so the internal JWKS path includes /auth too.
+      KEYCLOAK_JWK_SET_URI: http://keycloak:8080/auth/realms/occupi/protocol/openid-connect/certs
     ports:
       - "127.0.0.1:8080:8080"   # host Nginx → backend
 
@@ -24,6 +27,8 @@ services:
       # Public host of Keycloak (behind the TLS-terminating host Nginx).
       KC_HOSTNAME: ${KC_HOSTNAME:?set KC_HOSTNAME in docker/.env}
       KC_HOSTNAME_STRICT: "true"
+      # Served under https://<host>/auth — matches the host Nginx /auth route.
+      KC_HTTP_RELATIVE_PATH: /auth
       # Trust X-Forwarded-* from the host Nginx (TLS terminated there).
       KC_PROXY_HEADERS: xforwarded
     # 'start' (not start-dev) for production; auto-builds on first run.


### PR DESCRIPTION
## Production Nginx + Keycloak /auth for server deployment (#130)

Completes the server-side wiring for the new Docker structure (#128), based on a live inspection of `occupi.mi.hdm-stuttgart.de`.

### Findings on the server (old deployment)
- Ran the **old** branch with all ports public (postgres/influx exposed).
- Host Nginx proxied `/auth`→8080, `/api`→8081, `/grafana`→3000 (Grafana not running), **no `/ws`** → the Raspberry Pi could not connect. Missing `X-Forwarded-*` headers.
- Valid Let's Encrypt cert present (kept).

### Changes
- **`docker-compose.prod.yml`**: Keycloak `KC_HTTP_RELATIVE_PATH=/auth` and backend `KEYCLOAK_JWK_SET_URI` → `http://keycloak:8080/auth/realms/...` (internal, matches the relative path).
- **`deploy/nginx/occupi.conf`** (versioned): `/api/` + **`/ws`** (WebSocket upgrade) → `127.0.0.1:8080`, `/auth` → `127.0.0.1:8180`, full `X-Forwarded-*` headers, `/grafana` removed, TLS via the existing cert.
- **`docker/README.md`**: references the Nginx config + deploy commands.

### Verified
- `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` valid; Keycloak `start --import-realm`, JWKS path includes `/auth`.

### Next (server ops, after merge)
Clean redeploy on the server: wipe old deployment + data volumes, clone `develop`, `up -d --build` with the prod overlay, install this Nginx config, verify.

Refs #96
Closes #130
