### PR TITLE
add: mock mode can fill many rooms from a single container #173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ backend, frontend, authentication, the sensor pipeline, and the containerized de
   auto-reconnect, and a bounded queue that drops the oldest frame under load.
 - Containerized sender with a single mock/real switch and realistic mock data (#164).
 - TLS (`wss`) so the Pi streams to the production server (#166).
+- Mock mode can fill many rooms from a single container via `MOCK_ROOM_IDS` (#173).
 
 **Authentication**
 - Keycloak OAuth2 resource server with HdM LDAP login; `/ws` ingestion stays public (#20).

--- a/raspberry/README.md
+++ b/raspberry/README.md
@@ -54,8 +54,13 @@ Every setting comes from the environment. Edit `.env` (copied from `.env.example
 | `MOCK_INTERVAL` | `2.0` | Seconds between mock readings |
 | `MOCK_ROOM_CAPACITY` | `30` | Upper bound for the mock headcount |
 | `MOCK_MAX_STEP` | `2` | Largest change between two mock readings |
+| `MOCK_ROOM_IDS` | (empty) | Comma-separated room IDs to simulate from one container; empty = just `ROOM_ID_01` |
 
 For the real sensor, set `SENSOR_MODE=real` and map the serial devices (next section).
+
+To fill the whole dashboard from a single container, list the rooms in `MOCK_ROOM_IDS`
+(e.g. `MOCK_ROOM_IDS=006,011,137,i003`). One process simulates them all, each with its own
+curve — no need for one container per room. The queue grows automatically with the room count.
 
 ## Sending to the production server (TLS)
 

--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -14,6 +14,9 @@ SENSOR_MODE = os.getenv("SENSOR_MODE", "mock").strip().lower()
 MOCK_INTERVAL      = float(os.getenv("MOCK_INTERVAL",      "2.0"))  # seconds between fake readings
 MOCK_ROOM_CAPACITY = int(os.getenv("MOCK_ROOM_CAPACITY",   "30"))   # max plausible headcount for the room
 MOCK_MAX_STEP      = int(os.getenv("MOCK_MAX_STEP",        "2"))    # max headcount change per reading
+# Comma-separated room IDs to simulate from this single container (e.g. "006,011,137").
+# Empty = just ROOM_ID. Lets one mock container fill many rooms at once (no hardware).
+MOCK_ROOM_IDS      = [r.strip() for r in os.getenv("MOCK_ROOM_IDS", "").split(",") if r.strip()]
 
 # --- Serial ---
 SERIAL_CFG_PORT  = os.getenv("SERIAL_CFG_PORT",  "/dev/tty.usbserial-010BCEBF0")

--- a/raspberry/main.py
+++ b/raspberry/main.py
@@ -14,7 +14,7 @@ from config import (
     QUEUE_MAX_SIZE,
     WS_RECONNECT_DELAY, WS_MAX_RETRIES, BACKEND_WS_PATH,
     BACKEND_TLS, BACKEND_TLS_CA,
-    SENSOR_MODE,
+    SENSOR_MODE, ROOM_ID, MOCK_ROOM_IDS,
 )
 from sensor.receiver import open_ports, send_config, read_frame, CONFIG_FILE
 from sensor.metrics import ThroughputMetrics, start_metrics_monitor
@@ -30,7 +30,9 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-_queue: queue.Queue = queue.Queue(maxsize=QUEUE_MAX_SIZE)
+# Size the queue for the workload: in multi-room mock the generator enqueues one
+# frame per room each tick, so the queue must hold more than the room count.
+_queue: queue.Queue = queue.Queue(maxsize=max(QUEUE_MAX_SIZE, len(MOCK_ROOM_IDS) * 3))
 _metrics = ThroughputMetrics()
 
 def enqueue_frame(frame: dict) -> None:
@@ -129,8 +131,9 @@ if __name__ == '__main__':
         start_metrics_monitor(_queue, _metrics)
 
         if SENSOR_MODE == "mock":
-            log.info("Starting in MOCK mode — generating fake occupancy data.")
-            mock_sensor_loop(enqueue_frame)  # runs until the process is stopped
+            rooms = MOCK_ROOM_IDS or [ROOM_ID]
+            log.info("Starting in MOCK mode — fake occupancy for %d room(s).", len(rooms))
+            mock_sensor_loop(enqueue_frame, rooms)  # runs until the process is stopped
         else:
             log.info("Starting in REAL mode — reading from the mmWave sensor.")
             cfg_port, data_port = open_ports()

--- a/raspberry/mock_data.py
+++ b/raspberry/mock_data.py
@@ -37,43 +37,49 @@ def _estimate_confidence(count: int, capacity: int) -> float:
     return round(max(0.80, min(0.99, base + random.uniform(-0.02, 0.02))), 3)
 
 
-def mock_sensor_loop(enqueue_frame) -> None:
+def mock_sensor_loop(enqueue_frame, room_ids) -> None:
     """
-    Continuously generate realistic occupancy frames until the process stops.
+    Continuously generate realistic occupancy frames for one or more rooms.
 
-    Models a room whose headcount drifts via a bounded random walk: a slowly
-    changing target pulls the count up and down by small steps, clamped to the
-    room capacity. This produces a believable curve instead of random spikes.
+    Each room runs its own bounded random walk (a slowly changing target pulls the
+    count up and down by small steps, clamped to the capacity), so a single
+    container can fill many rooms with believable, independent curves — no need for
+    one container per room.
     """
     capacity = MOCK_ROOM_CAPACITY
     interval = MOCK_INTERVAL
     max_step = MOCK_MAX_STEP
 
-    count = random.randint(0, max(1, capacity // 4))   # start lightly occupied
-    target = count
-    frame_num = 0
+    # Independent random-walk state per room.
+    state = {}
+    for room_id in room_ids:
+        start = random.randint(0, max(1, capacity // 4))   # start lightly occupied
+        state[room_id] = {"count": start, "target": start}
 
+    frame_num = 0
     log.info(
-        "Mock generator started (capacity=%d, interval=%.1fs, max_step=%d).",
-        capacity, interval, max_step,
+        "Mock generator started for %d room(s) (capacity=%d, interval=%.1fs, max_step=%d).",
+        len(room_ids), capacity, interval, max_step,
     )
 
     while True:
         frame_num += 1
+        for room_id in room_ids:
+            s = state[room_id]
+            # Now and then aim for a new occupancy level for this room.
+            if random.random() < 0.1:
+                s["target"] = random.randint(0, capacity)
+            s["count"] = _next_count(s["count"], s["target"], capacity, max_step)
+            enqueue_frame({
+                "frameNum": frame_num,
+                "roomId": room_id,
+                "numDetectedTracks": s["count"],
+                "confidence": _estimate_confidence(s["count"], capacity),
+            })
 
-        # Now and then aim for a new occupancy level, so the count heads
-        # somewhere different over the coming frames instead of hovering.
-        if random.random() < 0.1:
-            target = random.randint(0, capacity)
-
-        count = _next_count(count, target, capacity, max_step)
-        confidence = _estimate_confidence(count, capacity)
-
-        log.info("Frame %d: %d people (target=%d, confidence=%.2f)",
-                 frame_num, count, target, confidence)
-        enqueue_frame({
-            "frameNum": frame_num,
-            "numDetectedTracks": count,
-            "confidence": confidence,
-        })
+        if len(room_ids) == 1:
+            only = room_ids[0]
+            log.info("Frame %d: %s -> %d people", frame_num, only, state[only]["count"])
+        else:
+            log.info("Tick %d: sent %d rooms", frame_num, len(room_ids))
         time.sleep(interval)

--- a/raspberry/sender/processor.py
+++ b/raspberry/sender/processor.py
@@ -11,7 +11,7 @@ def map_to_occupancy(frame: dict) -> dict:
         OccupancyData als Dict (JSON-serialisierbar)
     """
     return {
-        "roomId":     ROOM_ID,
+        "roomId":     frame.get("roomId", ROOM_ID),  # Mock setzt pro Raum eine ID; Real-Pfad nutzt ROOM_ID
         "sensorId":   SENSOR_ID,
         "count":      frame.get("numDetectedTracks", 0),
         "confidence": frame.get("confidence", 1.0),  # Mock liefert echte Werte; Real-Pfad bleibt 1.0 bis echte Logik existiert


### PR DESCRIPTION
## Summary
Lets a single mock container fill many rooms at once, so the whole dashboard shows believable occupancy without running one container per room. Real-sensor mode is unchanged (one container per physical sensor). Closes #173. Part of the v0.1.0 release (#170).

## Changes
- `config.py` — `MOCK_ROOM_IDS` (comma-separated; empty = just `ROOM_ID`).
- `mock_data.py` — per-room random-walk state; one reading per room each tick; per-tick summary log.
- `sender/processor.py` — uses the frame's `roomId` (real path falls back to `ROOM_ID`).
- `main.py` — passes the room list to the mock loop; the queue auto-sizes to the room count.
- `README.md` / `CHANGELOG.md` — documented.

## Verification
- Unit: 4 rooms, independent bounded random walks; processor maps the frame's `roomId`, real path falls back to `ROOM_ID`.
- E2E against the local backend: `MOCK_ROOM_IDS=mr-test-1,mr-test-2,mr-test-3` → all three rooms land in InfluxDB with independent curves.
