### PR TITLE
fix: batch occupancy writes to InfluxDB so high ingestion rates don't drop data #177

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ backend, frontend, authentication, the sensor pipeline, and the containerized de
 - Renamed the project from RoomSystem to OccuPi (#87).
 - Aligned the room data types between frontend and backend (#133).
 - Pinned PostgreSQL to version 16 (#113).
+- Occupancy writes to InfluxDB are buffered and flushed in batches, so many rooms reporting at once no longer drop data (#177).
 
 ### Removed
 - Dropped the unused chart feature (#21).

--- a/backend/src/main/java/com/occupi/AppApplication.java
+++ b/backend/src/main/java/com/occupi/AppApplication.java
@@ -2,6 +2,7 @@ package com.occupi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Application entry point.
@@ -10,8 +11,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * JPA entity/repository scanning and auto-configuration package detection all
  * cover the {@code com.occupi.feature.*} packages out of the box — no explicit
  * base-package configuration needed.
+ *
+ * {@code @EnableScheduling} powers the batched occupancy flush (see OccupancyService).
  */
 @SpringBootApplication
+@EnableScheduling
 public class AppApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/occupi/feature/database/service/OccupancyService.java
+++ b/backend/src/main/java/com/occupi/feature/database/service/OccupancyService.java
@@ -2,33 +2,48 @@ package com.occupi.feature.database.service;
 
 import com.occupi.feature.database.model.OccupancyData;
 import com.occupi.feature.database.repository.OccupancyRepository;
+import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * Service layer for occupancy data operations.
  * Coordinates between data receivers and the persistence layer.
  * Ensures only anonymized, processed headcounts are stored.
+ *
+ * Writes are buffered and flushed to InfluxDB in batches: a single write per
+ * incoming message can't keep up when many rooms report at once, so ingestion
+ * (cheap, in-memory) is decoupled from the write (batched, efficient).
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class OccupancyService {
 
+    /** Largest number of points written in one InfluxDB batch. */
+    private static final int MAX_BATCH = 500;
+
     private final OccupancyRepository occupancyRepository;
 
+    /** Incoming measurements wait here until the scheduled flush writes them. */
+    private final Queue<OccupancyData> writeBuffer = new ConcurrentLinkedQueue<>();
+
     /**
-     * Records a single occupancy measurement.
+     * Records a single occupancy measurement. The point is buffered and written by
+     * the scheduled batch flush, so this returns immediately — a burst of incoming
+     * sensor messages never blocks on individual database writes.
      *
      * @param data the anonymized occupancy data from a sensor
      */
     public void recordOccupancy(OccupancyData data) {
-        log.info("Recording occupancy: room={}, sensor={}, count={}",
-                data.getRoomId(), data.getSensorId(), data.getCount());
-        occupancyRepository.save(data);
+        writeBuffer.offer(data);
     }
 
     /**
@@ -39,5 +54,56 @@ public class OccupancyService {
     public void recordBatch(List<OccupancyData> batch) {
         log.info("Recording batch of {} occupancy measurements", batch.size());
         occupancyRepository.saveBatch(batch);
+    }
+
+    /**
+     * Writes all buffered measurements to InfluxDB, in batches of at most
+     * {@link #MAX_BATCH}. Runs on a fixed schedule (default every second).
+     */
+    @Scheduled(fixedDelayString = "${occupancy.flush-interval-ms:1000}")
+    public void flushBuffer() {
+        if (writeBuffer.isEmpty()) {
+            return;
+        }
+
+        List<OccupancyData> batch = new ArrayList<>(MAX_BATCH);
+        OccupancyData data;
+        while ((data = writeBuffer.poll()) != null) {
+            batch.add(data);
+            if (batch.size() >= MAX_BATCH) {
+                writeBatch(batch);
+                batch = new ArrayList<>(MAX_BATCH);
+            }
+        }
+        if (!batch.isEmpty()) {
+            writeBatch(batch);
+        }
+    }
+
+    /** Flushes whatever is still buffered on graceful shutdown. */
+    @PreDestroy
+    public void flushOnShutdown() {
+        flushBuffer();
+    }
+
+    /**
+     * Writes one batch, never throwing: if the batch write fails (e.g. one invalid
+     * point), each point is retried individually so the rest still land.
+     */
+    private void writeBatch(List<OccupancyData> batch) {
+        try {
+            occupancyRepository.saveBatch(batch);
+            log.debug("Flushed {} occupancy points", batch.size());
+        } catch (Exception e) {
+            log.warn("Batch write of {} points failed, retrying individually", batch.size(), e);
+            for (OccupancyData point : batch) {
+                try {
+                    occupancyRepository.save(point);
+                } catch (Exception ex) {
+                    log.error("Dropping occupancy point room={}, sensor={}",
+                            point.getRoomId(), point.getSensorId(), ex);
+                }
+            }
+        }
     }
 }

--- a/backend/src/test/java/com/occupi/feature/database/service/OccupancyServiceTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/service/OccupancyServiceTest.java
@@ -8,13 +8,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -25,6 +26,9 @@ class OccupancyServiceTest {
     @Mock
     private OccupancyRepository occupancyRepository;
 
+    @Captor
+    private ArgumentCaptor<List<OccupancyData>> batchCaptor;
+
     private OccupancyService service;
 
     @BeforeEach
@@ -32,43 +36,73 @@ class OccupancyServiceTest {
         service = new OccupancyService(occupancyRepository);
     }
 
+    private OccupancyData sample(String roomId) {
+        return OccupancyData.builder()
+                .roomId(roomId)
+                .sensorId("sensor-A")
+                .count(12)
+                .confidence(0.92)
+                .timestamp(Instant.now())
+                .build();
+    }
+
     @Nested
-    @DisplayName("recordOccupancy()")
-    class RecordOccupancy {
+    @DisplayName("recordOccupancy() + flushBuffer()")
+    class BufferAndFlush {
 
         @Test
-        @DisplayName("should delegate to repository with correct data")
-        void shouldDelegateToRepository() {
-            OccupancyData data = OccupancyData.builder()
-                    .roomId("seminar-101")
-                    .sensorId("sensor-A")
-                    .count(12)
-                    .confidence(0.92)
-                    .timestamp(Instant.now())
-                    .build();
+        @DisplayName("buffers measurements without writing until flushed")
+        void buffersUntilFlush() {
+            service.recordOccupancy(sample("room-1"));
 
-            service.recordOccupancy(data);
-
-            ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
-            verify(occupancyRepository).save(captor.capture());
-
-            OccupancyData saved = captor.getValue();
-            assertEquals("seminar-101", saved.getRoomId());
-            assertEquals("sensor-A", saved.getSensorId());
-            assertEquals(12, saved.getCount());
-            assertEquals(0.92, saved.getConfidence());
+            verify(occupancyRepository, never()).save(any());
+            verify(occupancyRepository, never()).saveBatch(any());
         }
 
         @Test
-        @DisplayName("should propagate repository exceptions")
-        void shouldPropagateExceptions() {
-            doThrow(new IllegalArgumentException("invalid"))
-                    .when(occupancyRepository).save(any());
+        @DisplayName("flush writes all buffered points as a single batch")
+        void flushWritesOneBatch() {
+            service.recordOccupancy(sample("room-1"));
+            service.recordOccupancy(sample("room-2"));
+            service.recordOccupancy(sample("room-3"));
 
-            OccupancyData data = OccupancyData.builder().build();
+            service.flushBuffer();
 
-            assertThrows(IllegalArgumentException.class,
-                    () -> service.recordOccupancy(data));
+            verify(occupancyRepository).saveBatch(batchCaptor.capture());
+            assertEquals(3, batchCaptor.getValue().size());
+        }
+
+        @Test
+        @DisplayName("flush with an empty buffer does nothing")
+        void flushEmptyIsNoop() {
+            service.flushBuffer();
+
+            verify(occupancyRepository, never()).saveBatch(any());
+        }
+
+        @Test
+        @DisplayName("flush drains the buffer so a second flush writes nothing")
+        void flushDrainsBuffer() {
+            service.recordOccupancy(sample("room-1"));
+
+            service.flushBuffer();
+            service.flushBuffer();
+
+            verify(occupancyRepository, times(1)).saveBatch(any());
+        }
+
+        @Test
+        @DisplayName("on a failed batch, retries each point individually and does not throw")
+        void retriesIndividuallyOnBatchFailure() {
+            service.recordOccupancy(sample("room-1"));
+            service.recordOccupancy(sample("room-2"));
+            doThrow(new RuntimeException("influx unavailable"))
+                    .when(occupancyRepository).saveBatch(any());
+
+            service.flushBuffer();
+
+            verify(occupancyRepository).saveBatch(any());
+            verify(occupancyRepository, times(2)).save(any());
         }
     }
 
@@ -79,16 +113,7 @@ class OccupancyServiceTest {
         @Test
         @DisplayName("should delegate batch to repository")
         void shouldDelegateBatchToRepository() {
-            List<OccupancyData> batch = List.of(
-                    OccupancyData.builder()
-                            .roomId("seminar-101").sensorId("sensor-A")
-                            .count(10).confidence(0.9).timestamp(Instant.now())
-                            .build(),
-                    OccupancyData.builder()
-                            .roomId("seminar-101").sensorId("sensor-B")
-                            .count(12).confidence(0.88).timestamp(Instant.now())
-                            .build()
-            );
+            List<OccupancyData> batch = List.of(sample("room-1"), sample("room-2"));
 
             service.recordBatch(batch);
 


### PR DESCRIPTION
## Summary
Buffers incoming occupancy measurements and writes them to InfluxDB in batches, fixing data loss under load. Each STOMP message previously did a synchronous single write; with many rooms the backend dropped a large share (~22/s → ~65/111). Closes #177. Part of v0.1.0 (#170).

## Changes
- **`OccupancyService`** — `recordOccupancy` now buffers (non-blocking); a `@Scheduled` flush (default every 1 s, `occupancy.flush-interval-ms`) writes buffered points via `saveBatch` in chunks of ≤500; flushes on shutdown (`@PreDestroy`); a failed batch retries each point individually so one bad point doesn't drop the batch.
- **`AppApplication`** — `@EnableScheduling`.
- The per-message `/topic/occupancy` broadcast stays, so the dashboard updates live.
- **`OccupancyServiceTest`** — buffer/flush behaviour.

## Verification
- Unit: 15 tests green (OccupancyService buffer/flush + SensorDataServiceImpl regression).
- Context loads with scheduling (`ReceiverIntegrationTest` green).
- **E2E**: rebuilt backend, 111 rooms at ~55/s (the rate that previously dropped to ~56–72) → **all 111** land in InfluxDB.

## Notes
- Trade-off: buffered points live in memory until the next flush (~1 s) — a crash can lose that window. Acceptable for occupancy data.
- On merge, CI rebuilds the backend image (→ GHCR → auto-deploy), so prod picks up the fix.
