### PR TITLE
add: automatic prod deploy via systemd timer with health-gated rollback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Keep shell scripts and systemd units LF-only so they work when checked out on
+# the Linux server (the repo is also edited on Windows where core.autocrlf=true).
+*.sh       text eol=lf
+*.service  text eol=lf
+*.timer    text eol=lf

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,102 @@
+# OccuPi — deploy
+
+Host-side bits that live outside Docker Compose: the Nginx reverse proxy
+([`nginx/occupi.conf`](nginx/occupi.conf)) and the **automatic deploy** timer.
+
+## Automatic deploy (systemd timer)
+
+The server only ever **pulls** prebuilt images from GHCR and never builds (an
+on-server Maven build once exhausted the swapless VM's RAM, see #140). This timer
+automates the manual `pull` + recreate you would otherwise SSH in to run.
+
+```
+auto-deploy.sh              # the deploy logic (versioned here, runs from the repo)
+occupi-autodeploy.service   # one-shot unit that runs the script
+occupi-autodeploy.timer     # fires the service every 5 minutes
+```
+
+### What a run does
+
+1. **Fast-forwards the repo** (`git pull --ff-only` on `develop`) so compose files
+   and this script stay current. Diverged/blocked checkout → it warns and skips
+   the update instead of forcing anything.
+2. **Pulls** the latest `backend` + `frontend` images from GHCR (download only —
+   running containers are not touched yet).
+3. **Recreates only what changed.** A service is restarted only if its `:latest`
+   image id differs from the one its container is running. Infra
+   (`postgres` / `keycloak` / `influxdb`) is deliberately left alone.
+4. **Health-gates each update with rollback.** After recreating a service it polls
+   a liveness URL (`backend` → `/v3/api-docs`, `frontend` → `/`). If it does not
+   return `200` within ~2 min, it **rolls back** to the previous image, records the
+   bad image digest, and that digest is **not redeployed** until `:latest` moves on.
+5. **Prunes** dangling and >14-day-old unused images to reclaim disk.
+
+It is safe to run on every tick: when nothing changed it is a no-op. Only one run
+executes at a time (flock).
+
+> **Note:** auto-deploy means *every merge to `develop` goes live by itself*
+> within ~5–10 min (CI build + next tick). That is the intended behaviour.
+
+### Install (one-time, on the server, as root)
+
+After this is merged to `develop` and the repo is pulled on the server:
+
+```bash
+cd /home/Elhan/Occupi
+git pull --ff-only                      # get the deploy/ files
+
+# Copy the units into systemd (cp, not symlink — most reliable for enable):
+cp deploy/occupi-autodeploy.service deploy/occupi-autodeploy.timer /etc/systemd/system/
+
+systemctl daemon-reload
+systemctl enable --now occupi-autodeploy.timer
+
+# Optional: run it once now and watch it
+systemctl start occupi-autodeploy.service
+journalctl -u occupi-autodeploy -f
+```
+
+The **script** (`auto-deploy.sh`) runs straight from the repo, so it stays current
+via `git pull` automatically. Only the two **unit files** are copied — re-`cp` them
++ `systemctl daemon-reload` on the rare occasion they change.
+
+### Operate
+
+```bash
+systemctl list-timers occupi-autodeploy.timer     # when does it next run?
+journalctl -u occupi-autodeploy -n 100 --no-pager # recent deploy logs
+systemctl start occupi-autodeploy.service         # deploy now (don't wait for the tick)
+
+# Pause / resume automatic deploys:
+systemctl stop occupi-autodeploy.timer            # pause
+systemctl start occupi-autodeploy.timer           # resume
+```
+
+A failed deploy makes the **service** unit fail (visible in
+`systemctl status occupi-autodeploy.service` and `journalctl`). The site stays up
+because the script rolls back.
+
+### Change the deploy logic later
+
+`auto-deploy.sh` runs straight from the repo, so editing it via Git (push to
+`develop`) takes effect on the next tick — **no server access needed**. Only
+changing the schedule in `occupi-autodeploy.timer` needs a server-side re-`cp`
++ `systemctl daemon-reload`.
+
+### Manual deploy (no timer)
+
+The timer just automates this; you can always do it by hand:
+
+```bash
+cd /home/Elhan/Occupi/docker
+docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+### Uninstall
+
+```bash
+systemctl disable --now occupi-autodeploy.timer
+rm -f /etc/systemd/system/occupi-autodeploy.{service,timer}
+systemctl daemon-reload
+```

--- a/deploy/auto-deploy.sh
+++ b/deploy/auto-deploy.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# OccuPi — automatic deploy (poll & apply the latest GHCR images, health-gated).
+#
+# Invoked periodically by occupi-autodeploy.timer. Each run:
+#   1. fast-forwards the repo (compose files + this script itself),
+#   2. pulls the latest backend/frontend images from GHCR,
+#   3. recreates ONLY the services whose image actually changed,
+#   4. health-checks each; on failure it ROLLS BACK to the previous image and
+#      records the bad digest so it is not redeployed until :latest moves on,
+#   5. prunes old images to reclaim disk.
+#
+# Infra (postgres / keycloak / influxdb) is intentionally NOT touched here —
+# those are pinned versions and updated manually (a DB major upgrade can need
+# migration steps). See deploy/README.md.
+#
+# Runs as root via systemd. Logs go to journald:  journalctl -u occupi-autodeploy
+#
+# The server only ever PULLS prebuilt images and never builds (see #140), so this
+# always uses the prod overlay explicitly — never the local override.
+
+set -euo pipefail
+
+# The whole body is wrapped in a brace group so bash reads the entire script into
+# memory before executing it. The `git pull` below may rewrite this very file
+# mid-run; reading it up front prevents that from corrupting execution.
+{
+
+# ── Configuration ────────────────────────────────────────────────────────────
+REPO_DIR="/home/Elhan/Occupi"
+BRANCH="develop"
+REGISTRY_OWNER="ghcr.io/elhan-salaji"
+SERVICES=(backend frontend)          # infra is updated manually on purpose
+STATE_DIR="/var/lib/occupi-autodeploy"
+LOCKFILE="/run/occupi-autodeploy.lock"
+HEALTH_RETRIES=40                    # 40 x 3s = up to 120s for a service to come up
+HEALTH_DELAY=3
+PRUNE_OLDER_THAN="336h"              # drop unused images older than 14 days
+
+COMPOSE_DIR="$REPO_DIR/docker"
+
+log() { echo "[$(date -Is)] $*"; }
+
+# Compose helper — ALWAYS base + prod overlay, never the local override.
+dc() {
+  docker compose -f "$COMPOSE_DIR/docker-compose.yml" \
+                 -f "$COMPOSE_DIR/docker-compose.prod.yml" "$@"
+}
+
+img_ref()       { echo "$REGISTRY_OWNER/occupi-$1:latest"; }
+running_image() { docker inspect --format '{{.Image}}' "occupi-$1" 2>/dev/null || echo "none"; }
+tag_image_id()  { docker image inspect --format '{{.Id}}' "$(img_ref "$1")" 2>/dev/null || echo "none"; }
+tag_digest()    { docker image inspect --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' "$(img_ref "$1")" 2>/dev/null || echo ""; }
+
+# Liveness URL per service, checked from the host (the prod overlay publishes
+# these on 127.0.0.1). backend: /v3/api-docs is permitAll in the prod
+# SecurityConfig -> 200 when up. frontend: nginx serves the SPA index -> 200.
+health_url() {
+  case "$1" in
+    backend)  echo "http://127.0.0.1:8080/v3/api-docs" ;;
+    frontend) echo "http://127.0.0.1:3000/" ;;
+    *)        echo "" ;;
+  esac
+}
+
+# Poll the URL until it returns HTTP 200, or fail after the retry budget.
+wait_healthy() {
+  local url="$1" code i
+  [ -n "$url" ] || return 0
+  for ((i = 1; i <= HEALTH_RETRIES; i++)); do
+    code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$url" 2>/dev/null || echo 000)
+    [ "$code" = "200" ] && return 0
+    sleep "$HEALTH_DELAY"
+  done
+  return 1
+}
+
+# ── Single-instance lock (skip if a previous run is still going) ─────────────
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+  log "another auto-deploy run is in progress — exiting"
+  exit 0
+fi
+
+mkdir -p "$STATE_DIR"
+
+# ── 1. Sync the repo (compose files + this script) ───────────────────────────
+log "fetching origin/$BRANCH in $REPO_DIR"
+if git -C "$REPO_DIR" fetch --quiet --prune origin "$BRANCH"; then
+  if git -C "$REPO_DIR" merge-base --is-ancestor HEAD "origin/$BRANCH"; then
+    if git -C "$REPO_DIR" pull --ff-only --quiet origin "$BRANCH"; then
+      log "repo fast-forwarded to $(git -C "$REPO_DIR" rev-parse --short HEAD)"
+    else
+      log "WARN: git pull failed — continuing with existing checkout"
+    fi
+  else
+    log "WARN: local HEAD diverged from origin/$BRANCH — skipping repo update"
+  fi
+else
+  log "WARN: git fetch failed — continuing with existing checkout"
+fi
+
+# ── 2. Pull the latest images (download only; running containers untouched) ───
+log "pulling images: ${SERVICES[*]}"
+dc pull "${SERVICES[@]}" || log "WARN: docker pull failed — using locally cached images"
+
+# ── 3. Apply changed services, health-gated with rollback ────────────────────
+failed=0
+changed_any=0
+
+for svc in "${SERVICES[@]}"; do
+  before=$(running_image "$svc")
+  after=$(tag_image_id "$svc")
+
+  if [ "$before" = "$after" ] && [ "$before" != "none" ]; then
+    log "$svc: up to date"
+    continue
+  fi
+
+  digest=$(tag_digest "$svc")
+  bad_marker="$STATE_DIR/$svc.bad"
+  if [ -n "$digest" ] && [ -f "$bad_marker" ] && [ "$(cat "$bad_marker")" = "$digest" ]; then
+    log "$svc: current :latest digest is known-bad — skipping until it changes"
+    continue
+  fi
+
+  changed_any=1
+  log "$svc: updating ($before -> $after)"
+
+  ok=1
+  dc up -d "$svc" || ok=0
+  if [ "$ok" = "1" ] && wait_healthy "$(health_url "$svc")"; then
+    log "$svc: healthy after update"
+    rm -f "$bad_marker"
+  else
+    log "ERROR: $svc did not come up healthy"
+    failed=1
+    if [ -n "$digest" ]; then echo "$digest" > "$bad_marker"; fi
+    if [ "$before" != "none" ]; then
+      log "$svc: rolling back to previous image $before"
+      docker tag "$before" "$(img_ref "$svc")" || true
+      dc up -d "$svc" || true
+      if wait_healthy "$(health_url "$svc")"; then
+        log "$svc: healthy again after rollback"
+      else
+        log "CRITICAL: $svc still unhealthy after rollback — manual intervention needed"
+      fi
+    else
+      log "CRITICAL: $svc has no previous image to roll back to — manual intervention needed"
+    fi
+  fi
+done
+
+# ── 4. Reclaim disk ──────────────────────────────────────────────────────────
+docker image prune -f >/dev/null 2>&1 || true
+docker image prune -af --filter "until=$PRUNE_OLDER_THAN" >/dev/null 2>&1 || true
+
+if [ "$changed_any" = "0" ]; then
+  log "nothing to deploy — already current"
+fi
+
+if [ "$failed" != "0" ]; then
+  log "auto-deploy finished WITH ERRORS"
+  exit 1
+fi
+log "auto-deploy finished OK"
+exit 0
+
+}

--- a/deploy/occupi-autodeploy.service
+++ b/deploy/occupi-autodeploy.service
@@ -1,0 +1,15 @@
+# OccuPi auto-deploy — one-shot unit run on a timer (see occupi-autodeploy.timer).
+# Pulls the latest GHCR images and applies them with health-gated rollback.
+# Install: see deploy/README.md.
+[Unit]
+Description=OccuPi auto-deploy (pull latest images, health-gated)
+Wants=network-online.target docker.service
+After=network-online.target docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# Run via bash explicitly so it does not depend on the file's executable bit
+# (the repo is also edited on Windows). The script itself uses the prod overlay.
+ExecStart=/bin/bash /home/Elhan/Occupi/deploy/auto-deploy.sh
+TimeoutStartSec=900

--- a/deploy/occupi-autodeploy.timer
+++ b/deploy/occupi-autodeploy.timer
@@ -1,0 +1,15 @@
+# Runs occupi-autodeploy.service periodically. Install: see deploy/README.md.
+[Unit]
+Description=Run OccuPi auto-deploy every 5 minutes
+
+[Timer]
+# First run 2 min after boot, then every 5 min after each run finishes.
+OnBootSec=2min
+OnUnitActiveSec=5min
+# Spread the wakeup a little so it never fires on the exact same second.
+RandomizedDelaySec=30
+# Catch up on a run that was missed while the machine was off.
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
Automates the server's manual `pull` + recreate so a merge to `develop` goes live by itself, without an SSH session. The server still only PULLS prebuilt GHCR images and never builds (#140).

A **systemd timer** polls GHCR every 5 min and applies new backend/frontend images:
- fast-forwards the repo, pulls the prod images (prod overlay only, never the local override)
- recreates only services whose image changed (infra postgres/keycloak/influxdb left untouched)
- health-checks each update (backend `/v3/api-docs`, frontend `/`) with rollback to the previous image on failure; skips a known-bad digest until `:latest` moves on
- prunes old images

Files under `deploy/` (script + systemd units + README). One-time server install is documented in `deploy/README.md`. Touches no image-trigger paths, so merging does not rebuild images.

Closes #146