### PR TITLE
fix: correct rooms API endpoint from /rooms to /api/rooms and english comments #49

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -13,7 +13,7 @@ export default function Dashboard() {
         const fetchRooms = async () => {
             try {
                 const [roomsRes, occupancyRes] = await Promise.all([
-                    api.get<RoomResponse[]>('/rooms'),
+                    api.get<RoomResponse[]>('/api/rooms'),
                     api.get<Occupancy[]>('/api/occupancy/all')
                 ]);
 
@@ -30,7 +30,7 @@ export default function Dashboard() {
                         };
                 });
 
-                // Solange noch keine echten Räume in der DB sind, Mock-Daten anzeigen
+                // as long as there are no room data in the DB, show / use mock data
                 setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
             } catch (error) {
                 console.error("Fehler beim Laden:", error);


### PR DESCRIPTION
## Fix rooms API endpoint and close Dashboard Page issue (#49)

Dashboard.tsx was calling `/rooms` instead of `/api/rooms`, causing the
rooms fetch to fail silently and always fall back to `MOCK_ROOMS` — even
when real rooms exist in the DB.

### Changes
- **`Dashboard.tsx`** — corrected endpoint from `/rooms` to `/api/rooms`
- **`Dashboard.tsx`** — changed german comments into english`


### Result
- Real rooms from the DB are now loaded correctly when available
- Mock fallback still applies when DB is empty (behaviour from #143)

### Context
Issue #49 (Dashboard Page) was implemented across several earlier commits
and PRs that referenced other issues. Key contributions:
- `ffdf218` — initial dashboard with mock data and Zustand store (#40)
- PR #144 — mock fallback fix so rooms don't vanish on reload (#143)
- PR #148 — rooms list page building on the same store (#46)

Closes #49