### PR TITLE
fix: DB no longer overwrites MOCK_ROOMS and Dashboard rooms dont vanish anymore #143

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -30,7 +30,8 @@ export default function Dashboard() {
                         };
                 });
 
-                setRooms(combined); //schreibt die kombinierten Daten in den Store
+                // Solange noch keine echten Räume in der DB sind, Mock-Daten anzeigen
+                setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
             } catch (error) {
                 console.error("Fehler beim Laden:", error);
                 setRooms(MOCK_ROOMS);


### PR DESCRIPTION
## Fallback to mock rooms when API returns empty (#143)

The dashboard relies on `MOCK_ROOMS` until real room data exists in the DB. After a Docker restart, the mock rooms were briefly shown, but a reload (or any successful `/api/rooms` response) overwrote them with an empty list — since `GET /api/rooms` returns `[]` until real rooms are seeded.

### Changes
- **`Dashboard.tsx`** — `setRooms` now falls back to `MOCK_ROOMS` when the combined room list from `/api/rooms` + `/api/occupancy/all` is empty

### Result
- Dashboard keeps showing the mock rooms (phase: mock) consistently, instead of going blank on reload
- Once real rooms are seeded in the DB, the real data is shown instead

Closes #143