### PR TITLE
fix: replace hard window.location redirect on 401 with React Router navigation #184

### DIFF
--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { useAuthStore} from "../hooks/useAuthStore";
 
 const api = axios.create({
     baseURL: import.meta.env.VITE_API_URL,
@@ -25,9 +26,10 @@ api.interceptors.request.use(
 api.interceptors.response.use(
     (response) => response,
     (error) => {
-        if (error.response?.status === 401) {
-            // Wenn ungültig ist -> Login
-            window.location.href = '/login';
+        const isTokenRequest =
+            error.config?.url?.includes('/openid-connect/token');
+        if (error.response?.status === 401 && !isTokenRequest) {
+            useAuthStore.getState().logout();
         }
         return Promise.reject(error);
     }


### PR DESCRIPTION
## Summary
The 401 response interceptor in `api.ts` used `window.location.href = '/login'` which caused a full page reload, destroying all React state. This also risked an infinite redirect loop if the login page itself triggered an authenticated API call.

## Changes
- **`frontend/src/utils/api.ts`** — replaced `window.location.href` redirect with `useAuthStore.getState().logout()`, which clears the session and lets `ProtectedRoute` handle the redirect via React Router (no page reload). Added a guard to exclude the Keycloak token endpoint from the interceptor to prevent loops during login attempts.

## Verification
- A 401 response clears the session and redirects to `/login` without a full page reload
- Login attempts that return 401 (wrong credentials) do not trigger the interceptor

Closes #184