### PR TITLE
add: occupancy history + weekpattern endpoints for room detail #199

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- Occupancy history and weekly-pattern REST endpoints for the room detail view:
+  `GET /api/occupancy/history` returns the recent time series (raw points within 24h,
+  downsampled to 30-minute slots beyond that), and `GET /api/occupancy/weekpattern`
+  returns the per-weekday/hour averages over the last N weeks with the peak and quiet
+  times (#199).
 - Wired the real TI IWR6843 mmWave radar into the Pi sender: `sensor-01` in
   `raspberry/compose.yml` maps the radar's two CP2105 USB serial ports and adds the
   `dialout` group, so on the Pi a plain `docker compose up` with `SENSOR_MODE=real` streams

--- a/backend/src/main/java/com/occupi/feature/chart/ChartController.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartController.java
@@ -1,0 +1,73 @@
+package com.occupi.feature.chart;
+
+import com.occupi.feature.chart.dto.HistoryResponse;
+import com.occupi.feature.chart.dto.WeekPatternResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoints backing the room detail view: historical occupancy and the
+ * aggregated weekly pattern.
+ *
+ * <pre>
+ * GET /api/occupancy/history?roomId=room-42&hours=24
+ * GET /api/occupancy/weekpattern?roomId=room-42&weeks=8
+ * </pre>
+ */
+@RestController
+@RequestMapping("/api/occupancy")
+public class ChartController {
+
+    private final ChartService chartService;
+
+    public ChartController(ChartService chartService) {
+        this.chartService = chartService;
+    }
+
+    /**
+     * Returns the occupancy history for the given room and look-back window.
+     *
+     * @param roomId the room identifier (required)
+     * @param hours  the look-back window in hours (default: 24, must be &gt; 0)
+     * @return 200 OK with {@link HistoryResponse}, or 400 if parameters are invalid
+     */
+    @GetMapping("/history")
+    public ResponseEntity<HistoryResponse> getHistory(
+            @RequestParam String roomId,
+            @RequestParam(defaultValue = "24") int hours) {
+
+        if (roomId == null || roomId.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        if (hours <= 0) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        return ResponseEntity.ok(chartService.getHistory(roomId, hours));
+    }
+
+    /**
+     * Returns the weekly occupancy pattern for the given room.
+     *
+     * @param roomId the room identifier (required)
+     * @param weeks  the number of weeks to aggregate (default: 8, must be &gt; 0)
+     * @return 200 OK with {@link WeekPatternResponse}, or 400 if parameters are invalid
+     */
+    @GetMapping("/weekpattern")
+    public ResponseEntity<WeekPatternResponse> getWeekPattern(
+            @RequestParam String roomId,
+            @RequestParam(defaultValue = "8") int weeks) {
+
+        if (roomId == null || roomId.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        if (weeks <= 0) {
+            return ResponseEntity.badRequest().build();
+        }
+
+        return ResponseEntity.ok(chartService.getWeekPattern(roomId, weeks));
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/chart/ChartService.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartService.java
@@ -1,0 +1,31 @@
+package com.occupi.feature.chart;
+
+import com.occupi.feature.chart.dto.HistoryResponse;
+import com.occupi.feature.chart.dto.WeekPatternResponse;
+
+/**
+ * Serves historical and aggregated occupancy data for the room detail view.
+ */
+public interface ChartService {
+
+    /**
+     * Returns the occupancy history for a room over the last {@code hours}.
+     * Raw points are returned for short windows; longer windows are downsampled
+     * into fixed slots.
+     *
+     * @param roomId the room to query
+     * @param hours  the look-back window in hours (must be &gt; 0)
+     * @return a {@link HistoryResponse} with the points and the queried window
+     */
+    HistoryResponse getHistory(String roomId, int hours);
+
+    /**
+     * Returns the weekly occupancy pattern for a room, averaged over the last
+     * {@code weeks} weeks and grouped by weekday and hour.
+     *
+     * @param roomId the room to query
+     * @param weeks  the number of weeks to aggregate (must be &gt; 0)
+     * @return a {@link WeekPatternResponse} with per-slot averages and the peak/quiet slots
+     */
+    WeekPatternResponse getWeekPattern(String roomId, int weeks);
+}

--- a/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
@@ -1,0 +1,240 @@
+package com.occupi.feature.chart;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.chart.dto.HistoryPoint;
+import com.occupi.feature.chart.dto.HistoryResponse;
+import com.occupi.feature.chart.dto.WeekPatternExtreme;
+import com.occupi.feature.chart.dto.WeekPatternResponse;
+import com.occupi.feature.chart.dto.WeekPatternSlot;
+import com.occupi.feature.database.InfluxTime;
+import com.occupi.feature.room.RoomService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Default {@link ChartService} implementation.
+ *
+ * <p>Reads raw occupancy points from InfluxDB and aggregates them in memory —
+ * mirroring the {@code forecast} feature — so the read path stays consistent and
+ * unit-testable against a mocked client. Aggregating in Java (rather than via SQL
+ * {@code GROUP BY}) also keeps weekday/hour bucketing in the configured local zone.
+ */
+@Slf4j
+@Service
+public class ChartServiceImpl implements ChartService {
+
+    private final InfluxDBClient influxDBClient;
+    private final RoomService roomService;
+
+    @Value("${influxdb.measurement:occupancy}")
+    private String measurement;
+
+    /** Windows up to this length return raw points; longer windows are downsampled. */
+    @Value("${chart.history.downsample-threshold-hours:24}")
+    private int downsampleThresholdHours;
+
+    /** Slot width used when downsampling a long history window. */
+    @Value("${chart.history.slot-minutes:30}")
+    private int slotMinutes;
+
+    /** Earliest hour (inclusive) considered when picking the quiet time. */
+    @Value("${chart.weekpattern.quiet-start-hour:8}")
+    private int quietStartHour;
+
+    /** Latest hour (inclusive) considered when picking the quiet time. */
+    @Value("${chart.weekpattern.quiet-end-hour:18}")
+    private int quietEndHour;
+
+    public ChartServiceImpl(InfluxDBClient influxDBClient, RoomService roomService) {
+        this.influxDBClient = influxDBClient;
+        this.roomService = roomService;
+    }
+
+    @Override
+    public HistoryResponse getHistory(String roomId, int hours) {
+        validateRoomId(roomId);
+        if (hours <= 0) {
+            throw new IllegalArgumentException("hours must be positive, got: " + hours);
+        }
+
+        Instant end = Instant.now();
+        Instant start = end.minus(hours, ChronoUnit.HOURS);
+
+        List<Object[]> rows = queryReadings(roomId, start, end, "\"count\", \"confidence\", time");
+
+        List<HistoryPoint> points = hours <= downsampleThresholdHours
+                ? toRawPoints(rows)
+                : toDownsampledPoints(rows);
+
+        log.debug("History for room={} window={}h: rows={} points={} downsampled={}",
+                roomId, hours, rows.size(), points.size(), hours > downsampleThresholdHours);
+
+        return new HistoryResponse(roomId, points, start, end);
+    }
+
+    @Override
+    public WeekPatternResponse getWeekPattern(String roomId, int weeks) {
+        validateRoomId(roomId);
+        if (weeks <= 0) {
+            throw new IllegalArgumentException("weeks must be positive, got: " + weeks);
+        }
+
+        Instant end = Instant.now();
+        Instant start = end.minus(weeks * 7L, ChronoUnit.DAYS);
+
+        List<Object[]> rows = queryReadings(roomId, start, end, "\"count\", time");
+
+        // (weekday, hour) → [sumCount, sampleCount]
+        Map<Slot, double[]> buckets = new LinkedHashMap<>();
+        for (Object[] row : rows) {
+            if (row[0] == null || row[1] == null) {
+                continue;
+            }
+            double count = ((Number) row[0]).doubleValue();
+            ZonedDateTime zdt = InfluxTime.toInstant(row[1]).atZone(ZoneId.systemDefault());
+            Slot slot = new Slot(zdt.getDayOfWeek(), zdt.getHour());
+
+            double[] acc = buckets.computeIfAbsent(slot, k -> new double[]{0.0, 0.0});
+            acc[0] += count;
+            acc[1] += 1;
+        }
+
+        int capacity = roomService.getRoom(roomId).map(r -> r.capacity()).orElse(0);
+
+        List<WeekPatternSlot> pattern = buckets.entrySet().stream()
+                .sorted(Comparator
+                        .<Map.Entry<Slot, double[]>>comparingInt(e -> e.getKey().day().getValue())
+                        .thenComparingInt(e -> e.getKey().hour()))
+                .map(e -> {
+                    double avgOccupancy = e.getValue()[0] / e.getValue()[1];
+                    double avgRate = capacity > 0 ? avgOccupancy / capacity : 0.0;
+                    return new WeekPatternSlot(
+                            e.getKey().day().name(), e.getKey().hour(), avgOccupancy, avgRate);
+                })
+                .toList();
+
+        WeekPatternExtreme peakTime = pattern.stream()
+                .max(Comparator.comparingDouble(WeekPatternSlot::avgRate))
+                .map(this::toExtreme)
+                .orElse(null);
+
+        WeekPatternExtreme quietTime = pattern.stream()
+                .filter(s -> s.hour() >= quietStartHour && s.hour() <= quietEndHour)
+                .min(Comparator.comparingDouble(WeekPatternSlot::avgRate))
+                .map(this::toExtreme)
+                .orElse(null);
+
+        log.debug("Week pattern for room={} weeks={}: rows={} slots={} capacity={}",
+                roomId, weeks, rows.size(), pattern.size(), capacity);
+
+        return new WeekPatternResponse(roomId, weeks, pattern, peakTime, quietTime);
+    }
+
+    /**
+     * Returns one {@link HistoryPoint} per reading, untouched. Used for short
+     * windows where the raw resolution is already small enough for the client.
+     */
+    private List<HistoryPoint> toRawPoints(List<Object[]> rows) {
+        List<HistoryPoint> points = new ArrayList<>(rows.size());
+        for (Object[] row : rows) {
+            if (row[0] == null || row[2] == null) {
+                continue;
+            }
+            int count = ((Number) row[0]).intValue();
+            double confidence = row[1] == null ? 0.0 : ((Number) row[1]).doubleValue();
+            points.add(new HistoryPoint(InfluxTime.toInstant(row[2]), count, confidence));
+        }
+        return points;
+    }
+
+    /**
+     * Aggregates readings into fixed {@link #slotMinutes}-wide slots (count and
+     * confidence averaged), so a long window doesn't ship thousands of points.
+     */
+    private List<HistoryPoint> toDownsampledPoints(List<Object[]> rows) {
+        long slotSeconds = slotMinutes * 60L;
+        // slot start (epoch seconds) → [sumCount, sumConfidence, sampleCount]
+        Map<Long, double[]> slots = new LinkedHashMap<>();
+
+        for (Object[] row : rows) {
+            if (row[0] == null || row[2] == null) {
+                continue;
+            }
+            double count = ((Number) row[0]).doubleValue();
+            double confidence = row[1] == null ? 0.0 : ((Number) row[1]).doubleValue();
+            long epochSecond = InfluxTime.toInstant(row[2]).getEpochSecond();
+            long slotStart = Math.floorDiv(epochSecond, slotSeconds) * slotSeconds;
+
+            double[] acc = slots.computeIfAbsent(slotStart, k -> new double[]{0.0, 0.0, 0.0});
+            acc[0] += count;
+            acc[1] += confidence;
+            acc[2] += 1;
+        }
+
+        return slots.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> {
+                    double[] acc = e.getValue();
+                    int avgCount = (int) Math.round(acc[0] / acc[2]);
+                    double avgConfidence = acc[1] / acc[2];
+                    return new HistoryPoint(Instant.ofEpochSecond(e.getKey()), avgCount, avgConfidence);
+                })
+                .toList();
+    }
+
+    private WeekPatternExtreme toExtreme(WeekPatternSlot slot) {
+        return new WeekPatternExtreme(slot.dayOfWeek(), slot.hour(), slot.avgRate());
+    }
+
+    /**
+     * Runs a range query against the occupancy measurement and returns the rows.
+     * The selected columns are passed in so callers fetch only what they need.
+     */
+    private List<Object[]> queryReadings(String roomId, Instant start, Instant end, String columns) {
+        String sql = """
+                SELECT %s
+                FROM "%s"
+                WHERE "roomId" = '%s'
+                  AND time >= '%s'
+                  AND time < '%s'
+                ORDER BY time ASC
+                """.formatted(columns, measurement, roomId, start, end);
+
+        List<Object[]> result = new ArrayList<>();
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            rows.forEach(row -> {
+                if (row != null) {
+                    result.add(row);
+                }
+            });
+        }
+        return result;
+    }
+
+    private void validateRoomId(String roomId) {
+        if (roomId == null || roomId.isBlank()) {
+            throw new IllegalArgumentException("roomId must not be blank");
+        }
+        if (!roomId.matches("[a-zA-Z0-9\\-]+")) {
+            throw new IllegalArgumentException("roomId contains invalid characters: " + roomId);
+        }
+    }
+
+    /** Aggregation key for a weekly-pattern cell. */
+    private record Slot(DayOfWeek day, int hour) {
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/chart/dto/HistoryPoint.java
+++ b/backend/src/main/java/com/occupi/feature/chart/dto/HistoryPoint.java
@@ -1,0 +1,18 @@
+package com.occupi.feature.chart.dto;
+
+import java.time.Instant;
+
+/**
+ * A single point in an occupancy history series.
+ *
+ * @param time       the instant the measurement applies to (slot start for
+ *                   downsampled series)
+ * @param count      the anonymized headcount; the rounded average when the
+ *                   series is downsampled into slots
+ * @param confidence confidence score of the measurement in [0.0, 1.0]
+ */
+public record HistoryPoint(
+        Instant time,
+        int count,
+        double confidence
+) {}

--- a/backend/src/main/java/com/occupi/feature/chart/dto/HistoryResponse.java
+++ b/backend/src/main/java/com/occupi/feature/chart/dto/HistoryResponse.java
@@ -1,0 +1,20 @@
+package com.occupi.feature.chart.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Response DTO for a room's historical occupancy time series.
+ *
+ * @param roomId the room the series belongs to
+ * @param points the occupancy points over the requested window, ordered
+ *               oldest to newest
+ * @param start  the inclusive start of the queried window
+ * @param end    the exclusive end of the queried window (the request instant)
+ */
+public record HistoryResponse(
+        String roomId,
+        List<HistoryPoint> points,
+        Instant start,
+        Instant end
+) {}

--- a/backend/src/main/java/com/occupi/feature/chart/dto/WeekPatternExtreme.java
+++ b/backend/src/main/java/com/occupi/feature/chart/dto/WeekPatternExtreme.java
@@ -1,0 +1,15 @@
+package com.occupi.feature.chart.dto;
+
+/**
+ * Highlights a single slot of the weekly pattern — the busiest (peak) or
+ * quietest slot — for the room detail view.
+ *
+ * @param dayOfWeek the weekday, as a {@link java.time.DayOfWeek} name (e.g. "WEDNESDAY")
+ * @param hour      the hour of day in [0, 23]
+ * @param avgRate   the average occupancy rate in [0.0, 1.0] for this slot
+ */
+public record WeekPatternExtreme(
+        String dayOfWeek,
+        int hour,
+        double avgRate
+) {}

--- a/backend/src/main/java/com/occupi/feature/chart/dto/WeekPatternResponse.java
+++ b/backend/src/main/java/com/occupi/feature/chart/dto/WeekPatternResponse.java
@@ -1,0 +1,23 @@
+package com.occupi.feature.chart.dto;
+
+import java.util.List;
+
+/**
+ * Response DTO for a room's weekly occupancy pattern, averaged over the
+ * requested number of weeks.
+ *
+ * @param roomId    the room the pattern belongs to
+ * @param weeks     the number of weeks that were aggregated
+ * @param pattern   the per-slot averages, ordered by weekday then hour
+ * @param peakTime  the slot with the highest average rate, or {@code null} when
+ *                  there is no data
+ * @param quietTime the slot with the lowest average rate within business hours
+ *                  (08:00–18:00), or {@code null} when there is no data in that window
+ */
+public record WeekPatternResponse(
+        String roomId,
+        int weeks,
+        List<WeekPatternSlot> pattern,
+        WeekPatternExtreme peakTime,
+        WeekPatternExtreme quietTime
+) {}

--- a/backend/src/main/java/com/occupi/feature/chart/dto/WeekPatternSlot.java
+++ b/backend/src/main/java/com/occupi/feature/chart/dto/WeekPatternSlot.java
@@ -1,0 +1,19 @@
+package com.occupi.feature.chart.dto;
+
+/**
+ * One cell of the weekly occupancy pattern: the average occupancy for a given
+ * weekday and hour, aggregated over the requested number of weeks.
+ *
+ * @param dayOfWeek    the weekday, as a {@link java.time.DayOfWeek} name (e.g. "MONDAY")
+ * @param hour         the hour of day in [0, 23]
+ * @param avgOccupancy the average headcount in this slot
+ * @param avgRate      the average occupancy rate in [0.0, 1.0]
+ *                     ({@code avgOccupancy / room capacity}); 0.0 when the room
+ *                     capacity is unknown
+ */
+public record WeekPatternSlot(
+        String dayOfWeek,
+        int hour,
+        double avgOccupancy,
+        double avgRate
+) {}

--- a/backend/src/test/java/com/occupi/feature/chart/ChartControllerTest.java
+++ b/backend/src/test/java/com/occupi/feature/chart/ChartControllerTest.java
@@ -1,0 +1,134 @@
+package com.occupi.feature.chart;
+
+import com.occupi.feature.chart.dto.HistoryPoint;
+import com.occupi.feature.chart.dto.HistoryResponse;
+import com.occupi.feature.chart.dto.WeekPatternExtreme;
+import com.occupi.feature.chart.dto.WeekPatternResponse;
+import com.occupi.feature.chart.dto.WeekPatternSlot;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChartControllerTest {
+
+    @Mock
+    private ChartService chartService;
+
+    @InjectMocks
+    private ChartController controller;
+
+    private HistoryResponse historyResponse;
+    private WeekPatternResponse weekPatternResponse;
+
+    @BeforeEach
+    void setUp() {
+        historyResponse = new HistoryResponse(
+                "room-1",
+                List.of(new HistoryPoint(Instant.parse("2025-01-13T10:00:00Z"), 15, 0.92)),
+                Instant.parse("2025-01-13T09:00:00Z"),
+                Instant.parse("2025-01-13T10:00:00Z"));
+        weekPatternResponse = new WeekPatternResponse(
+                "room-1",
+                8,
+                List.of(new WeekPatternSlot("MONDAY", 10, 25.0, 0.625)),
+                new WeekPatternExtreme("WEDNESDAY", 15, 0.9),
+                new WeekPatternExtreme("SUNDAY", 12, 0.05));
+    }
+
+    // ---------- history ----------
+
+    @Test
+    @DisplayName("history returns 200 with body when roomId and hours are valid")
+    void getHistory_validParams_returns200() {
+        when(chartService.getHistory("room-1", 24)).thenReturn(historyResponse);
+
+        ResponseEntity<HistoryResponse> response = controller.getHistory("room-1", 24);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(historyResponse);
+        verify(chartService).getHistory("room-1", 24);
+    }
+
+    @Test
+    @DisplayName("history returns 400 when roomId is blank")
+    void getHistory_blankRoomId_returns400() {
+        ResponseEntity<HistoryResponse> response = controller.getHistory("  ", 24);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(chartService);
+    }
+
+    @Test
+    @DisplayName("history returns 400 when hours is zero")
+    void getHistory_zeroHours_returns400() {
+        ResponseEntity<HistoryResponse> response = controller.getHistory("room-1", 0);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(chartService);
+    }
+
+    @Test
+    @DisplayName("history returns 400 when hours is negative")
+    void getHistory_negativeHours_returns400() {
+        ResponseEntity<HistoryResponse> response = controller.getHistory("room-1", -5);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(chartService);
+    }
+
+    // ---------- weekpattern ----------
+
+    @Test
+    @DisplayName("weekpattern returns 200 with body when roomId and weeks are valid")
+    void getWeekPattern_validParams_returns200() {
+        when(chartService.getWeekPattern("room-1", 8)).thenReturn(weekPatternResponse);
+
+        ResponseEntity<WeekPatternResponse> response = controller.getWeekPattern("room-1", 8);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(weekPatternResponse);
+        verify(chartService).getWeekPattern("room-1", 8);
+    }
+
+    @Test
+    @DisplayName("weekpattern returns 400 when roomId is blank")
+    void getWeekPattern_blankRoomId_returns400() {
+        ResponseEntity<WeekPatternResponse> response = controller.getWeekPattern("  ", 8);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(chartService);
+    }
+
+    @Test
+    @DisplayName("weekpattern returns 400 when weeks is zero")
+    void getWeekPattern_zeroWeeks_returns400() {
+        ResponseEntity<WeekPatternResponse> response = controller.getWeekPattern("room-1", 0);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(chartService);
+    }
+
+    @Test
+    @DisplayName("weekpattern returns 400 when weeks is negative")
+    void getWeekPattern_negativeWeeks_returns400() {
+        ResponseEntity<WeekPatternResponse> response = controller.getWeekPattern("room-1", -3);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(chartService);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
@@ -1,0 +1,244 @@
+package com.occupi.feature.chart;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.chart.dto.HistoryResponse;
+import com.occupi.feature.chart.dto.WeekPatternResponse;
+import com.occupi.feature.chart.dto.WeekPatternSlot;
+import com.occupi.feature.room.RoomService;
+import com.occupi.feature.room.dto.RoomResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChartServiceImplTest {
+
+    @Mock
+    private InfluxDBClient influxDBClient;
+
+    @Mock
+    private RoomService roomService;
+
+    private ChartServiceImpl service;
+
+    /** Mirrors how InfluxDB 3 returns the time column: nanoseconds since epoch. */
+    private static BigInteger nanos(Instant t) {
+        return BigInteger.valueOf(t.getEpochSecond())
+                .multiply(BigInteger.valueOf(1_000_000_000L))
+                .add(BigInteger.valueOf(t.getNano()));
+    }
+
+    /** Builds an instant at a fixed local wall-clock time, so weekday/hour are zone-independent. */
+    private static Instant localTime(int year, int month, int day, int hour, int minute) {
+        return LocalDateTime.of(year, month, day, hour, minute)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
+    }
+
+    @BeforeEach
+    void setUp() {
+        service = new ChartServiceImpl(influxDBClient, roomService);
+        ReflectionTestUtils.setField(service, "measurement", "occupancy");
+        ReflectionTestUtils.setField(service, "downsampleThresholdHours", 24);
+        ReflectionTestUtils.setField(service, "slotMinutes", 30);
+        ReflectionTestUtils.setField(service, "quietStartHour", 8);
+        ReflectionTestUtils.setField(service, "quietEndHour", 18);
+    }
+
+    // ---------- history ----------
+
+    @Test
+    @DisplayName("history returns raw points unchanged for windows within the threshold")
+    void getHistory_shortWindow_returnsRawPoints() {
+        Instant t1 = Instant.parse("2025-01-13T10:00:00Z");
+        Instant t2 = Instant.parse("2025-01-13T10:05:00Z");
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>of(
+                        new Object[]{15, 0.92, nanos(t1)},
+                        new Object[]{18, 0.88, nanos(t2)}));
+
+        HistoryResponse response = service.getHistory("room-1", 2);
+
+        assertThat(response.roomId()).isEqualTo("room-1");
+        assertThat(response.points()).hasSize(2);
+        assertThat(response.points().get(0).time()).isEqualTo(t1);
+        assertThat(response.points().get(0).count()).isEqualTo(15);
+        assertThat(response.points().get(0).confidence()).isEqualTo(0.92);
+        assertThat(response.points().get(1).count()).isEqualTo(18);
+        assertThat(response.start()).isBefore(response.end());
+    }
+
+    @Test
+    @DisplayName("history downsamples long windows into averaged slots")
+    void getHistory_longWindow_downsamplesIntoSlots() {
+        // three readings in the same 30-min slot [10:00,10:30) → avg count 20,
+        // one reading in the next aligned slot [11:00,11:30) → count 8
+        Instant a = Instant.parse("2025-01-13T10:00:00Z");
+        Instant b = Instant.parse("2025-01-13T10:10:00Z");
+        Instant c = Instant.parse("2025-01-13T10:20:00Z");
+        Instant d = Instant.parse("2025-01-13T11:00:00Z");
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>of(
+                        new Object[]{10, 0.9, nanos(a)},
+                        new Object[]{20, 0.9, nanos(b)},
+                        new Object[]{30, 0.9, nanos(c)},
+                        new Object[]{8, 0.9, nanos(d)}));
+
+        HistoryResponse response = service.getHistory("room-1", 48);
+
+        assertThat(response.points()).hasSize(2);
+        assertThat(response.points().get(0).time()).isEqualTo(Instant.parse("2025-01-13T10:00:00Z"));
+        assertThat(response.points().get(0).count()).isEqualTo(20);
+        assertThat(response.points().get(0).confidence()).isCloseTo(0.9, within(1e-9));
+        assertThat(response.points().get(1).time()).isEqualTo(Instant.parse("2025-01-13T11:00:00Z"));
+        assertThat(response.points().get(1).count()).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("history returns an empty series when the room has no data")
+    void getHistory_noData_returnsEmptyPoints() {
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.empty());
+
+        HistoryResponse response = service.getHistory("room-1", 24);
+
+        assertThat(response.points()).isEmpty();
+        assertThat(response.start()).isBefore(response.end());
+    }
+
+    @Test
+    @DisplayName("history throws on blank roomId")
+    void getHistory_blankRoomId_throws() {
+        assertThatIllegalArgumentException().isThrownBy(() -> service.getHistory("  ", 24));
+    }
+
+    @Test
+    @DisplayName("history throws on roomId with invalid characters")
+    void getHistory_invalidRoomId_throws() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> service.getHistory("room'; DROP TABLE--", 24));
+    }
+
+    @Test
+    @DisplayName("history throws on non-positive hours")
+    void getHistory_zeroHours_throws() {
+        assertThatIllegalArgumentException().isThrownBy(() -> service.getHistory("room-1", 0));
+    }
+
+    // ---------- weekpattern ----------
+
+    @Test
+    @DisplayName("weekpattern averages per slot, derives rate from capacity, and picks peak/quiet")
+    void getWeekPattern_aggregatesAndPicksExtremes() {
+        when(roomService.getRoom("room-1"))
+                .thenReturn(Optional.of(new RoomResponse("room-1", "R1", "B", 1, 40)));
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>of(
+                        new Object[]{20, nanos(localTime(2025, 1, 13, 10, 5))},  // Mon 10
+                        new Object[]{30, nanos(localTime(2025, 1, 13, 10, 40))}, // Mon 10 (same slot)
+                        new Object[]{0, nanos(localTime(2025, 1, 13, 3, 0))},    // Mon 03 (outside 8-18)
+                        new Object[]{36, nanos(localTime(2025, 1, 15, 15, 0))},  // Wed 15 (peak)
+                        new Object[]{2, nanos(localTime(2025, 1, 12, 12, 0))})); // Sun 12 (quiet)
+
+        WeekPatternResponse response = service.getWeekPattern("room-1", 8);
+
+        assertThat(response.weeks()).isEqualTo(8);
+        assertThat(response.pattern()).hasSize(4);
+
+        WeekPatternSlot monday10 = response.pattern().stream()
+                .filter(s -> s.dayOfWeek().equals("MONDAY") && s.hour() == 10)
+                .findFirst().orElseThrow();
+        assertThat(monday10.avgOccupancy()).isCloseTo(25.0, within(1e-9));
+        assertThat(monday10.avgRate()).isCloseTo(0.625, within(1e-9));
+
+        assertThat(response.peakTime().dayOfWeek()).isEqualTo("WEDNESDAY");
+        assertThat(response.peakTime().hour()).isEqualTo(15);
+        assertThat(response.peakTime().avgRate()).isCloseTo(0.9, within(1e-9));
+
+        // Monday 03:00 has the lowest rate (0.0) but is outside business hours,
+        // so the quiet time is Sunday 12:00 instead.
+        assertThat(response.quietTime().dayOfWeek()).isEqualTo("SUNDAY");
+        assertThat(response.quietTime().hour()).isEqualTo(12);
+        assertThat(response.quietTime().avgRate()).isCloseTo(0.05, within(1e-9));
+    }
+
+    @Test
+    @DisplayName("weekpattern yields a zero rate when the room capacity is unknown")
+    void getWeekPattern_unknownRoom_rateIsZero() {
+        when(roomService.getRoom("room-1")).thenReturn(Optional.empty());
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>of(
+                        new Object[]{20, nanos(localTime(2025, 1, 13, 10, 0))}));
+
+        WeekPatternResponse response = service.getWeekPattern("room-1", 8);
+
+        assertThat(response.pattern()).hasSize(1);
+        assertThat(response.pattern().get(0).avgOccupancy()).isCloseTo(20.0, within(1e-9));
+        assertThat(response.pattern().get(0).avgRate()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("weekpattern returns no pattern and null extremes when there is no data")
+    void getWeekPattern_noData_returnsEmptyPattern() {
+        lenient().when(roomService.getRoom("room-1"))
+                .thenReturn(Optional.of(new RoomResponse("room-1", "R1", "B", 1, 40)));
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.empty());
+
+        WeekPatternResponse response = service.getWeekPattern("room-1", 8);
+
+        assertThat(response.pattern()).isEmpty();
+        assertThat(response.peakTime()).isNull();
+        assertThat(response.quietTime()).isNull();
+    }
+
+    @Test
+    @DisplayName("weekpattern leaves quietTime null when all data falls outside business hours")
+    void getWeekPattern_onlyOutsideBusinessHours_quietTimeNull() {
+        when(roomService.getRoom("room-1"))
+                .thenReturn(Optional.of(new RoomResponse("room-1", "R1", "B", 1, 40)));
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>of(
+                        new Object[]{5, nanos(localTime(2025, 1, 13, 6, 0))},   // 06:00
+                        new Object[]{7, nanos(localTime(2025, 1, 13, 22, 0))})); // 22:00
+
+        WeekPatternResponse response = service.getWeekPattern("room-1", 8);
+
+        assertThat(response.pattern()).hasSize(2);
+        assertThat(response.peakTime()).isNotNull();
+        assertThat(response.quietTime()).isNull();
+    }
+
+    @Test
+    @DisplayName("weekpattern throws on blank roomId")
+    void getWeekPattern_blankRoomId_throws() {
+        assertThatIllegalArgumentException().isThrownBy(() -> service.getWeekPattern("  ", 8));
+    }
+
+    @Test
+    @DisplayName("weekpattern throws on non-positive weeks")
+    void getWeekPattern_zeroWeeks_throws() {
+        assertThatIllegalArgumentException().isThrownBy(() -> service.getWeekPattern("room-1", 0));
+    }
+}


### PR DESCRIPTION
## What

Two read-only REST endpoints under `/api/occupancy` that back the room detail modal (#199):

- `GET /api/occupancy/history?roomId=&hours=24` — recent occupancy time series. Raw points within the 24h threshold; downsampled to 30-minute average slots beyond it.
- `GET /api/occupancy/weekpattern?roomId=&weeks=8` — average occupancy per weekday/hour over the last N weeks, plus the busiest (peak) and quietest slot. The quiet slot is restricted to business hours (08:00–18:00).

## How

- New `chart` feature (package by feature), mirroring the existing `forecast` slice: `ChartController` → `ChartService` / `ChartServiceImpl`, DTOs as records under `chart/dto`.
- Reads raw points from InfluxDB via range queries and aggregates in memory — consistent with the forecast read path, keeps weekday/hour bucketing in the local zone, and stays unit-testable against a mocked client. The expensive weekpattern aggregation is a natural caching target later (noted in `ROOM_DETAIL_SPEC.md`).
- `avgRate` divides the average occupancy by the room capacity from Postgres (via `RoomService`); it falls back to `0.0` when the room or its capacity is unknown, so rooms that only exist in InfluxDB still return data.
- `roomId` is validated against the same allowlist regex used elsewhere, so it never reaches the SQL string unchecked.

## Response shapes

Match `ROOM_DETAIL_SPEC.md` (on `feature/room-detail-modal-#200`) and the frontend TypeScript types — `dayOfWeek` is the `DayOfWeek` enum name (e.g. `"MONDAY"`), `hour` is `0–23`.

## Tests

- `ChartControllerTest` — 200 and 400 paths for both endpoints.
- `ChartServiceImplTest` — raw vs. downsampled history, empty data, weekly aggregation with rate from capacity, peak/quiet selection (including the business-hours filter), unknown-capacity fallback, and input validation (blank/invalid `roomId`, non-positive `hours`/`weeks`).
- Full backend suite green: 130 tests.

Closes #199
