### PR TITLE
Feature/analytics page #53

### DIFF
--- a/frontend/src/components/RoomStatus.tsx
+++ b/frontend/src/components/RoomStatus.tsx
@@ -1,0 +1,37 @@
+import type { Room } from '../types/room';
+
+export function StatusBadge({ occupancyRate }: { occupancyRate: Room['occupancyRate'] }) {
+    const styles = {
+        low:    'bg-green-100 text-green-800',
+        medium: 'bg-yellow-100 text-yellow-800',
+        high:   'bg-red-100 text-red-800',
+    };
+
+    const labels = {
+        low: 'Niedrig',
+        medium: 'Mittel',
+        high: 'Hoch',
+    };
+    return (
+        <span className={`text-xs px-2 py-1 rounded-md font-medium ${styles[occupancyRate]}`}>
+            {labels[occupancyRate]}
+        </span>
+    );
+
+}
+
+export function OccupancyBar({count, capacity}: {count: number; capacity: number}) {
+    const pct = Math.round((count / capacity)*100);
+
+    return (
+        <div className="flex items-center gap-2">
+            <div className="w-24 h-2 bg-gray-100 rounded-full overflow-hidden">
+                <div
+                    className="h-full bg-blue-500 rounded-full"
+                    style={{width: `${pct}%`}}
+                />
+            </div>
+            <span className="text-gray-500 text-xs">{count} / {capacity}</span>
+        </div>
+    );
+}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,10 +1,33 @@
 import { useRoomStore } from '../hooks/useRoomStore';
 import { StatusBadge} from '../components/RoomStatus';
