### PR TITLE
fix: show warning when falling back to mock data #188

### DIFF
--- a/frontend/src/hooks/useFetchRooms.ts
+++ b/frontend/src/hooks/useFetchRooms.ts
@@ -6,7 +6,7 @@ import type { Room, RoomResponse, Occupancy } from '../types/room';
 
 export function useFetchRooms() {
     // we retrieve spaces and function for setting them from the sore
-    const { setRooms, isConnected } = useRoomStore();
+    const { setRooms, isConnected, setIsMockData } = useRoomStore();
 
     const fetchRooms = useCallback (async() => {
         try {
@@ -30,9 +30,11 @@ export function useFetchRooms() {
 
             // as long as there are no room data in the DB, show / use mock data
             setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
+            setIsMockData(combined.length === 0);
         } catch (error) {
             console.error("Fehler beim Laden:", error);
             setRooms(MOCK_ROOMS);
+            setIsMockData(true);
         }
     }, [setRooms]);
 

--- a/frontend/src/hooks/useRoomStore.ts
+++ b/frontend/src/hooks/useRoomStore.ts
@@ -8,6 +8,8 @@ interface RoomState {
     updateRoom: (roomId: string, count: number) => void;
     isConnected: boolean;
     setIsConnected: (value: boolean) => void;
+    isMockData: boolean;
+    setIsMockData: (value: boolean) => void;
 }
 
 export const useRoomStore = create<RoomState>((set) => ({
@@ -28,5 +30,7 @@ export const useRoomStore = create<RoomState>((set) => ({
 
     isConnected: false,
     setIsConnected: (value) => set({ isConnected: value}),
+    isMockData: false,
+    setIsMockData: (value) => set({isMockData: value }),
 
 }));

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import { useFetchRooms } from '../hooks/useFetchRooms';
 
 export default function Dashboard() {
     // we retrieve spaces and function for setting them from the sore
-    const { rooms, isConnected } = useRoomStore();
+    const { rooms, isConnected, isMockData } = useRoomStore();
 
     useFetchRooms();
 
@@ -22,6 +22,12 @@ export default function Dashboard() {
                     </span>
                 </div>
             </header>
+
+            {isMockData && (
+                <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg text-sm text-yellow-800">
+                    Konnte keine Echtzeitdaten laden | Beispieldaten werden angezeigt
+                </div>
+            )}
 
             {/* grid for rooms */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
## Summary
When the backend API was unreachable, the app silently fell back to mock data with no indication to the user. Users could make decisions based on data they believed was real.

## Changes
- **`frontend/src/hooks/useRoomStore.ts`** — added `isMockData` flag and `setIsMockData` setter to the store
- **`frontend/src/hooks/useFetchRooms.ts`** — set `isMockData` to `true` when falling back to mock data (API error or empty response), `false` on successful load
- **`frontend/src/pages/Dashboard.tsx`** — display a yellow warning banner when `isMockData` is true

## Verification
- Backend running: no banner, real data displayed
- Backend unreachable: yellow banner shown with "Konnte keine Echtzeitdaten laden — Beispieldaten werden angezeigt"

Closes #188