### PR TITLE
feat: frontend container + Keycloak login (local + server)

### DIFF
--- a/deploy/nginx/occupi.conf
+++ b/deploy/nginx/occupi.conf
@@ -48,5 +48,12 @@ server {
         proxy_read_timeout 3600s;
     }
 
-    # Frontend (SPA) — add a root location here once a frontend is deployed.
+    # Frontend (SPA) — served by the frontend container (Docker prod overlay).
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -16,6 +16,12 @@ services:
     ports:
       - "8080:8080"
 
+  # Built SPA at http://localhost:3000 (an occupi-frontend webOrigin in Keycloak).
+  # For hot-reload development run Vite directly instead (npm run dev → :5173).
+  frontend:
+    ports:
+      - "3000:80"
+
   influxdb:
     ports:
       - "8181:8181"

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -22,6 +22,16 @@ services:
     ports:
       - "127.0.0.1:8080:8080"   # host Nginx → backend
 
+  # SPA built with the public URLs (Vite inlines them at build time) and published
+  # only to localhost; the host Nginx proxies "/" here.
+  frontend:
+    build:
+      args:
+        VITE_API_URL: https://${KC_HOSTNAME}/api
+        VITE_KEYCLOAK_URL: https://${KC_HOSTNAME}/auth
+    ports:
+      - "127.0.0.1:3000:80"   # host Nginx → frontend
+
   keycloak:
     environment:
       # Public host of Keycloak (behind the TLS-terminating host Nginx).

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,6 +36,20 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  # Frontend SPA, served by nginx inside the image. Vite inlines VITE_* at build
+  # time; these defaults target local dev, the prod overlay overrides the URLs.
+  frontend:
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_URL: http://localhost:8080/api
+        VITE_KEYCLOAK_URL: http://localhost:8180
+        VITE_KEYCLOAK_REALM: occupi
+        VITE_KEYCLOAK_CLIENT_ID: occupi-frontend
+    container_name: occupi-frontend
+    restart: unless-stopped
+
   influxdb:
     image: influxdb:3-core
     container_name: occupi-influxdb3

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,6 @@
 VITE_API_URL=http://localhost:8080/api
+
+# Keycloak (local dev). Token endpoint = <URL>/realms/<REALM>/protocol/openid-connect/token
+VITE_KEYCLOAK_URL=http://localhost:8180
+VITE_KEYCLOAK_REALM=occupi
+VITE_KEYCLOAK_CLIENT_ID=occupi-frontend

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,9 @@
-# Basis-URL für die Kommunikation mit dem Raspberry Pi / Backend
+# Base URL for talking to the backend REST API
 VITE_API_URL=http://localhost:8080/api
+
+# Keycloak OIDC connection used by the login (password grant).
+# Token endpoint = <VITE_KEYCLOAK_URL>/realms/<VITE_KEYCLOAK_REALM>/protocol/openid-connect/token
+# Local dev defaults; on the server point these at https://occupi.mi.hdm-stuttgart.de/auth etc.
+VITE_KEYCLOAK_URL=http://localhost:8180
+VITE_KEYCLOAK_REALM=occupi
+VITE_KEYCLOAK_CLIENT_ID=occupi-frontend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,10 +4,21 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
+
+# Vite inlines VITE_* at build time → injected per environment via Compose build args.
+ARG VITE_API_URL=http://localhost:8080/api
+ARG VITE_KEYCLOAK_URL=http://localhost:8180
+ARG VITE_KEYCLOAK_REALM=occupi
+ARG VITE_KEYCLOAK_CLIENT_ID=occupi-frontend
+ENV VITE_API_URL=$VITE_API_URL \
+    VITE_KEYCLOAK_URL=$VITE_KEYCLOAK_URL \
+    VITE_KEYCLOAK_REALM=$VITE_KEYCLOAK_REALM \
+    VITE_KEYCLOAK_CLIENT_ID=$VITE_KEYCLOAK_CLIENT_ID
 RUN npm run build
 
 # ─── Runtime Stage ────────────────────────────────────────────────────────────
 FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /app/dist /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,12 @@
