### PR TITLE
add: containerize the Raspberry Pi sender with mock/real switch and realistic mock data #164

### DIFF
--- a/raspberry/.dockerignore
+++ b/raspberry/.dockerignore
@@ -1,0 +1,19 @@
+# Version control
+.git
+.gitignore
+
+# Python caches and local virtualenv
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# Local configuration and secrets
+.env
+
+# Files not needed inside the image
+Dockerfile
+.dockerignore
+compose.yml
+README.md
+run.sh

--- a/raspberry/.env.example
+++ b/raspberry/.env.example
@@ -1,0 +1,25 @@
+# Copy to .env and adjust:  cp .env.example .env
+# .env is git-ignored — never commit it.
+#
+# Mock works with the defaults below (data goes to a backend on localhost:8080).
+# On the Raspberry Pi: set BACKEND_HOST/PORT to your backend and SENSOR_MODE=real.
+
+# ── Mode ──────────────────────────────────────────────────────────────────────
+# mock = generate realistic fake data (no hardware). real = read the mmWave sensor.
+SENSOR_MODE=mock
+
+# ── Backend (STOMP over WebSocket) ────────────────────────────────────────────
+BACKEND_HOST=localhost
+BACKEND_PORT=8080
+BACKEND_WS_PATH=/ws
+STOMP_DESTINATION=/app/data
+
+# ── Room identity ─────────────────────────────────────────────────────────────
+# ROOM_ID_02 is only used when the second-sensor profile is active.
+ROOM_ID_01=room-01
+ROOM_ID_02=room-02
+
+# ── Mock generator (only used when SENSOR_MODE=mock) ──────────────────────────
+MOCK_INTERVAL=2.0
+MOCK_ROOM_CAPACITY=30
+MOCK_MAX_STEP=2

--- a/raspberry/.gitignore
+++ b/raspberry/.gitignore
@@ -1,0 +1,10 @@
+# Python bytecode and caches
+__pycache__/
+*.py[cod]
+
+# Virtual environment (created by run.sh)
+.venv/
+venv/
+
+# Local configuration and secrets (never commit)
+.env

--- a/raspberry/Dockerfile
+++ b/raspberry/Dockerfile
@@ -1,0 +1,34 @@
+# ─── Build stage ──────────────────────────────────────────────────────────────
+# Install the dependencies into an isolated virtualenv, so the runtime image
+# carries only the packages — not pip's caches or any build leftovers.
+# python:3.x-slim is multi-arch and runs natively on the Raspberry Pi 5 (arm64).
+FROM python:3.12-slim AS builder
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /app
+
+# Copy requirements first so this layer is cached until they actually change.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# ─── Runtime stage ────────────────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+# Run as an unprivileged user — never root inside the container.
+RUN useradd --create-home --uid 1000 occupi
+
+WORKDIR /app
+
+# Bring in the prebuilt virtualenv from the builder stage.
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1
+
+# Application code (the .dockerignore keeps caches, venv and secrets out).
+COPY . .
+
+USER occupi
+
+CMD ["python", "main.py"]

