### PR TITLE
fix: implement token refresh to prevent silent session expiry #183

### DIFF
--- a/frontend/src/hooks/useAuthStore.ts
+++ b/frontend/src/hooks/useAuthStore.ts
@@ -17,10 +17,10 @@ interface AuthState {
 
 // Keycloak connection — overridable via env, with local-dev defaults so the
 // app works out of the box against the local Docker stack.
-const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL ?? 'http://localhost:8180';
-const REALM = import.meta.env.VITE_KEYCLOAK_REALM ?? 'occupi';
-const CLIENT_ID = import.meta.env.VITE_KEYCLOAK_CLIENT_ID ?? 'occupi-frontend';
-const TOKEN_ENDPOINT = `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token`;
+export const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL ?? 'http://localhost:8180';
+export const REALM = import.meta.env.VITE_KEYCLOAK_REALM ?? 'occupi';
+export const CLIENT_ID = import.meta.env.VITE_KEYCLOAK_CLIENT_ID ?? 'occupi-frontend';
+export const TOKEN_ENDPOINT = `${KEYCLOAK_URL}/realms/${REALM}/protocol/openid-connect/token`;
 
 interface JwtClaims {
     preferred_username?: string;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { useAuthStore} from "../hooks/useAuthStore";
+import { useAuthStore, TOKEN_ENDPOINT, CLIENT_ID} from "../hooks/useAuthStore";
 
 const api = axios.create({
     baseURL: import.meta.env.VITE_API_URL,
@@ -25,11 +25,48 @@ api.interceptors.request.use(
 // Response Interceptor
 api.interceptors.response.use(
     (response) => response,
-    (error) => {
+    async (error) => {
+        const originalRequest = error.config;
         const isTokenRequest =
             error.config?.url?.includes('/openid-connect/token');
-        if (error.response?.status === 401 && !isTokenRequest) {
-            useAuthStore.getState().logout();
+
+        if (error.response?.status === 401 && !isTokenRequest && !originalRequest._retry) {
+            originalRequest._retry = true;
+
+            const refreshToken = localStorage.getItem('refresh_token');
+            if (!refreshToken) {
+                useAuthStore.getState().logout();
+                return Promise.reject(error);
+            }
+
+            try {
+                const res = await fetch(TOKEN_ENDPOINT, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: new URLSearchParams({
+                        grant_type: 'refresh_token',
+                        client_id: CLIENT_ID,
+                        refresh_token: refreshToken,
+                    }),
+                });
+
+                if (!res.ok) {
+                    useAuthStore.getState().logout();
+                    return Promise.reject(error);
+                }
+
+                const data = await res.json();
+                localStorage.setItem('token', data.access_token);
+                if (data.refresh_token) {
+                    localStorage.setItem('refresh_token', data.refresh_token);
+                }
+
+                originalRequest.headers.Authorization = `Bearer ${data.access_token}`;
+                return api(originalRequest);
+            } catch {
+                useAuthStore.getState().logout();
+                return Promise.reject(error);
+            }
         }
         return Promise.reject(error);
     }


### PR DESCRIPTION
## Summary
`useAuthStore.ts` saves the `refresh_token` to localStorage but never uses it. Keycloak access tokens expire after ~5 minutes — once expired, every API call triggered a logout and redirect to `/login` without warning.

## Changes
- **`frontend/src/hooks/useAuthStore.ts`** — exported `TOKEN_ENDPOINT` and `CLIENT_ID` constants so they can be reused from the API layer.
- **`frontend/src/utils/api.ts`** — extended the 401 response interceptor to attempt a token refresh using the stored `refresh_token` before logging out. On success, the new token is saved and the original request is retried. On failure, `logout()` is called. A `_retry` flag prevents infinite refresh loops.

## Verification
- With a valid refresh token: expired access token is silently refreshed and the request succeeds
- With an expired/missing refresh token: user is logged out and redirected to `/login`
- Login attempts (token endpoint) are excluded from the interceptor

Closes #183