+# Frontend SPA: serve hashed static assets, fall back to index.html so that
+# client-side (react-router) routes like /dashboard resolve on direct hit/reload.
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/frontend/src/hooks/useAuthStore.ts
+++ b/frontend/src/hooks/useAuthStore.ts
@@ -5,71 +5,131 @@ interface User {
     role: string;
 }
 
+type LoginResult = { ok: true } | { ok: false; error: string };
+
 interface AuthState {
     user: User | null;
     token: string | null;
     isAuthenticated: boolean;
-    login: (username: string, password: string) => Promise<boolean>;
+    login: (username: string, password: string) => Promise<LoginResult>;
     logout: () => void;
     initializeAuth: () => void;
 }
 
-const MOCK_TOKEN = 'mock-jwt-token-xyz-12345';
+// Keycloak connection — overridable via env, with local-dev defaults so the
+// app works out of the box against the local Docker stack.
+const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL ?? 'http://localhost:8180';
+const REALM = import.meta.env.VITE_KEYCLOAK_REALM ?? 'occupi';
+const CLIENT_ID = import.meta.env.VITE_KEYCLOAK_CLIENT_ID ?? 'occupi-frontend';
+const TOKEN_ENDPOINT = `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token`;
+
+interface JwtClaims {
+    preferred_username?: string;
+    email?: string;
+    exp?: number;
+    realm_access?: { roles?: string[] };
+}
+
+// Decode a JWT payload (base64url) without pulling in a dependency.
+function decodeJwt(token: string): JwtClaims | null {
+    try {
+        const base64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+        const json = decodeURIComponent(
+            atob(base64)
+                .split('')
+                .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+                .join('')
+        );
+        return JSON.parse(json) as JwtClaims;
+    } catch {
+        return null;
+    }
+}
+
+function userFromToken(token: string): User {
+    const claims = decodeJwt(token);
+    const username = claims?.preferred_username ?? 'unbekannt';
+    const roles = claims?.realm_access?.roles ?? [];
+    return { username, role: roles.includes('admin') ? 'admin' : 'user' };
+}
+
+function isExpired(token: string): boolean {
+    const claims = decodeJwt(token);
+    if (!claims?.exp) return true;
+    // 5s clock-skew allowance
+    return Date.now() >= claims.exp * 1000 - 5000;
+}
 
 export const useAuthStore = create<AuthState>((set) => ({
     user: null,
     token: null,
     isAuthenticated: false,
 
-    // added error handling and edited token handling
+    // Restore a previous session from localStorage if the token is still valid.
     initializeAuth: () => {
-        try {
-            const token = localStorage.getItem('token');
-            const savedUser = localStorage.getItem('user');
-
-            // token string must exactly match the mock token now
-            if (token === MOCK_TOKEN && savedUser) {
-                set({
-                    token,
-                    user: JSON.parse(savedUser),
-                    isAuthenticated: true,
-                });
-            } else {
-                localStorage.removeItem('token');
-                localStorage.removeItem('user');
-            }
-
-        } catch {
-            // Reset everything if JSON data in localStorage is corrupt
+        const token = localStorage.getItem('token');
+        if (token && !isExpired(token)) {
+            set({ token, user: userFromToken(token), isAuthenticated: true });
+        } else {
             localStorage.removeItem('token');
             localStorage.removeItem('user');
+            localStorage.removeItem('refresh_token');
             set({ user: null, token: null, isAuthenticated: false });
         }
     },
 
+    // Real login: exchange HdM credentials for a Keycloak JWT (password grant).
+    // Credentials go straight to Keycloak, which federates the HdM LDAP.
     login: async (username, password) => {
-        if (username.trim() === 'admin' && password === 'admin123') {
-            const mockUser = { username, role: 'admin' };
-
-            localStorage.setItem('token', MOCK_TOKEN);
-            localStorage.setItem('user', JSON.stringify(mockUser));
-
-            set({
-                user: mockUser,
-                token: MOCK_TOKEN,
-                isAuthenticated: true,
+        let res: Response;
+        try {
+            res = await fetch(TOKEN_ENDPOINT, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: new URLSearchParams({
+                    grant_type: 'password',
+                    client_id: CLIENT_ID,
+                    username: username.trim(),
+                    password,
+                }),
             });
-            return true;
+        } catch {
+            return {
+                ok: false,
+                error: 'Keine Verbindung zu Keycloak. Bist du im HdM-Netz/VPN und läuft der Stack?',
+            };
         }
-        return false;
+
+        if (!res.ok) {
+            let body: { error?: string; error_description?: string } | null = null;
+            try {
+                body = await res.json();
+            } catch {
+                /* non-JSON error body */
+            }
+            if (body?.error === 'invalid_grant') {
+                return { ok: false, error: 'Ungültiger Benutzername oder Passwort.' };
+            }
+            return {
+                ok: false,
+                error: body?.error_description ?? body?.error ?? `Keycloak-Fehler (HTTP ${res.status}).`,
+            };
+        }
+
+        const data = await res.json();
+        const token = data.access_token as string;
+        localStorage.setItem('token', token);
+        if (data.refresh_token) {
+            localStorage.setItem('refresh_token', data.refresh_token);
+        }
+        set({ token, user: userFromToken(token), isAuthenticated: true });
+        return { ok: true };
     },
 
-    // removed window.location.href. We now handle the redirect reactively via the ProtectedRoute / App layout.
     logout: () => {
         localStorage.removeItem('token');
         localStorage.removeItem('user');
+        localStorage.removeItem('refresh_token');
         set({ user: null, token: null, isAuthenticated: false });
     },
 }));
-
-// the automatic call at the module level has been removed here

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -21,13 +21,13 @@ export const Login = () => {
             return;
         }
 
-        const success = await login(username, password);
+        const result = await login(username, password);
 
-        if (success) {
+        if (result.ok) {
             // Login successful -> redirect to dashboard
             navigate('/');
         } else {
-            setError('Ungültiger Username oder Passwort.'); //Test Daten
+            setError(result.error);
         }
     };
 


### PR DESCRIPTION
## Summary
Makes the frontend production-ready and runnable **both locally and on the server**:
- Connects the login to Keycloak (password grant) — replaces the previous `admin`/`admin123` mock.
- Containerizes the frontend and wires it into **all three** Compose files (base + local override + prod overlay) plus the host Nginx.

Closes #135
Closes #136

## What changed
- **Login (#135):** `useAuthStore` exchanges HdM credentials for a Keycloak JWT (password grant), decodes the token client-side for username/role, restores sessions with an expiry check, and surfaces clear errors. Added `VITE_KEYCLOAK_*` env vars with local-dev defaults.
- **Frontend image (#136):** `frontend/Dockerfile` takes `VITE_*` **build args** (Vite inlines them at build time; `.env` is dockerignored) and ships an **SPA-fallback** nginx config (`try_files … /index.html`).
- **Compose (#136):** `frontend` service in the **base**; **local override** publishes `:3000` with localhost URLs; **prod overlay** bakes `https://${KC_HOSTNAME}/api|/auth` and binds to `127.0.0.1:3000`.
- **Host Nginx (#136):** `location /` proxies to the frontend container.

## Run it
- **Local:** `cd docker && docker compose up -d` → SPA at http://localhost:3000 (or `npm run dev` → :5173 for hot reload).
- **Server:** `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build` builds + serves the SPA; host Nginx routes `/`.

## Verification
- Merged compose config valid for **local** and **prod** (correct URLs/ports per environment).
- Frontend container **builds and serves locally**: `/` and `/dashboard` → 200 (SPA fallback), localhost URLs baked in (no domain).
- Login verified end-to-end against the local stack (prod backend profile, JWT accepted by the backend).

_No backend code changed; the backend test suite is unaffected (CI still runs it)._