--- a/raspberry/README.md
+++ b/raspberry/README.md
@@ -1,0 +1,117 @@
+# OccuPi — Raspberry Pi sender
+
+Reads a TI IWR6843 mmWave radar over USB and streams room occupancy to the OccuPi
+backend over STOMP/WebSocket. Runs on the Raspberry Pi as a Docker container. It
+ships with a mock mode that generates believable occupancy data, so you can test
+the whole pipeline without the sensor.
+
+## What it does
+
+The sender produces one occupancy reading per frame and sends it to the backend at
+`/app/data`, which stores it in InfluxDB. A reading carries the room, the sensor, the
+headcount, a confidence value, and a timestamp:
+
+```json
+{"roomId": "room-01", "sensorId": "sensor-01", "count": 12, "confidence": 0.93, "timestamp": "2026-06-20T10:11:12.096454+00:00"}
+```
+
+`SENSOR_MODE` picks the source:
+
+- `mock` (default) generates a smooth, bounded occupancy curve. No hardware needed.
+- `real` reads frames from the mmWave sensor over two serial ports.
+
+## Requirements
+
+- Raspberry Pi 5 (16 GB) on a 64-bit OS (arm64). The image builds natively on the Pi.
+- Docker with the Compose plugin.
+- For real mode: the IWR6843 connected over USB. It exposes a config port and a data port.
+
+## Quick start (mock)
+
+```bash
+cd raspberry
+cp .env.example .env          # optional: mock runs on the built-in defaults
+docker compose up -d --build
+docker compose logs -f
+```
+
+You should see lines like `Frame 12: 6 people (target=6, confidence=0.95)`. To send to
+your backend, set `BACKEND_HOST` and `BACKEND_PORT` in `.env` (default `localhost:8080`).
+
+## Configuration
+
+Every setting comes from the environment. Edit `.env` (copied from `.env.example`).
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `SENSOR_MODE` | `mock` | `mock` or `real` |
+| `BACKEND_HOST` | `localhost` | Backend host |
+| `BACKEND_PORT` | `8080` | Backend port |
+| `BACKEND_WS_PATH` | `/ws` | WebSocket path |
+| `STOMP_DESTINATION` | `/app/data` | STOMP destination |
+| `ROOM_ID_01` | `room-01` | Room of the first sensor |
+| `MOCK_INTERVAL` | `2.0` | Seconds between mock readings |
+| `MOCK_ROOM_CAPACITY` | `30` | Upper bound for the mock headcount |
+| `MOCK_MAX_STEP` | `2` | Largest change between two mock readings |
+
+For the real sensor, set `SENSOR_MODE=real` and map the serial devices (next section).
+
+## Real sensor mode
+
+The container needs the sensor's two USB serial devices and membership in the serial
+group. USB enumeration order changes across reboots, so use the stable by-id paths. List
+them:
+
+```bash
+ls -l /dev/serial/by-id/
+```
+
+In `compose.yml`, uncomment the `SERIAL_*`, `devices`, and `group_add` lines for
+`sensor-01` and fill in the paths:
+
+```yaml
+    environment:
+      SENSOR_ID: sensor-01
+      ROOM_ID: ${ROOM_ID_01:-room-01}
+      SERIAL_CFG_PORT: /dev/ttyUSB0
+      SERIAL_DATA_PORT: /dev/ttyUSB1
+    devices:
+      - "/dev/serial/by-id/usb-...-if00:/dev/ttyUSB0"   # config port
+      - "/dev/serial/by-id/usb-...-if01:/dev/ttyUSB1"   # data port
+    group_add:
+      - dialout
+```
+
+The `dialout` group in the container must match the group that owns the device on the
+host. Check with `ls -l /dev/ttyUSB0` and `getent group dialout`. If the GID differs, put
+the numeric GID in `group_add` instead of the name.
+
+## Two sensors
+
+One container runs one sensor. The compose file has a second service, `sensor-02`, behind
+a profile. Give it its own devices the same way, then start both:
+
+```bash
+docker compose --profile second-sensor up -d --build
+```
+
+Each sensor keeps its own `SENSOR_ID` and `ROOM_ID`, so the backend tells them apart.
+Running one process per sensor keeps each container single-purpose and stops one sensor's
+failure from taking down the other.
+
+## Local development without Docker
+
+`run.sh` creates a virtualenv, installs the dependencies, and runs `main.py`. It does not
+read `.env`, so pass configuration as environment variables:
+
+```bash
+cd raspberry
+SENSOR_MODE=mock BACKEND_HOST=localhost ./run.sh
+```
+
+## Notes
+
+- The sender connects over plain WebSocket (`ws`). Reaching the production backend through
+  the Nginx TLS endpoint (`wss`) needs extra setup and is tracked separately.
+- Pi health metrics (CPU, memory, queue depth) are logged locally but not yet sent to the
+  backend (#110).

--- a/raspberry/compose.yml
+++ b/raspberry/compose.yml
@@ -1,0 +1,61 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# OccuPi — Raspberry Pi sender
+#
+# Runs ON the Raspberry Pi (this is NOT part of the server stack in /docker).
+# Reads the mmWave sensor — or generates realistic mock data — and streams
+# occupancy to the backend over STOMP/WebSocket.
+#
+#   Mock (default, one sensor):  docker compose up -d --build
+#   Two sensors:                 docker compose --profile second-sensor up -d --build
+#   Logs:                        docker compose logs -f
+#
+# Configure via .env (copy from .env.example). Flip mock/real with SENSOR_MODE.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Shared config for every sensor container (one container per sensor).
+x-sensor-base: &sensor-base
+  build: .
+  image: occupi-pi-sender:local
+  env_file:
+    - path: .env
+      required: false        # mock runs on the config defaults even without a .env
+  restart: unless-stopped
+  security_opt:
+    - no-new-privileges:true
+
+services:
+  sensor-01:
+    <<: *sensor-base
+    container_name: occupi-sensor-01
+    environment:
+      SENSOR_ID: sensor-01
+      ROOM_ID: ${ROOM_ID_01:-room-01}
+      # Real mode — the in-container device names the mapping below targets:
+      # SERIAL_CFG_PORT: /dev/ttyUSB0
+      # SERIAL_DATA_PORT: /dev/ttyUSB1
+    # ── Real mode only ────────────────────────────────────────────────────────
+    # Hand this sensor's two USB serial devices to the container and grant the
+    # serial group. Use stable by-id paths — USB enumeration order is not stable
+    # across reboots. Find them with:  ls -l /dev/serial/by-id/
+    # devices:
+    #   - "/dev/serial/by-id/usb-...-if00:/dev/ttyUSB0"   # config port
+    #   - "/dev/serial/by-id/usb-...-if01:/dev/ttyUSB1"   # data port
+    # group_add:
+    #   - dialout
+
+  # Second sensor — opt-in. Start with:
+  #   docker compose --profile second-sensor up -d --build
+  sensor-02:
+    <<: *sensor-base
+    container_name: occupi-sensor-02
+    profiles: ["second-sensor"]
+    environment:
+      SENSOR_ID: sensor-02
+      ROOM_ID: ${ROOM_ID_02:-room-02}
+      # SERIAL_CFG_PORT: /dev/ttyUSB0
+      # SERIAL_DATA_PORT: /dev/ttyUSB1
+    # devices:
+    #   - "/dev/serial/by-id/usb-...-if00:/dev/ttyUSB0"
+    #   - "/dev/serial/by-id/usb-...-if01:/dev/ttyUSB1"
+    # group_add:
+    #   - dialout

--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -10,6 +10,11 @@ SENSOR_ID = os.getenv("SENSOR_ID", "sensor-01")
 # Flip this in one place: the SENSOR_MODE entry of your .env file.
 SENSOR_MODE = os.getenv("SENSOR_MODE", "mock").strip().lower()
 
+# --- Mock Generator (only used when SENSOR_MODE=mock) ---
+MOCK_INTERVAL      = float(os.getenv("MOCK_INTERVAL",      "2.0"))  # seconds between fake readings
+MOCK_ROOM_CAPACITY = int(os.getenv("MOCK_ROOM_CAPACITY",   "30"))   # max plausible headcount for the room
+MOCK_MAX_STEP      = int(os.getenv("MOCK_MAX_STEP",        "2"))    # max headcount change per reading
+
 # --- Serial ---
 SERIAL_CFG_PORT  = os.getenv("SERIAL_CFG_PORT",  "/dev/tty.usbserial-010BCEBF0")
 SERIAL_DATA_PORT = os.getenv("SERIAL_DATA_PORT", "/dev/tty.usbserial-010BCEBF1")

--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -4,6 +4,12 @@ import os
 ROOM_ID   = os.getenv("ROOM_ID",   "room-01")
 SENSOR_ID = os.getenv("SENSOR_ID", "sensor-01")
 
+# --- Sensor Mode ---
+# "mock" generates realistic fake occupancy data (no hardware needed) — used by the
+# container and for local testing. "real" reads from the mmWave sensor over serial.
+# Flip this in one place: the SENSOR_MODE entry of your .env file.
+SENSOR_MODE = os.getenv("SENSOR_MODE", "mock").strip().lower()
+
 # --- Serial ---
 SERIAL_CFG_PORT  = os.getenv("SERIAL_CFG_PORT",  "/dev/tty.usbserial-010BCEBF0")
 SERIAL_DATA_PORT = os.getenv("SERIAL_DATA_PORT", "/dev/tty.usbserial-010BCEBF1")

--- a/raspberry/main.py
+++ b/raspberry/main.py
@@ -12,6 +12,7 @@ from config import (
     STOMP_DESTINATION,
     QUEUE_MAX_SIZE,
     WS_RECONNECT_DELAY, WS_MAX_RETRIES, BACKEND_WS_PATH,
+    SENSOR_MODE,
 )
 from sensor.receiver import open_ports, send_config, read_frame, CONFIG_FILE
 from sensor.metrics import ThroughputMetrics, start_metrics_monitor, log_snapshot
@@ -110,8 +111,6 @@ def start_sender() -> None:
     log.info("Sender thread started.")
 
 
-# Set to False for real sensor data
-USE_MOCK = True
 # Main execution
 if __name__ == '__main__':
     cfg_port = None
@@ -121,13 +120,15 @@ if __name__ == '__main__':
         start_sender()
         start_metrics_monitor(_queue, _metrics)
 
-        if USE_MOCK:
+        if SENSOR_MODE == "mock":
+            log.info("Starting in MOCK mode — generating fake occupancy data.")
             mock_sensor_loop(enqueue_frame)
             # wait for sender to drain the queue before logging final metrics
             while not _queue.empty():
                 time.sleep(0.05)
             log_snapshot(_queue, _metrics)
         else:
+            log.info("Starting in REAL mode — reading from the mmWave sensor.")
             cfg_port, data_port = open_ports()
             send_config(cfg_port, CONFIG_FILE)
             while True:

--- a/raspberry/main.py
+++ b/raspberry/main.py
@@ -15,7 +15,7 @@ from config import (
     SENSOR_MODE,
 )
 from sensor.receiver import open_ports, send_config, read_frame, CONFIG_FILE
-from sensor.metrics import ThroughputMetrics, start_metrics_monitor, log_snapshot
+from sensor.metrics import ThroughputMetrics, start_metrics_monitor
 from sender.processor import map_to_occupancy
 from mock_data import mock_sensor_loop
 from stomp import exception as stomp_exception
@@ -122,11 +122,7 @@ if __name__ == '__main__':
 
         if SENSOR_MODE == "mock":
             log.info("Starting in MOCK mode — generating fake occupancy data.")
-            mock_sensor_loop(enqueue_frame)
-            # wait for sender to drain the queue before logging final metrics
-            while not _queue.empty():
-                time.sleep(0.05)
-            log_snapshot(_queue, _metrics)
+            mock_sensor_loop(enqueue_frame)  # runs until the process is stopped
         else:
             log.info("Starting in REAL mode — reading from the mmWave sensor.")
             cfg_port, data_port = open_ports()

--- a/raspberry/mock_data.py
+++ b/raspberry/mock_data.py
@@ -1,14 +1,79 @@
 import logging
+import random
 import time
 
+from config import (
+    MOCK_INTERVAL,
+    MOCK_ROOM_CAPACITY,
+    MOCK_MAX_STEP,
+)
 
 log = logging.getLogger(__name__)
 
-def mock_sensor_loop(enqueue_frame):
-    """Sends 10 mock frames for testing."""
-    for frame_num in range(1, 11):
-        people_count = frame_num % 3  # 0, 1, 2, 0, 1, 2 ...
-        log.info(f"Frame {frame_num}: Detected {people_count} people")
-        enqueue_frame({"frameNum": frame_num, "numDetectedTracks": people_count})
-        time.sleep(0.1)
-    log.info("Mock done — 10 frames sent.")
+
+def _next_count(current: int, target: int, capacity: int, max_step: int) -> int:
+    """
+    Move the headcount one small step toward a drifting target.
+
+    The step is at most ``max_step`` people and biased toward the target, so the
+    series rises and falls gradually — it never jumps from a full room to empty.
+    """
+    if current < target:
+        step = random.randint(0, max_step)       # tend to grow
+    elif current > target:
+        step = -random.randint(0, max_step)      # tend to shrink
+    else:
+        step = random.choice([-1, 0, 0, 1])      # idle jitter around the target
+    return max(0, min(capacity, current + step))
+
+
+def _estimate_confidence(count: int, capacity: int) -> float:
+    """
+    Fake a plausible confidence: high for a near-empty room, a little lower as it
+    fills up (more people are harder to separate), with light random jitter.
+    """
+    crowding = count / capacity if capacity else 0.0
+    base = 0.97 - 0.12 * crowding
+    return round(max(0.80, min(0.99, base + random.uniform(-0.02, 0.02))), 3)
+
+
+def mock_sensor_loop(enqueue_frame) -> None:
+    """
+    Continuously generate realistic occupancy frames until the process stops.
+
+    Models a room whose headcount drifts via a bounded random walk: a slowly
+    changing target pulls the count up and down by small steps, clamped to the
+    room capacity. This produces a believable curve instead of random spikes.
+    """
+    capacity = MOCK_ROOM_CAPACITY
+    interval = MOCK_INTERVAL
+    max_step = MOCK_MAX_STEP
+
+    count = random.randint(0, max(1, capacity // 4))   # start lightly occupied
+    target = count
+    frame_num = 0
+
+    log.info(
+        "Mock generator started (capacity=%d, interval=%.1fs, max_step=%d).",
+        capacity, interval, max_step,
+    )
+
+    while True:
+        frame_num += 1
+
+        # Now and then aim for a new occupancy level, so the count heads
+        # somewhere different over the coming frames instead of hovering.
+        if random.random() < 0.1:
+            target = random.randint(0, capacity)
+
+        count = _next_count(count, target, capacity, max_step)
+        confidence = _estimate_confidence(count, capacity)
+
+        log.info("Frame %d: %d people (target=%d, confidence=%.2f)",
+                 frame_num, count, target, confidence)
+        enqueue_frame({
+            "frameNum": frame_num,
+            "numDetectedTracks": count,
+            "confidence": confidence,
+        })
+        time.sleep(interval)

--- a/raspberry/sender/processor.py
+++ b/raspberry/sender/processor.py
@@ -14,6 +14,6 @@ def map_to_occupancy(frame: dict) -> dict:
         "roomId":     ROOM_ID,
         "sensorId":   SENSOR_ID,
         "count":      frame.get("numDetectedTracks", 0),
-        "confidence": 1.0,   # Platzhalter – später durch echte Logik ersetzen
+        "confidence": frame.get("confidence", 1.0),  # Mock liefert echte Werte; Real-Pfad bleibt 1.0 bis echte Logik existiert
         "timestamp":  datetime.now(timezone.utc).isoformat(),
     }


### PR DESCRIPTION
## Summary
Deploys the Raspberry Pi sender as a Docker container that streams occupancy to the backend, switchable between realistic mock data and the real mmWave sensor. Closes #164.

The wire format already matched the backend `SensorData` record, so this PR adds the container, a believable mock generator, and a single mode switch. It does not change the payload schema.

## Changes
- **`config.py`** — new `SENSOR_MODE` (`mock` | `real`) switch and mock settings (`MOCK_INTERVAL`, `MOCK_ROOM_CAPACITY`, `MOCK_MAX_STEP`), all from the environment
- **`main.py`** — reads `SENSOR_MODE` instead of the hardcoded `USE_MOCK`; mock now runs continuously
- **`mock_data.py`** — rewritten as a bounded random walk toward a drifting target, so the headcount rises and falls in small steps instead of jumping (no 15 → 0)
- **`sender/processor.py`** — carries the mock `confidence` into the payload; the real path keeps its default
- **`Dockerfile` + `.dockerignore`** — multi-stage, slim Python, arm64 (Pi 5), runs as a non-root user
- **`compose.yml` + `.env.example`** — mock by default; real mode maps the USB serial devices; a second sensor runs as `sensor-02` behind a `second-sensor` profile
- **`README.md`** — run mock/real, flip the switch, run one or two sensors, Pi 5 / arm64 notes
- **`.gitignore`** — Python caches, `.venv`, `.env`

### Multi-sensor
One container runs one sensor. A second sensor runs as a second compose service with its own `SENSOR_ID`, `ROOM_ID`, and device paths. This keeps each container single-purpose and isolates failures, instead of threading several sensors through one process.

## Verification
Tested against the running dev stack:
- Image builds on arm64 (the Pi's architecture); the container runs as `uid=1000 occupi` (non-root).
- Mock generator over 200 frames: counts stay within `[0, capacity]`, no step larger than `MOCK_MAX_STEP`.
- Payload keys and types match the backend `SensorData` record.
- End-to-end: mock container → STOMP `/app/data` → backend → InfluxDB. Confirmed 49 rows in the `occupancy` measurement with correct `roomId`, `sensorId`, `count`, `confidence`, and timestamp.

## Out of scope (tracked separately)
- Production TLS (`wss`) to the Nginx endpoint.
- Pi metrics → STOMP (#110).
