### PR TITLE
refactor: extract useFetchRooms hook and fix direct navigation to /rooms and /analytics #160

### DIFF
--- a/frontend/src/hooks/useFetchRooms.ts
+++ b/frontend/src/hooks/useFetchRooms.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useRoomStore } from './useRoomStore';
+import { MOCK_ROOMS } from '../utils/mockData';
+import api from '../utils/api';
+import type { Room, RoomResponse, Occupancy } from '../types/room';
+
+export function useFetchRooms() {
+    // we retrieve spaces and function for setting them from the sore
+    const { setRooms } = useRoomStore();
+
+    useEffect(() => {
+        const fetchRooms = async () => {
+            try {
+                const [roomsRes, occupancyRes] = await Promise.all([
+                    api.get<RoomResponse[]>('/rooms'),
+                    api.get<Occupancy[]>('/occupancy/all')
+                ]);
+
+                const combined: Room[] = roomsRes.data.map((room) => {
+                    const occ = occupancyRes.data.find((o) => o.roomId === room.roomId);
+                    const ratio = (occ?.count ?? 0) / room.capacity;
+                    const occupancyRate = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
+                    return {
+                        ...room,
+                        count: occ?.count ?? 0,
+                        confidence: occ?.confidence ?? 0,
+                        timestamp: occ?.timestamp ?? '',
+                        occupancyRate,
+                    };
+                });
+
+                // as long as there are no room data in the DB, show / use mock data
+                setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
+            } catch (error) {
+                console.error("Fehler beim Laden:", error);
+                setRooms(MOCK_ROOMS);
+            }
+        };
+
+        fetchRooms();
+    }, [setRooms]);
+}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,6 +1,7 @@
 import { useRoomStore } from '../hooks/useRoomStore';
 import { StatusBadge} from '../components/RoomStatus';
 import {useState} from "react";
+import { useFetchRooms } from '../hooks/useFetchRooms';
 
 function SummaryCard({ label, value }: {label: string; value: string | number }) {
     return (
@@ -14,7 +15,7 @@ function SummaryCard({ label, value }: {label: string; value: string | number })
 
 export default function Analytics() {
     const { rooms } = useRoomStore();
-
+    useFetchRooms();
     // Filter & sort state
     const [search, setSearch] = useState('');
     const [buildingFilter, setBuildingFilter] = useState('');

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,45 +1,12 @@
-import { useEffect } from 'react';
 import { useRoomStore } from '../hooks/useRoomStore';
-import { MOCK_ROOMS } from '../utils/mockData';
 import { Users, Activity } from 'lucide-react';
-import api from '../utils/api';
-import type { Room, RoomResponse, Occupancy } from '../types/room';
+import { useFetchRooms } from '../hooks/useFetchRooms';
 
 export default function Dashboard() {
     // we retrieve spaces and function for setting them from the sore
-    const { rooms, setRooms, isConnected } = useRoomStore();
+    const { rooms, isConnected } = useRoomStore();
 
-    useEffect(() => {
-        const fetchRooms = async () => {
-            try {
-                const [roomsRes, occupancyRes] = await Promise.all([
-                    api.get<RoomResponse[]>('/rooms'),
-                    api.get<Occupancy[]>('/occupancy/all')
-                ]);
-
-                const combined: Room[] = roomsRes.data.map((room) => {
-                    const occ = occupancyRes.data.find((o) => o.roomId === room.roomId);
-                    const ratio = (occ?.count ?? 0) / room.capacity;
-                    const occupancyRate = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
-                        return {
-                            ...room,
-                            count: occ?.count ?? 0,
-                            confidence: occ?.confidence ?? 0,
-                            timestamp: occ?.timestamp ?? '',
-                            occupancyRate,
-                        };
-                });
-
-                // as long as there are no room data in the DB, show / use mock data
-                setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
-            } catch (error) {
-                console.error("Fehler beim Laden:", error);
-                setRooms(MOCK_ROOMS);
-            }
-        };
-
-        fetchRooms();
-    }, [setRooms]);
+    useFetchRooms();
 
     return (
         <div className="max-w-7xl mx-auto">

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -1,5 +1,6 @@
 import { useRoomStore } from '../hooks/useRoomStore.ts';
 import { StatusBadge, OccupancyBar } from '../components/RoomStatus.tsx';
+import { useFetchRooms } from '../hooks/useFetchRooms';
 import type { Room } from '../types/room';
 import React from 'react';
 
@@ -23,6 +24,8 @@ function formatTime(timestamp: string) {
 
 export default function Rooms(){
     const { rooms } = useRoomStore();
+
+    useFetchRooms();
 
     return (
 


### PR DESCRIPTION
## Extract useFetchRooms hook and fix direct navigation (#160)

Navigating directly to `/rooms` or `/analytics` without visiting `/dashboard`
first resulted in an empty page because both pages only read from the Zustand
store without fetching data themselves.

### Changes
- **`useFetchRooms.ts`** — new shared hook containing the fetch + combine logic
  for `/rooms` and `/occupancy/all`
- **`Rooms.tsx`** — removed duplicated fetch logic, now uses `useFetchRooms`
- **`Analytics.tsx`** — same as above
- **`Dashboard.tsx`** — same as above, fetch logic centralised

### Result
- Navigating directly to `/rooms` or `/analytics` shows data without requiring
  a prior visit to `/dashboard`
- Fetch logic lives in one place instead of being duplicated across three pages

Closes #160