### PR TITLE
fix: pace multi-room mock sends across the interval #175

### DIFF
--- a/raspberry/README.md
+++ b/raspberry/README.md
@@ -62,6 +62,11 @@ To fill the whole dashboard from a single container, list the rooms in `MOCK_ROO
 (e.g. `MOCK_ROOM_IDS=006,011,137,i003`). One process simulates them all, each with its own
 curve — no need for one container per room. The queue grows automatically with the room count.
 
+The generator spreads its sends evenly across `MOCK_INTERVAL`. For many rooms, raise the
+interval so the backend can ingest every room: keep roughly `rooms ÷ interval ≲ 5` per
+second. For ~100 rooms use `MOCK_INTERVAL=30`; a single burst overwhelms the ingestion and
+some rooms get dropped.
+
 ## Sending to the production server (TLS)
 
 The production backend sits behind the host Nginx and is reachable only over `https`/`wss`

--- a/raspberry/mock_data.py
+++ b/raspberry/mock_data.py
@@ -56,6 +56,11 @@ def mock_sensor_loop(enqueue_frame, room_ids) -> None:
         start = random.randint(0, max(1, capacity // 4))   # start lightly occupied
         state[room_id] = {"count": start, "target": start}
 
+    # Spread the per-room sends evenly across the interval instead of bursting them
+    # all at once — a single burst of many rooms overwhelms the backend ingestion,
+    # and a steady stream is also closer to how independent sensors behave.
+    per_room_delay = interval / max(1, len(room_ids))
+
     frame_num = 0
     log.info(
         "Mock generator started for %d room(s) (capacity=%d, interval=%.1fs, max_step=%d).",
@@ -76,10 +81,9 @@ def mock_sensor_loop(enqueue_frame, room_ids) -> None:
                 "numDetectedTracks": s["count"],
                 "confidence": _estimate_confidence(s["count"], capacity),
             })
+            time.sleep(per_room_delay)
 
         if len(room_ids) == 1:
-            only = room_ids[0]
-            log.info("Frame %d: %s -> %d people", frame_num, only, state[only]["count"])
+            log.info("Frame %d: %s -> %d people", frame_num, room_ids[0], state[room_ids[0]]["count"])
         else:
-            log.info("Tick %d: sent %d rooms", frame_num, len(room_ids))
-        time.sleep(interval)
+            log.info("Tick %d: sent %d rooms (paced)", frame_num, len(room_ids))


### PR DESCRIPTION
Spreads the per-room mock sends evenly across `MOCK_INTERVAL` instead of bursting them all at once, so the backend ingests every room. Verified: 111 rooms paced at `MOCK_INTERVAL=30` → all 111 land (burst → ~56). README notes the rate guidance. Closes #175 (follow-up to #173).