### PR TITLE
fix: wrap WebSocket message parsing in try/catch #185

### DIFF
--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef } from 'react';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 import { useRoomStore } from './useRoomStore';
-import type { Occupancy } from '../types/room';
 
 export function useWebSocket() {
     const { updateRoom, setIsConnected } = useRoomStore();
@@ -16,8 +15,15 @@ export function useWebSocket() {
             onConnect: () => {
                 setIsConnected(true);
                 client.subscribe('/topic/occupancy', (message) => {
-                    const data: Occupancy = JSON.parse(message.body);
-                    updateRoom(data.roomId, data.count);
+                    try {
+                        const data= JSON.parse(message.body);
+                        if (typeof data.roomId === 'string' && typeof data.count === 'number') {
+                            updateRoom(data.roomId, data.count);
+                        }
+                    } catch (e) {
+                        console.error('Failed to parse occupancy message:', e);
+                    }
+
                 });
             },
             onDisconnect: () => setIsConnected(false),


### PR DESCRIPTION
## Summary
The STOMP subscription handler in `useWebSocket.ts` calls `JSON.parse(message.body)` without a try/catch. A single malformed message from the sensor pipeline throws and crashes the handler for the entire session.

## Changes
- **`frontend/src/hooks/useWebSocket.ts`** — wrap `JSON.parse` in a try/catch and log parse errors. Added runtime type checks (`typeof roomId === 'string'`, `typeof count === 'number'`) before calling `updateRoom` to guard against unexpected payloads.

## Verification
- Malformed messages are caught and logged instead of crashing the handler
- Valid messages continue to update room occupancy as before

Closes #185