### PR TITLE
fix: guard against division by zero when room capacity is 0 #189

### DIFF
--- a/frontend/src/components/RoomStatus.tsx
+++ b/frontend/src/components/RoomStatus.tsx
@@ -21,7 +21,7 @@ export function StatusBadge({ occupancyRate }: { occupancyRate: Room['occupancyR
 }
 
 export function OccupancyBar({count, capacity}: {count: number; capacity: number}) {
-    const pct = Math.round((count / capacity)*100);
+    const pct = capacity > 0 ? Math.round((count / capacity)*100) : 0;
 
     return (
         <div className="flex items-center gap-2">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -55,7 +55,7 @@ export default function Dashboard() {
                                     room.occupancyRate === 'low' ? 'bg-green-500' :
                                         room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
                                 }`}
-                                style={{ width: `${(room.count / room.capacity) * 100}%` }}
+                                style={{ width: `${room.capacity > 0 ? (room.count / room.capacity) * 100 : 0}%` }}
                             />
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
Occupancy percentage calculations in multiple components used `count / capacity * 100` without checking for zero capacity. A room with `capacity: 0` (e.g., data error) would produce `NaN` or `Infinity`, breaking progress bars and percentage displays.

## Changes
- **`frontend/src/components/RoomStatus.tsx`** — guard `OccupancyBar` percentage calculation
- **`frontend/src/pages/Dashboard.tsx`** — guard progress bar width calculation

All use the same pattern: `capacity > 0 ? Math.round((count / capacity) * 100) : 0`

## Verification
- Rooms with capacity > 0 display correctly as before
- A room with capacity = 0 shows 0% instead of NaN/Infinity

Closes #189