### PR TITLE
CD: build backend & frontend images in CI, server pulls only (no on-server build)

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,86 @@
+# Builds the backend & frontend images in CI and pushes them to GHCR, so the
+# production server only ever PULLS prebuilt images and never builds on the host
+# (an on-server Maven build once exhausted the swapless VM's RAM). See issue #140.
+name: Build & Push Images
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'docker/**'
+      - '.github/workflows/images.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  # Public host the frontend is served from. Vite inlines VITE_* at build time,
+  # so the GHCR frontend image must be built with the prod URLs.
+  PROD_HOSTNAME: occupi.mi.hdm-stuttgart.de
+
+jobs:
+  backend:
+    name: Backend image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push backend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/elhan-salaji/occupi-backend:latest
+            ${{ env.REGISTRY }}/elhan-salaji/occupi-backend:${{ github.sha }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,scope=backend,mode=max
+
+  frontend:
+    name: Frontend image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          build-args: |
+            VITE_API_URL=https://${{ env.PROD_HOSTNAME }}/api
+            VITE_KEYCLOAK_URL=https://${{ env.PROD_HOSTNAME }}/auth
+            VITE_KEYCLOAK_REALM=occupi
+            VITE_KEYCLOAK_CLIENT_ID=occupi-frontend
+          tags: |
+            ${{ env.REGISTRY }}/elhan-salaji/occupi-frontend:latest
+            ${{ env.REGISTRY }}/elhan-salaji/occupi-frontend:${{ github.sha }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,scope=frontend,mode=max

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,12 +4,26 @@ One base + two overlays. The base (`docker-compose.yml`) is never run alone.
 
 ```
 docker-compose.yml           # base: shared services + internal network (no host ports)
-docker-compose.override.yml  # LOCAL: dev profile, all ports on host, Keycloak start-dev
+docker-compose.override.yml  # LOCAL: dev profile, all ports on host, Keycloak start-dev, builds from source
 docker-compose.prod.yml      # SERVER: prod profile, 127.0.0.1-only ports, Keycloak hardened
 .env / .env.example          # secrets & host config (.env is git-ignored)
 keycloak/realm-occupi.json   # realm import (clients, HdM-LDAP federation, roles)
 postgres/init/               # creates the 'keycloak' database on first start
 ```
+
+## Images: built in CI, pulled in prod
+
+The `backend` and `frontend` services reference prebuilt GHCR images in the base:
+`ghcr.io/elhan-salaji/occupi-{backend,frontend}:latest`. They are built and pushed by
+the [`Build & Push Images`](../.github/workflows/images.yml) workflow on every push to
+`develop`. The **production server only pulls** these images and never builds — an
+on-server Maven build once exhausted the swapless VM's RAM (memory livelock, see #140).
+
+- The **frontend** image is built in CI with the **prod** `VITE_*` URLs baked in (Vite
+  inlines them at build time), so it points at `https://occupi.mi.hdm-stuttgart.de`.
+- The GHCR packages are **public**, so the server pulls without authentication.
+- **Local development** still builds from source: the local overlay adds a `build:` for
+  both services (frontend with `localhost` URLs).
 
 ## Local
 
@@ -17,10 +31,13 @@ postgres/init/               # creates the 'keycloak' database on first start
 
 ```bash
 cd docker
-docker compose up -d                 # full stack (builds the backend image)
+docker compose up -d --build         # full stack (builds backend & frontend from source)
 docker compose up -d influxdb postgres keycloak   # infra only (run backend via ./mvnw)
 docker compose down                  # stop (add -v to also drop data volumes)
 ```
+
+Use `--build` to pick up source changes — without it Compose reuses the local image
+(which may be a previously pulled GHCR `:latest`).
 
 Exposed locally: backend `:8080`, Keycloak `:8180`, InfluxDB `:8181`, Postgres `:5432`.
 Backend runs in the open **dev** profile (no auth). To test auth locally:
@@ -31,6 +48,7 @@ Backend runs in the open **dev** profile (no auth). To test auth locally:
 ```bash
 cd docker
 cp .env.example .env        # then set real POSTGRES_PASSWORD, KEYCLOAK_ADMIN_PASSWORD, KC_HOSTNAME
+docker compose -f docker-compose.yml -f docker-compose.prod.yml pull   # pull prebuilt images (never builds)
 docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 docker compose -f docker-compose.yml -f docker-compose.prod.yml ps
 ```

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -10,6 +10,10 @@
 # ─────────────────────────────────────────────────────────────────────────────
 services:
   backend:
+    # Local builds from source; prod pulls the GHCR image defined in the base.
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
     environment:
       # 'dev' = all endpoints open (no auth). Override to 'prod' to test auth locally.
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
@@ -19,6 +23,16 @@ services:
   # Built SPA at http://localhost:3000 (an occupi-frontend webOrigin in Keycloak).
   # For hot-reload development run Vite directly instead (npm run dev → :5173).
   frontend:
+    # Local builds from source with localhost URLs; prod pulls the GHCR image
+    # (built in CI with the prod URLs) defined in the base.
+    build:
+      context: ../frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_URL: http://localhost:8080/api
+        VITE_KEYCLOAK_URL: http://localhost:8180
+        VITE_KEYCLOAK_REALM: occupi
+        VITE_KEYCLOAK_CLIENT_ID: occupi-frontend
     ports:
       - "3000:80"
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -22,13 +22,9 @@ services:
     ports:
       - "127.0.0.1:8080:8080"   # host Nginx → backend
 
-  # SPA built with the public URLs (Vite inlines them at build time) and published
-  # only to localhost; the host Nginx proxies "/" here.
+  # Pulled from GHCR (built in CI with the public prod URLs baked in via VITE_*).
+  # Published only to localhost; the host Nginx proxies "/" here.
   frontend:
-    build:
-      args:
-        VITE_API_URL: https://${KC_HOSTNAME}/api
-        VITE_KEYCLOAK_URL: https://${KC_HOSTNAME}/auth
     ports:
       - "127.0.0.1:3000:80"   # host Nginx → frontend
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,9 +14,9 @@
 # ─────────────────────────────────────────────────────────────────────────────
 services:
   backend:
-    build:
-      context: ../backend
-      dockerfile: Dockerfile
+    # Prebuilt in CI and pulled from GHCR — the server never builds (see #140).
+    # The local overlay adds a `build:` so development still builds from source.
+    image: ghcr.io/elhan-salaji/occupi-backend:latest
     container_name: occupi-backend
     environment:
       # Internal service-to-service URLs (same in every environment).
@@ -36,17 +36,11 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
-  # Frontend SPA, served by nginx inside the image. Vite inlines VITE_* at build
-  # time; these defaults target local dev, the prod overlay overrides the URLs.
+  # Frontend SPA, served by nginx inside the image. Prebuilt in CI with the PROD
+  # VITE_* URLs (Vite inlines them at build time) and pulled from GHCR. The local
+  # overlay adds a `build:` with localhost URLs so development builds from source.
   frontend:
-    build:
-      context: ../frontend
-      dockerfile: Dockerfile
-      args:
-        VITE_API_URL: http://localhost:8080/api
-        VITE_KEYCLOAK_URL: http://localhost:8180
-        VITE_KEYCLOAK_REALM: occupi
-        VITE_KEYCLOAK_CLIENT_ID: occupi-frontend
+    image: ghcr.io/elhan-salaji/occupi-frontend:latest
     container_name: occupi-frontend
     restart: unless-stopped
 


### PR DESCRIPTION
## What
Build the backend and frontend images in CI and push them to GHCR, so the production server only ever **pulls** prebuilt images and never builds on the host.

## Why
A previous on-server `docker compose up -d --build` ran the Maven build on the swapless 4 GB VM and exhausted its RAM → memory livelock (SSH/Nginx frozen, hard reboot needed). Pulling a prebuilt JRE/nginx image needs almost no CPU/RAM, so moving the build off the server is the core crash-safety fix and the foundation for automatic deployment (#141).

## Changes
- **`.github/workflows/images.yml`** — on push to `develop` (paths `backend/**`, `frontend/**`, `docker/**`) + manual dispatch:
  - builds & pushes `ghcr.io/elhan-salaji/occupi-backend` (`latest` + commit SHA)
  - builds & pushes `ghcr.io/elhan-salaji/occupi-frontend` (`latest` + commit SHA), with the **prod** `VITE_*` URLs baked in (Vite inlines them at build time)
  - buildx + GHA cache, `packages: write`, login via `GITHUB_TOKEN`
- **Compose refactor** — base references `image: ghcr.io/elhan-salaji/occupi-{backend,frontend}:latest` (no `build:`); the local overlay adds `build:` for both (frontend with `localhost` URLs); prod inherits the base image → pull only.
- **Docs** — `docker/README.md` updated for the build-in-CI / pull-in-prod split (local uses `up -d --build`, server uses `pull` then `up -d`).

## Follow-up (one-time, manual)
- Make both GHCR packages **public** so the server pulls without auth.

## Verification
- `docker compose config` (local) → backend & frontend keep both `build:` and `image:`.
- `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` → backend & frontend resolve to the GHCR `image:` with no `build:`.

Closes #140. Part of #96.
