### PR TITLE
add: rooms list page with occupancy table #46

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -20,13 +20,13 @@ export default function Dashboard() {
                 const combined: Room[] = roomsRes.data.map((room) => {
                     const occ = occupancyRes.data.find((o) => o.roomId === room.roomId);
                     const ratio = (occ?.count ?? 0) / room.capacity;
-                    const status = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
+                    const occupancyRate = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
                         return {
                             ...room,
                             count: occ?.count ?? 0,
                             confidence: occ?.confidence ?? 0,
                             timestamp: occ?.timestamp ?? '',
-                            status,
+                            occupancyRate,
                         };
                 });
 
@@ -59,8 +59,8 @@ export default function Dashboard() {
                             </div>
                             {/* traffic light system */}
                             <div className={`w-3 h-3 rounded-full ${
-                                room.status === 'low' ? 'bg-green-500' :
-                                    room.status === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
+                                room.occupancyRate === 'low' ? 'bg-green-500' :
+                                    room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
                             }`} />
                         </div>
 
@@ -77,8 +77,8 @@ export default function Dashboard() {
                         <div className="mt-4 w-full bg-gray-100 rounded-full h-2">
                             <div
                                 className={`h-2 rounded-full transition-all duration-500 ${
-                                    room.status === 'low' ? 'bg-green-500' :
-                                        room.status === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
+                                    room.occupancyRate === 'low' ? 'bg-green-500' :
+                                        room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
                                 }`}
                                 style={{ width: `${(room.count / room.capacity) * 100}%` }}
                             />

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -7,12 +7,12 @@ const columns: { label: string; render: (r: Room) => React.ReactNode }[] = [
     {label: 'Gebäude', render: (r) => r.building},
     {label: 'Etage', render: (r) => String(r.floor) },
     {label: 'Belegung', render: (r) => <OccupancyBar count={r.count} capacity={r.capacity} /> },
-    {label: 'Auslastung', render: (r) => <StatusBadge status={r.status}/> },
+    {label: 'Auslastung', render: (r) => <StatusBadge status={r.occupancyRate}/> },
     {label: 'Aktualisiert', render: (r) => formatTime(r.timestamp) },
 
 ];
 
-function StatusBadge({ status }: { status: Room['status'] }) {
+function StatusBadge({ status }: { status: Room['occupancyRate'] }) {
     const styles = {
         low:    'bg-green-100 text-green-800',
         medium: 'bg-yellow-100 text-yellow-800',
@@ -63,10 +63,10 @@ export default function Rooms(){
 
         <div className="max-w-7xl mx-auto">
             <header className="mb-8">
-                <h1 className="text-3xl text-left px-4 py-2 font-bold text-blue-900">Raumübersicht</h1> {/*not styled to the usual norm -> "text-left px-4 py-2 | delete by chance"*/}
-                <p className="text-left px-4 text-gray-500">Alle Räume mit aktueller Belegung</p> {/*not styled to the usual norm -> "text-left px-4" | delete by chance*/}
+                <h1 className="text-3xl text-left px-4 py-2 font-bold text-blue-900">Raumübersicht</h1> {/*not styled to the usual norm of dashboard.tsx -> "text-left px-4 py-2 | delete by chance"*/}
+                <p className="text-left px-4 text-gray-500">Alle Räume mit aktueller Belegung</p> {/*not styled to the usual norm of dashboard.tsx -> "text-left px-4" | delete by chance*/}
             </header>
-
+        <div className="overflow-x-auto">
             <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
                 <table className="w-full">
                     <thead>
@@ -92,7 +92,7 @@ export default function Rooms(){
                     </tbody>
                 </table>
             </div>
-
+        </div>
         </div>
 
     );

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -63,8 +63,8 @@ export default function Rooms(){
 
         <div className="max-w-7xl mx-auto">
             <header className="mb-8">
-                <h1 className="text-3xl text-left px-4 py-2 font-bold text-blue-900">Raumübersicht</h1> {/*not styled to the usual norm of dashboard.tsx -> "text-left px-4 py-2 | delete by chance"*/}
-                <p className="text-left px-4 text-gray-500">Alle Räume mit aktueller Belegung</p> {/*not styled to the usual norm of dashboard.tsx -> "text-left px-4" | delete by chance*/}
+                <h1 className="text-3xl text-left font-bold text-gray-900">Raumübersicht</h1>
+                <p className="text-left text-gray-500">Alle Räume mit aktueller Belegung</p>
             </header>
         <div className="overflow-x-auto">
             <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -1,8 +1,101 @@
-export default function Raumuebersicht() {
+import { useRoomStore } from '../hooks/useRoomStore.ts';
+import type { Room } from '../types/room';
+import React from 'react';
+
+const columns: { label: string; render: (r: Room) => React.ReactNode }[] = [
+    {label: 'Raum', render: (r) => r.name },
+    {label: 'Gebäude', render: (r) => r.building},
+    {label: 'Etage', render: (r) => String(r.floor) },
+    {label: 'Belegung', render: (r) => <OccupancyBar count={r.count} capacity={r.capacity} /> },
+    {label: 'Auslastung', render: (r) => <StatusBadge status={r.status}/> },
+    {label: 'Aktualisiert', render: (r) => formatTime(r.timestamp) },
+
+];
+
+function StatusBadge({ status }: { status: Room['status'] }) {
+    const styles = {
+        low:    'bg-green-100 text-green-800',
+        medium: 'bg-yellow-100 text-yellow-800',
+        high:   'bg-red-100 text-red-800',
+    };
+
+    const labels = {
+        low: 'Niedrig',
+        medium: 'Mittel',
+        high: 'Hoch',
+    };
     return (
-        <div className="p-8">
-            <h1 className="text-3xl font-bold text-blue-600">Raumübersicht</h1>
-            <p className="text-gray-500 mt-2">Hier entstehen bald die Raumübersicht-Visualisierungen.</p>
-        </div>
+        <span className={`text-xs px-2 py-1 rounded-md font-medium ${styles[status]}`}>
+            {labels[status]}
+        </span>
     );
+
+}
+
+function OccupancyBar({count, capacity}: {count: number; capacity: number}) {
+    const pct = Math.round((count / capacity)*100);
+
+    return (
+      <div className="flex items-center gap-2">
+          <div className="w-24 h-2 bg-gray-100 rounded-full overflow-hidden">
+              <div
+                  className="h-full bg-blue-500 rounded-full"
+                  style={{width: `${pct}%`}}
+                  />
+          </div>
+          <span className="text-gray-500 text-xs">{count} / {capacity}</span>
+      </div>
+    );
+}
+
+function formatTime(timestamp: string) {
+    if (!timestamp) return '—';
+    const diff = Math.round((Date.now() - new Date(timestamp).getTime()) / 1000);
+    if (diff < 60) return 'gerade eben';
+    if (diff < 3600) return `vor ${Math.floor(diff / 60)} Min`;
+    return new Date(timestamp).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function Rooms(){
+    const { rooms } = useRoomStore();
+
+    return (
+
+        <div className="max-w-7xl mx-auto">
+            <header className="mb-8">
+                <h1 className="text-3xl text-left px-4 py-2 font-bold text-blue-900">Raumübersicht</h1> {/*not styled to the usual norm -> "text-left px-4 py-2 | delete by chance"*/}
+                <p className="text-left px-4 text-gray-500">Alle Räume mit aktueller Belegung</p> {/*not styled to the usual norm -> "text-left px-4" | delete by chance*/}
+            </header>
+
+            <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
+                <table className="w-full">
+                    <thead>
+                    <tr className="border-b border-gray-100">
+                        {columns.map((col) => (
+                            <th key={col.label} className="text-left px-4 py-3 text-sm font-medium text-gray-600">
+                                {col.label}
+                            </th>
+                        ))}
+                    </tr>
+                    </thead>
+                    <tbody>
+                        {rooms.map((room) => (
+                            <tr key={room.roomId} className="border-b border-gray-200 hover:bg-gray-50">
+                                    {columns.map((col) => (
+                                        <td key={col.label} className="px-4 py-3 text-sm text-gray-700">
+                                            {col.render(room)}
+
+                                        </td>
+                                    ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+        </div>
+
+    );
+
+
 }

--- a/frontend/src/types/room.ts
+++ b/frontend/src/types/room.ts
@@ -23,7 +23,7 @@ export interface Room {
     count: number; // How many people are in the room?
     confidence: number;
     timestamp: string; //
-    status: 'low' | 'medium' | 'high'; // status
+    occupancyRate: 'low' | 'medium' | 'high'; // status
 }
 
 export interface RoomResponse {

--- a/frontend/src/utils/mockData.ts
+++ b/frontend/src/utils/mockData.ts
@@ -14,7 +14,7 @@ export const MOCK_ROOMS: Room[] = [
         count: 49,
         confidence: 0.85,
         capacity: 50,
-        status: 'high',
+        occupancyRate: 'high',
         timestamp: new Date().toISOString(),
     },
     {
@@ -25,7 +25,7 @@ export const MOCK_ROOMS: Room[] = [
         count: 6,
         confidence: 1,
         capacity: 20,
-        status: 'low',
+        occupancyRate: 'low',
         timestamp: new Date().toISOString(),
     },
     {
@@ -36,7 +36,7 @@ export const MOCK_ROOMS: Room[] = [
         count: 110,
         confidence: 0.5,
         capacity: 250,
-        status: 'medium',
+        occupancyRate: 'medium',
         timestamp: new Date().toISOString(),
     }
 ];


### PR DESCRIPTION
## Rooms list page with occupancy table (#46)

`Rooms.tsx` was a placeholder. This implements the full rooms list page
with a data-driven table showing all rooms and their current sensor readings.

### Changes
- **`frontend/src/types/room.ts`** — renamed `status` to `occupancyRate` on the
  `Room` interface for clarity; updated all usages across the codebase
- **`frontend/src/pages/Rooms.tsx`** — replaced placeholder with a table built
  from a `columns` config array (label + render fn per column), making it easy
  to add, remove or reorder columns without touching the table structure.
  Pulls room data from `useRoomStore` (same store as Dashboard, no duplicate fetch).
- **`StatusBadge`** — color-coded pill (green/yellow/red) for low/medium/high occupancy rate
- **`OccupancyBar`** — progress bar showing `count / capacity` as percentage
- **`formatTime`** — formats ISO timestamp to relative time ("gerade eben", "vor X Min")
- **Responsive** — horizontal scroll on mobile via `overflow-x-auto`

### Result
- Rooms page displays all rooms in a scannable table with building, floor,
  live occupancy bar, status badge and last updated time
- Column structure is easily extendable for future additions (e.g. confidence, filters)
- Mock data (MOCK_ROOMS) is shown as fallback until real API data is available
- Table scrolls horizontally on small screens

Closes #46