### PR TITLE
fix: broadcast for occupancy data #159

### DIFF
--- a/backend/src/main/java/com/occupi/feature/receiver/SensorDataServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/receiver/SensorDataServiceImpl.java
@@ -5,6 +5,7 @@ import com.occupi.feature.database.service.OccupancyService;
 import com.occupi.feature.receiver.dto.SensorData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 /**
@@ -27,6 +28,7 @@ import org.springframework.stereotype.Service;
 public class SensorDataServiceImpl implements SensorDataService {
 
     private final OccupancyService occupancyService;
+    private final SimpMessagingTemplate messagingTemplate;
 
     /**
      * Processes incoming sensor data by mapping it to an occupancy record
@@ -48,6 +50,8 @@ public class SensorDataServiceImpl implements SensorDataService {
 
             // Delegate persistence to the database layer
             occupancyService.recordOccupancy(occupancyData);
+
+            messagingTemplate.convertAndSend("/topic/occupancy", data);
 
             log.debug("Successfully processed sensor data: room={}, sensor={}, count={}",
                     data.roomId(), data.sensorId(), data.count());

--- a/backend/src/test/java/com/occupi/feature/receiver/SensorDataServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/receiver/SensorDataServiceImplTest.java
@@ -8,15 +8,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.time.Instant;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for {@link SensorDataServiceImpl}.
@@ -31,11 +33,14 @@ class SensorDataServiceImplTest {
     @Mock
     private OccupancyService occupancyService;
 
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
     private SensorDataServiceImpl sensorDataService;
 
     @BeforeEach
     void setUp() {
-        sensorDataService = new SensorDataServiceImpl(occupancyService);
+        sensorDataService = new SensorDataServiceImpl(occupancyService, messagingTemplate);
     }
 
     @Test
@@ -92,7 +97,7 @@ class SensorDataServiceImplTest {
         sensorDataService.process(sensorData);
 
         // Assert
-        verify(occupancyService).recordOccupancy(org.mockito.ArgumentMatchers.any(OccupancyData.class));
+        verify(occupancyService).recordOccupancy(any(OccupancyData.class));
     }
 
     @Test
@@ -102,7 +107,7 @@ class SensorDataServiceImplTest {
         sensorDataService.process(null);
 
         // Assert
-        verify(occupancyService, never()).recordOccupancy(org.mockito.ArgumentMatchers.any());
+        verify(occupancyService, never()).recordOccupancy(any());
     }
 
     @Test
@@ -117,7 +122,7 @@ class SensorDataServiceImplTest {
                 Instant.now()
         );
         org.mockito.Mockito.doThrow(new RuntimeException("Database connection failed"))
-                .when(occupancyService).recordOccupancy(org.mockito.ArgumentMatchers.any());
+                .when(occupancyService).recordOccupancy(any());
 
         // Act & Assert
         assertThatThrownBy(() -> sensorDataService.process(sensorData))
@@ -218,6 +223,18 @@ class SensorDataServiceImplTest {
 
         // Assert
         verify(occupancyService, org.mockito.Mockito.times(2))
-                .recordOccupancy(org.mockito.ArgumentMatchers.any());
+                .recordOccupancy(any());
+    }
+
+    @Test
+    @DisplayName("Should broadcast sensor data to /topic/occupancy after persistence")
+    void testBroadcastAfterPersistence() {
+        SensorData data = new SensorData("room-101", "sensor-A", 5, 0.95, Instant.now());
+
+        sensorDataService.process(data);
+
+        InOrder inOrder = inOrder(occupancyService, messagingTemplate);
+        inOrder.verify(occupancyService).recordOccupancy(any(OccupancyData.class));
+        inOrder.verify(messagingTemplate).convertAndSend("/topic/occupancy", data);
     }
 }


### PR DESCRIPTION
## Summary
`SensorDataServiceImpl` persisted incoming sensor data to InfluxDB but never forwarded it to the STOMP broker, leaving clients subscribed to `/topic/occupancy` without any messages.

## Changes
Injected `SimpMessagingTemplate` into `SensorDataServiceImpl`
Added `messagingTemplate.convertAndSend("/topic/occupancy", data)` after successful persistence