### PR TITLE
fix: remove committed .env and add to .gitignore #180

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,6 +1,0 @@
-VITE_API_URL=http://localhost:8080/api
-
-# Keycloak (local dev). Token endpoint = <URL>/realms/<REALM>/protocol/openid-connect/token
-VITE_KEYCLOAK_URL=http://localhost:8180
-VITE_KEYCLOAK_REALM=occupi
-VITE_KEYCLOAK_CLIENT_ID=occupi-frontend

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,7 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
-
+.env
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## Summary
- Add `.env` to `frontend/.gitignore` to prevent secrets from being committed in the future
- Remove the tracked `frontend/.env` via `git rm --cached` (local file stays untouched)
- The existing `.env.example` already provides the dev defaults

Closes #180