### PR TITLE
add: poll occupancy data every 10s for real-time updates (#54)

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -39,6 +39,8 @@ export default function Dashboard() {
         };
 
         fetchRooms();
+        const interval = setInterval(fetchRooms, 10000);
+        return () => clearInterval(interval);
     }, [setRooms]);
 
     return (


### PR DESCRIPTION
## Poll occupancy data every 10s for real-time updates (#54)

Previously, room occupancy data was only fetched once on Dashboard mount and never refreshed. This adds a polling interval so the UI stays up to date without requiring a page reload.

### Changes
- **`Dashboard.tsx`** — added `setInterval(fetchRooms, 10000)` to re-fetch every 10 seconds; added `clearInterval` cleanup to stop polling when the component unmounts

### Result
- Dashboard now reflects live occupancy changes within 10 seconds
- No API calls leak in the background after navigating away

Closes #54