### PR TITLE
add: send to the backend over TLS (wss) so the Pi can reach production #166

### DIFF
--- a/raspberry/.env.example
+++ b/raspberry/.env.example
@@ -13,6 +13,15 @@ BACKEND_HOST=localhost
 BACKEND_PORT=8080
 BACKEND_WS_PATH=/ws
 STOMP_DESTINATION=/app/data
+# Set true to connect over TLS (wss). Required for the production server below.
+BACKEND_TLS=false
+# Optional: path to a custom CA bundle. Empty = certifi (trusts Let's Encrypt).
+# BACKEND_TLS_CA=
+
+# Production (real Pi → Nginx over TLS). Uncomment to send to the live server:
+# BACKEND_HOST=occupi.mi.hdm-stuttgart.de
+# BACKEND_PORT=443
+# BACKEND_TLS=true
 
 # ── Room identity ─────────────────────────────────────────────────────────────
 # ROOM_ID_02 is only used when the second-sensor profile is active.

--- a/raspberry/README.md
+++ b/raspberry/README.md
@@ -49,12 +49,29 @@ Every setting comes from the environment. Edit `.env` (copied from `.env.example
 | `BACKEND_PORT` | `8080` | Backend port |
 | `BACKEND_WS_PATH` | `/ws` | WebSocket path |
 | `STOMP_DESTINATION` | `/app/data` | STOMP destination |
+| `BACKEND_TLS` | `false` | Connect over TLS (`wss`); set `true` for the production server |
 | `ROOM_ID_01` | `room-01` | Room of the first sensor |
 | `MOCK_INTERVAL` | `2.0` | Seconds between mock readings |
 | `MOCK_ROOM_CAPACITY` | `30` | Upper bound for the mock headcount |
 | `MOCK_MAX_STEP` | `2` | Largest change between two mock readings |
 
 For the real sensor, set `SENSOR_MODE=real` and map the serial devices (next section).
+
+## Sending to the production server (TLS)
+
+The production backend sits behind the host Nginx and is reachable only over `https`/`wss`
+at `occupi.mi.hdm-stuttgart.de`. The `/ws` ingestion endpoint is public (no token), so the
+Pi needs TLS and nothing else. Set this in `.env`:
+
+```bash
+BACKEND_HOST=occupi.mi.hdm-stuttgart.de
+BACKEND_PORT=443
+BACKEND_TLS=true
+```
+
+`certifi` ships the CA bundle, so the Let's Encrypt server certificate validates out of the
+box. To pin a custom CA, point `BACKEND_TLS_CA` at a bundle file. The Pi has to reach
+`occupi.mi.hdm-stuttgart.de`, so run it inside the HdM network.
 
 ## Real sensor mode
 

--- a/raspberry/README.md
+++ b/raspberry/README.md
@@ -70,8 +70,12 @@ BACKEND_TLS=true
 ```
 
 `certifi` ships the CA bundle, so the Let's Encrypt server certificate validates out of the
-box. To pin a custom CA, point `BACKEND_TLS_CA` at a bundle file. The Pi has to reach
-`occupi.mi.hdm-stuttgart.de`, so run it inside the HdM network.
+box. To pin a custom CA, point `BACKEND_TLS_CA` at a bundle file. The endpoint is public
+(the same host as the website), so the Pi can send from any internet connection — no HdM
+network or VPN needed.
+
+The Pi talks to the backend, never to the database directly. InfluxDB and Postgres have no
+public ports on purpose; the backend is the only door, and `/ws` is already open for it.
 
 ## Real sensor mode
 

--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -27,6 +27,14 @@ BACKEND_PORT        = int(os.getenv("BACKEND_PORT",    "8080"))
 BACKEND_WS_PATH     = os.getenv("BACKEND_WS_PATH",     "/ws")
 STOMP_DESTINATION   = os.getenv("STOMP_DESTINATION",   "/app/data")
 
+# Connect over TLS (wss) instead of plain ws. Needed to reach the production
+# backend through the Nginx endpoint (occupi.mi.hdm-stuttgart.de:443). Leave off
+# for a local or internal backend.
+BACKEND_TLS         = os.getenv("BACKEND_TLS", "false").strip().lower() in ("1", "true", "yes")
+# Optional path to a CA bundle for verifying the server certificate. Empty uses
+# certifi's bundle, which trusts Let's Encrypt (the prod server's issuer).
+BACKEND_TLS_CA      = os.getenv("BACKEND_TLS_CA", "").strip()
+
 # --- Queue & Processing ---
 QUEUE_MAX_SIZE      = int(os.getenv("QUEUE_MAX_SIZE",      "100"))
 PROCESSING_INTERVAL = float(os.getenv("PROCESSING_INTERVAL", "0.1"))  # seconds (= 10fps)

--- a/raspberry/main.py
+++ b/raspberry/main.py
@@ -6,12 +6,14 @@ import threading
 import time
 import serial
 import stomp
+import certifi
 
 from config import (
     BACKEND_HOST, BACKEND_PORT,
     STOMP_DESTINATION,
     QUEUE_MAX_SIZE,
     WS_RECONNECT_DELAY, WS_MAX_RETRIES, BACKEND_WS_PATH,
+    BACKEND_TLS, BACKEND_TLS_CA,
     SENSOR_MODE,
 )
 from sensor.receiver import open_ports, send_config, read_frame, CONFIG_FILE
@@ -70,6 +72,12 @@ def _sender_loop() -> None:
         heartbeats=(25000, 25000),
         ws_path=BACKEND_WS_PATH,
     )
