### PR TITLE
feat: add frontend Dockerfile #97

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# ─── Build Stage ─────────────────────────────────────────────────────────────
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ─── Runtime Stage ────────────────────────────────────────────────────────────
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Frontend Dockerfile (#97)

Adds the missing `frontend/Dockerfile` to complete the containerization of the full stack. The backend Dockerfile and Docker Compose structure were already in place; this closes the remaining open item from #97.

### Changes
- **`frontend/Dockerfile`** — multi-stage build: `node:22-alpine` builds the Vite app (`npm ci` + `npm run build`), `nginx:alpine` serves the static `dist/` output on port 80.

### Notes
- The `frontend/.dockerignore` was already present (added with the backend Dockerfile in an earlier commit).
- The frontend is not wired into the Compose files by design — in production it is served as static files by the host Nginx (see #96/#130); for local development `npm run dev` is used directly.

Closes #97