### PR TITLE
fix: restore auth synchronously so page reload keeps logged-in user #157

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,21 +1,14 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { useEffect } from 'react';
 import Dashboard from './pages/Dashboard';
 import { Login } from './pages/Login';
 import Rooms from './pages/Rooms';
 import Analytics from './pages/Analytics';
 import { ProtectedRoute } from './components/ProtectedRoute';
-import { useAuthStore } from './hooks/useAuthStore';
 import { MainLayout } from './layouts/MainLayout.tsx';
 
 function App() {
-    const initializeAuth = useAuthStore((state) => state.initializeAuth);
-
-    // fix: perform initialization cleanly on app mount
-    useEffect(() => {
-        initializeAuth();
-    }, [initializeAuth]);
-
+    // Auth state is restored synchronously when the store is created
+    // (see useAuthStore → loadInitialAuth), so no init effect is needed here.
     return (
         <Router>
             <Routes>

--- a/frontend/src/hooks/useAuthStore.ts
+++ b/frontend/src/hooks/useAuthStore.ts
@@ -13,7 +13,6 @@ interface AuthState {
     isAuthenticated: boolean;
     login: (username: string, password: string) => Promise<LoginResult>;
     logout: () => void;
-    initializeAuth: () => void;
 }
 
 // Keycloak connection — overridable via env, with local-dev defaults so the
@@ -60,23 +59,25 @@ function isExpired(token: string): boolean {
     return Date.now() >= claims.exp * 1000 - 5000;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-    user: null,
-    token: null,
-    isAuthenticated: false,
+// Derive the initial auth state from a token left in localStorage by a previous
+// session. This runs synchronously when the store is created — i.e. before React's
+// first render — so a page reload (F5) restores the session up front and
+// ProtectedRoute sees the correct isAuthenticated value immediately, instead of
+// briefly treating the user as logged out and redirecting to /login.
+function loadInitialAuth(): Pick<AuthState, 'user' | 'token' | 'isAuthenticated'> {
+    const token = localStorage.getItem('token');
+    if (token && !isExpired(token)) {
+        return { token, user: userFromToken(token), isAuthenticated: true };
+    }
+    // Token missing or expired — clear any stale leftovers.
+    localStorage.removeItem('token');
+    localStorage.removeItem('user');
+    localStorage.removeItem('refresh_token');
+    return { user: null, token: null, isAuthenticated: false };
+}
 
-    // Restore a previous session from localStorage if the token is still valid.
-    initializeAuth: () => {
-        const token = localStorage.getItem('token');
-        if (token && !isExpired(token)) {
-            set({ token, user: userFromToken(token), isAuthenticated: true });
-        } else {
-            localStorage.removeItem('token');
-            localStorage.removeItem('user');
-            localStorage.removeItem('refresh_token');
-            set({ user: null, token: null, isAuthenticated: false });
-        }
-    },
+export const useAuthStore = create<AuthState>((set) => ({
+    ...loadInitialAuth(),
 
     // Real login: exchange HdM credentials for a Keycloak JWT (password grant).
     // Credentials go straight to Keycloak, which federates the HdM LDAP.


### PR DESCRIPTION
## Summary
Reloading the page (F5) while logged in redirected the user to `/login`, even with a valid token still in `localStorage`. Auth was restored in a `useEffect` in `App.tsx`, which runs *after* the first render — but `ProtectedRoute` reads `isAuthenticated` *during* that first render, so it saw `false` and redirected before the session was restored.

This restores the session synchronously when the store is created, so the route guard sees the correct `isAuthenticated` on the very first render.

## Changes
- **`useAuthStore.ts`** — the restore logic moves into `loadInitialAuth()`, which reads the token from `localStorage` and returns the initial state synchronously, before React''s first render. A missing or expired token clears the stale `token` / `user` / `refresh_token` keys and falls back to logged-out. The store spreads this as its initial state instead of starting from `isAuthenticated: false`. The `initializeAuth` action is dropped from the store and the `AuthState` interface.
- **`App.tsx`** — removes the mount `useEffect` that called `initializeAuth()`, plus the now-unused `useEffect` and `useAuthStore` imports.

## Verification
- Log in, then reload (F5) → session persists, no redirect to `/login`.
- With an expired or missing token → stale `localStorage` keys are cleared and the user lands on `/login` as before.

Closes #157