+import {useState} from "react";
 
 
 export default function Analytics() {
     const { rooms } = useRoomStore();
 
+    // Filter & sort state
+    const [search, setSearch] = useState('');
+    const [buildingFilter, setBuildingFilter] = useState('');
+    const [statusFilter, setStatusFilter] = useState('');
+    const [sortBy, setSortBy] = useState('');
+
+    //Filtered & sorted room list
+    const filteredRooms = rooms
+            .filter((r) => r.name.toLowerCase().includes(search.toLowerCase()))
+            .filter((r) => buildingFilter === '' || r.building === buildingFilter)
+            .filter((r) => statusFilter === '' || r.occupancyRate === statusFilter)
+        .sort((a, b) => {
+            if (sortBy === 'least') return a.count / a.capacity - b.count / b.capacity;
+            if (sortBy === 'most') return b.count / b.capacity - a.count / a.capacity;
+            if (sortBy === 'building') return a.building.localeCompare(b.building);
+            return 0;
+        });
+
+    //Unique buildings for dropdown
+    const buildings = [...new Set(rooms.map((r) => r.building))];
+
+    //Summary card values
     const totalRooms = rooms.length;
     const totalCapacity = rooms.reduce((sum, r) => sum + r.capacity, 0);
     const totalPeople = rooms.reduce((sum, r) => sum + r.count, 0);
@@ -35,19 +58,63 @@ export default function Analytics() {
                 <SummaryCard label="Auslastung" value={`${occupancyPct}%`}/>
             </div>
 
+            <div className="flex flex-wrap gap-3 mb-4">
+
+                {/* Search input */}
+                <input type="text" placeholder="Suche..." value={search} onChange={(e) => setSearch(e.target.value)}
+                       className="bg-white w-full md:w-72 px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100"/>
+
+                {/* Building filter */}
+                <select
+                    value={buildingFilter}
+                    onChange={(e) => setBuildingFilter(e.target.value)}
+                    className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100">
+
+                    <option value="">Alle Gebäude</option>
+                    {buildings.map((b) => (
+                        <option key={b} value={b}>{b}</option>
+                    ))}
+                </select>
+
+                {/* Status filter */}
+                <select
+                    value={statusFilter}
+                    onChange={(e) => setStatusFilter(e.target.value)}
+                    className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100">
+
+                    <option value="">Alle Status</option>
+                    <option value="low">Niedrig</option>
+                    <option value="medium">Mittel</option>
+                    <option value="high">Hoch</option>
+                </select>
+
+                {/* Sort */}
+                <select
+                    value={sortBy}
+                    onChange={(e) => setSortBy(e.target.value)}
+                    className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100"
+                >
+                    <option value="">Sortierung</option>
+                    <option value="least">Aktuell am leersten</option>
+                    <option value="most">Aktuell am vollsten</option>
+                    <option value="building">Nach Gebäude</option>
+                </select>
+
+            </div>
+
             <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
                 <table className="w-full">
                     <thead>
                     <tr className="border-b border-gray-100">
-                            {columns.map((col) => (
-                                <th key={col} className="text-left px-4 py-3 text-sm font-medium text-gray-600">
-                                    {col}
+                        {columns.map((col) => (
+                            <th key={col} className="text-left px-4 py-3 text-sm font-medium text-gray-600">
+                            {col}
                             </th>
-                         ))}
-                        </tr>
+                        ))}
+                    </tr>
                     </thead>
                     <tbody>
-                    {rooms.map((room) => (
+                    {filteredRooms.map((room) => (
                         <tr key={room.roomId} className="border-b border-gray-100 hover:bg-gray-50">
                             <td className="px-4 py-3 text-sm font-medium text-gray-900">
                                 {room.name}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,8 +1,71 @@
+import { useRoomStore } from '../hooks/useRoomStore';
+import { StatusBadge} from '../components/RoomStatus';
+
+
 export default function Analytics() {
+    const { rooms } = useRoomStore();
+
+    const totalRooms = rooms.length;
+    const totalCapacity = rooms.reduce((sum, r) => sum + r.capacity, 0);
+    const totalPeople = rooms.reduce((sum, r) => sum + r.count, 0);
+    const occupancyPct = totalCapacity > 0 ? Math.round((totalPeople / totalCapacity) * 100) : 0;
+
+    const columns = ['Raum', 'Gebäude', 'Belegung', 'Auslastung'];
+
+    function SummaryCard({ label, value }: {label: string; value: string | number }) {
+        return (
+            <div className="bg-white rounded-2xl border border-gray-100 p-4">
+                <p className="text-sm text-gray-400 mb-1">{label}</p>
+                <p className="text-2xl font-semibold text-gray-900">{value}</p>
+            </div>
+        );
+
+    }
+
     return (
-        <div className="p-8">
-            <h1 className="text-3xl font-bold text-purple-600">Analytics</h1>
-            <p className="text-gray-500 mt-2">Hier werden später die Trend-Charts visualisiert.</p>
+        <div className="max-w-7xl mx-auto">
+            <header className="mb-8">
+                <h1 className="text-3xl font-bold text-purple-600">Analytics</h1>
+                <p className="text-gray-500 mt-2">Campus-Überblick, Filter, Sortierung & Export</p>
+            </header>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+                <SummaryCard label="Räume" value={totalRooms}/>
+                <SummaryCard label="Kapazität" value={totalCapacity}/>
+                <SummaryCard label="Personen anwesend" value={totalPeople}/>
+                <SummaryCard label="Auslastung" value={`${occupancyPct}%`}/>
+            </div>
+
+            <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
+                <table className="w-full">
+                    <thead>
+                    <tr className="border-b border-gray-100">
+                            {columns.map((col) => (
+                                <th key={col} className="text-left px-4 py-3 text-sm font-medium text-gray-600">
+                                    {col}
+                            </th>
+                         ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {rooms.map((room) => (
+                        <tr key={room.roomId} className="border-b border-gray-100 hover:bg-gray-50">
+                            <td className="px-4 py-3 text-sm font-medium text-gray-900">
+                                {room.name}
+                                <span className="ml-2 text-gray-400 font-normal">{room.roomId}</span>
+                            </td>
+                            <td className="px-4 py-3 text-sm text-gray-600">{room.building}</td>
+                            <td className="px-4 py-3 text-sm text-gray-600">{room.count} / {room.capacity}</td>
+                            <td className="px-4 py-3 text-sm">
+                                <StatusBadge occupancyRate={room.occupancyRate} />
+                            </td>
+                        </tr>
+                    ))}
+                    </tbody>
+                </table>
+            </div>
+
         </div>
+
+
     );
 }

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -2,6 +2,15 @@ import { useRoomStore } from '../hooks/useRoomStore';
 import { StatusBadge} from '../components/RoomStatus';
 import {useState} from "react";
 
+function SummaryCard({ label, value }: {label: string; value: string | number }) {
+    return (
+        <div className="bg-white rounded-2xl border border-gray-100 p-4">
+            <p className="text-sm text-gray-400 mb-1">{label}</p>
+            <p className="text-2xl font-semibold text-gray-900">{value}</p>
+        </div>
+    );
+
+}
 
 export default function Analytics() {
     const { rooms } = useRoomStore();
@@ -34,16 +43,6 @@ export default function Analytics() {
     const occupancyPct = totalCapacity > 0 ? Math.round((totalPeople / totalCapacity) * 100) : 0;
 
     const columns = ['Raum', 'Gebäude', 'Belegung', 'Auslastung'];
-
-    function SummaryCard({ label, value }: {label: string; value: string | number }) {
-        return (
-            <div className="bg-white rounded-2xl border border-gray-100 p-4">
-                <p className="text-sm text-gray-400 mb-1">{label}</p>
-                <p className="text-2xl font-semibold text-gray-900">{value}</p>
-            </div>
-        );
-
-    }
 
     return (
         <div className="max-w-7xl mx-auto">

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -1,4 +1,5 @@
 import { useRoomStore } from '../hooks/useRoomStore.ts';
+import { StatusBadge, OccupancyBar } from '../components/RoomStatus.tsx';
 import type { Room } from '../types/room';
 import React from 'react';
 
@@ -11,42 +12,6 @@ const columns: { label: string; render: (r: Room) => React.ReactNode }[] = [
     {label: 'Aktualisiert', render: (r) => formatTime(r.timestamp) },
 
 ];
-
-function StatusBadge({ status }: { status: Room['occupancyRate'] }) {
-    const styles = {
-        low:    'bg-green-100 text-green-800',
-        medium: 'bg-yellow-100 text-yellow-800',
-        high:   'bg-red-100 text-red-800',
-    };
-
-    const labels = {
-        low: 'Niedrig',
-        medium: 'Mittel',
-        high: 'Hoch',
-    };
-    return (
-        <span className={`text-xs px-2 py-1 rounded-md font-medium ${styles[status]}`}>
-            {labels[status]}
-        </span>
-    );
-
-}
-
-function OccupancyBar({count, capacity}: {count: number; capacity: number}) {
-    const pct = Math.round((count / capacity)*100);
-
-    return (
-      <div className="flex items-center gap-2">
-          <div className="w-24 h-2 bg-gray-100 rounded-full overflow-hidden">
-              <div
-                  className="h-full bg-blue-500 rounded-full"
-                  style={{width: `${pct}%`}}
-                  />
-          </div>
-          <span className="text-gray-500 text-xs">{count} / {capacity}</span>
-      </div>
-    );
-}
 
 function formatTime(timestamp: string) {
     if (!timestamp) return '—';

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -8,7 +8,7 @@ const columns: { label: string; render: (r: Room) => React.ReactNode }[] = [
     {label: 'Gebäude', render: (r) => r.building},
     {label: 'Etage', render: (r) => String(r.floor) },
     {label: 'Belegung', render: (r) => <OccupancyBar count={r.count} capacity={r.capacity} /> },
-    {label: 'Auslastung', render: (r) => <StatusBadge status={r.occupancyRate}/> },
+    {label: 'Auslastung', render: (r) => <StatusBadge occupancyRate={r.occupancyRate}/> },
     {label: 'Aktualisiert', render: (r) => formatTime(r.timestamp) },
 
 ];


### PR DESCRIPTION
## Analytics page with filters, sorting and summary cards (#53)

Replaces the Analytics placeholder with a fully functional page showing
live room data from the existing Zustand store — no new API endpoints needed.

### Changes
- **`Analytics.tsx`** — page header, summary cards (rooms, capacity, people,
  occupancy%), searchable and filterable room table, sort by occupancy/building
- **`RoomStatus.tsx`** — new shared component extracting `StatusBadge` and
  `OccupancyBar` from `Rooms.tsx` to avoid duplication
- **`Rooms.tsx`** — removed local `StatusBadge`/`OccupancyBar` definitions,
  replaced with import from `RoomStatus.tsx`, renamed prop `status` → `occupancyRate`

### Result
- Analytics page shows live occupancy for all rooms with color-coded status badges
- Search filters by room name, dropdowns filter by building and status,
  sort dropdown orders by fullest/emptiest/building
- `StatusBadge` and `OccupancyBar` are now shared — one change applies everywhere

### Out of scope
- Time filter (#47) and Room filter (#48) deferred — not needed for current MVP
- Grafana panels deferred to #50

Closes #53