+    if BACKEND_TLS:
+        # Registering SSL for this host makes stomp.py use wss://. Passing ca_certs
+        # turns on server-certificate validation (without it stomp.py skips the check).
+        ca_bundle = BACKEND_TLS_CA or certifi.where()
+        conn.set_ssl(for_hosts=[(BACKEND_HOST, BACKEND_PORT)], ca_certs=ca_bundle)
+        log.info("TLS enabled: connecting via wss, verifying server cert against %s", ca_bundle)
 
     retries = 0
 

--- a/raspberry/requirements.txt
+++ b/raspberry/requirements.txt
@@ -1,3 +1,4 @@
 pyserial==3.5
 stomp.py==8.1.2
 psutil==7.2.2
+certifi==2026.6.17


### PR DESCRIPTION
## Summary
Adds a TLS (`wss`) option to the sender so the real Raspberry Pi can stream to the production backend at `wss://occupi.mi.hdm-stuttgart.de/ws`. Plain `ws` only reached a local or LAN backend. Closes #166, follow-up to #164.

`/ws/**` is `permitAll()` in the prod security config, so ingestion needs no Keycloak token; TLS was the only gap. The Pi talks to the backend over the same public endpoint as the website — the database stays internal (no public ports).

## Changes
- **`config.py`** — `BACKEND_TLS` (on/off) and an optional `BACKEND_TLS_CA`
- **`main.py`** — when `BACKEND_TLS` is set, calls `conn.set_ssl(for_hosts=..., ca_certs=...)`; stomp.py then connects via `wss` and validates the server certificate (without `ca_certs` it would skip the check)
- **`requirements.txt`** — `certifi` for the default CA bundle (trusts Let's Encrypt)
- **`.env.example` / `README.md`** — production settings (`BACKEND_HOST=occupi.mi.hdm-stuttgart.de`, `BACKEND_PORT=443`, `BACKEND_TLS=true`)

## Verification
- Local TLS proxy in front of the dev backend, using the real prod hostname: `wss` handshake + STOMP CONNECT succeed, data lands in InfluxDB (`occupancy`) over `wss`.
- Negative test: with the wrong CA, the connection fails with `CERTIFICATE_VERIFY_FAILED` and writes nothing — certificate validation is real, not skipped.
- Against the **live production server** (connect-only, no data sent): `wss` STOMP CONNECT to `occupi.mi.hdm-stuttgart.de:443/ws` succeeds with Let's Encrypt cert validation. The endpoint is public, so the Pi works from any internet connection.

## How to test on the live server
On the Pi, set `.env`:
```
BACKEND_HOST=occupi.mi.hdm-stuttgart.de
BACKEND_PORT=443
BACKEND_TLS=true
```
then `docker compose up -d --build` and confirm rows arrive in the server's InfluxDB.
