### PR TITLE
Feature/periodic data refresh #192

### DIFF
--- a/frontend/src/hooks/useFetchRooms.ts
+++ b/frontend/src/hooks/useFetchRooms.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { useRoomStore } from './useRoomStore';
 import { MOCK_ROOMS } from '../utils/mockData';
 import api from '../utils/api';
@@ -8,7 +8,7 @@ export function useFetchRooms() {
     // we retrieve spaces and function for setting them from the sore
     const { setRooms, isConnected } = useRoomStore();
 
-    const fetchRooms = async () => {
+    const fetchRooms = useCallback (async() => {
         try {
             const [roomsRes, occupancyRes] = await Promise.all([
                 api.get<RoomResponse[]>('/rooms'),
@@ -34,11 +34,11 @@ export function useFetchRooms() {
             console.error("Fehler beim Laden:", error);
             setRooms(MOCK_ROOMS);
         }
-    };
+    }, [setRooms]);
 
     useEffect(() => {
         fetchRooms();
-    }, [setRooms]);
+    }, [setRooms, fetchRooms]);
 
     useEffect(() => {
         if (isConnected) return;
@@ -48,6 +48,6 @@ export function useFetchRooms() {
         }, 30000);
 
         return () => clearInterval(id);
-    }, [isConnected]);
+    }, [isConnected, fetchRooms]);
 
 }

--- a/frontend/src/hooks/useFetchRooms.ts
+++ b/frontend/src/hooks/useFetchRooms.ts
@@ -6,37 +6,48 @@ import type { Room, RoomResponse, Occupancy } from '../types/room';
 
 export function useFetchRooms() {
     // we retrieve spaces and function for setting them from the sore
-    const { setRooms } = useRoomStore();
+    const { setRooms, isConnected } = useRoomStore();
+
+    const fetchRooms = async () => {
+        try {
+            const [roomsRes, occupancyRes] = await Promise.all([
+                api.get<RoomResponse[]>('/rooms'),
+                api.get<Occupancy[]>('/occupancy/all')
+            ]);
+
+            const combined: Room[] = roomsRes.data.map((room) => {
+                const occ = occupancyRes.data.find((o) => o.roomId === room.roomId);
+                const ratio = (occ?.count ?? 0) / room.capacity;
+                const occupancyRate = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
+                return {
+                    ...room,
+                    count: occ?.count ?? 0,
+                    confidence: occ?.confidence ?? 0,
+                    timestamp: occ?.timestamp ?? '',
+                    occupancyRate,
+                };
+            });
+
+            // as long as there are no room data in the DB, show / use mock data
+            setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
+        } catch (error) {
+            console.error("Fehler beim Laden:", error);
+            setRooms(MOCK_ROOMS);
+        }
+    };
 
     useEffect(() => {
-        const fetchRooms = async () => {
-            try {
-                const [roomsRes, occupancyRes] = await Promise.all([
-                    api.get<RoomResponse[]>('/rooms'),
-                    api.get<Occupancy[]>('/occupancy/all')
-                ]);
-
-                const combined: Room[] = roomsRes.data.map((room) => {
-                    const occ = occupancyRes.data.find((o) => o.roomId === room.roomId);
-                    const ratio = (occ?.count ?? 0) / room.capacity;
-                    const occupancyRate = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
-                    return {
-                        ...room,
-                        count: occ?.count ?? 0,
-                        confidence: occ?.confidence ?? 0,
-                        timestamp: occ?.timestamp ?? '',
-                        occupancyRate,
-                    };
-                });
-
-                // as long as there are no room data in the DB, show / use mock data
-                setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
-            } catch (error) {
-                console.error("Fehler beim Laden:", error);
-                setRooms(MOCK_ROOMS);
-            }
-        };
-
         fetchRooms();
     }, [setRooms]);
+
+    useEffect(() => {
+        if (isConnected) return;
+
+        const id = setInterval(() => {
+            fetchRooms();
+        }, 30000);
+
+        return () => clearInterval(id);
+    }, [isConnected]);
+
 }

--- a/frontend/src/hooks/useRoomStore.ts
+++ b/frontend/src/hooks/useRoomStore.ts
@@ -22,7 +22,7 @@ export const useRoomStore = create<RoomState>((set) => ({
             if (room.roomId !== roomId) return room;
             const ratio = count / room.capacity;
             const occupancyRate = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
-            return { ...room, count, occupancyRate };
+            return { ...room, count, occupancyRate, timestamp: new Date().toISOString() };
         }),
     })),
 

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -17,9 +17,18 @@ const columns: { label: string; render: (r: Room) => React.ReactNode }[] = [
 function formatTime(timestamp: string) {
     if (!timestamp) return '—';
     const diff = Math.round((Date.now() - new Date(timestamp).getTime()) / 1000);
+    const now = new Date();
+    const date = new Date(timestamp);
+    const time = date.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+    const dateStr = date.toLocaleDateString('de-DE', { day: 'numeric', month: 'long' });
+    const dateStrWithYear = date.toLocaleDateString('de-DE', { day: 'numeric', month: 'long', year: 'numeric' });
     if (diff < 60) return 'gerade eben';
     if (diff < 3600) return `vor ${Math.floor(diff / 60)} Min`;
-    return new Date(timestamp).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+    if (diff < 86400) return time;
+    if (now.getFullYear() === date.getFullYear()) {
+        return `${time}, ${dateStr}`;
+    }
+    return `${time}, ${dateStrWithYear}`;
 }
 
 export default function Rooms(){

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -1,8 +1,8 @@
+import { useState, useEffect } from "react";
 import { useRoomStore } from '../hooks/useRoomStore.ts';
 import { StatusBadge, OccupancyBar } from '../components/RoomStatus.tsx';
 import { useFetchRooms } from '../hooks/useFetchRooms';
 import type { Room } from '../types/room';
-import React from 'react';
 
 const columns: { label: string; render: (r: Room) => React.ReactNode }[] = [
     {label: 'Raum', render: (r) => r.name },
@@ -33,8 +33,16 @@ function formatTime(timestamp: string) {
 
 export default function Rooms(){
     const { rooms } = useRoomStore();
-
+    const [, setTick] = useState(0);
     useFetchRooms();
+
+    useEffect(() => {
+        const id = setInterval(() => {
+            setTick((tick) => tick + 1);
+        }, 60000)
+
+        return () => clearInterval(id);
+    }, []);
 
     return (
 


### PR DESCRIPTION
## Periodic data refresh for room occupancy (#192)

Room occupancy data was fetched once on mount and never visually updated afterward. Relative timestamps like "vor 3 Min" stayed frozen, and `updateRoom()` did not set the `timestamp` field when WebSocket messages arrived.

### Changes
- **`frontend/src/pages/Rooms.tsx`** — improved `formatTime()` to show date context for older timestamps (same day → time only, same year → time + date, older → time + date + year). Added a 60s re-render timer so relative timestamps stay current.
- **`frontend/src/hooks/useRoomStore.ts`** — `updateRoom()` now sets `timestamp: new Date().toISOString()` alongside count and occupancyRate.
- **`frontend/src/hooks/useFetchRooms.ts`** — added a 30s polling fallback that re-fetches room data when WebSocket is disconnected.

### Result
- "Aktualisiert" column now shows progressively more context for older timestamps
- Relative timestamps tick forward automatically every 60s
- Room data stays fresh even without an active WebSocket connection

Closes #192