### PR TITLE
fix: keep Keycloak management endpoint at root for prod healthcheck

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -39,6 +39,9 @@ services:
       KC_HOSTNAME_STRICT: "true"
       # Served under https://<host>/auth — matches the host Nginx /auth route.
       KC_HTTP_RELATIVE_PATH: /auth
+      # Keep the management/health endpoint (port 9000) at root, otherwise /auth
+      # also moves /health/ready and the container healthcheck fails (unhealthy).
+      KC_HTTP_MANAGEMENT_RELATIVE_PATH: "/"
       # Trust X-Forwarded-* from the host Nginx (TLS terminated there).
       KC_PROXY_HEADERS: xforwarded
     # 'start' (not start-dev) for production; auto-builds on first run.


### PR DESCRIPTION
## Problem
In the prod overlay, `KC_HTTP_RELATIVE_PATH=/auth` also shifts Keycloak's management/health endpoint (port 9000) under `/auth`. The container healthcheck (from the base compose) probes `/health/ready` → **404** → Keycloak is marked **unhealthy**. Since the backend has `depends_on: keycloak: condition: service_healthy`, the backend never starts and the whole prod stack is blocked.

## Fix
Add `KC_HTTP_MANAGEMENT_RELATIVE_PATH: "/"` to the keycloak service in `docker-compose.prod.yml`, so the management/health endpoint stays at root (`/health/ready`) and the base healthcheck passes. The realm/JWKS path stays under `/auth` (unchanged).

## Verification (on the server)
- Before: `GET :9000/health/ready` → 404, `/auth/health/ready` → 200, keycloak `unhealthy`.
- After: keycloak `healthy`, backend starts; end-to-end checks green (`/api`→401, `/auth/realms/occupi`→200, `/`→200).

Closes #138