### PR TITLE
docs: add reference docs for the sensor module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,11 @@ docker/seed.py
 
 ### Local secrets ###
 docker/.env
+
+### Python (raspberry/) ###
+.venv/
+__pycache__/
+*.pyc
+
+### macOS ###
+.DS_Store

--- a/raspberry/docs/README.md
+++ b/raspberry/docs/README.md
@@ -1,0 +1,33 @@
+# OccuPi: Sensor (Raspberry Pi)
+
+Software, die auf dem Raspberry Pi läuft: sie konfiguriert den TI-mmWave-Radar, liest
+dessen People-Tracking-Frames über UART und schickt die Belegungszahl ans Backend.
+
+## Datenpipeline
+
+```
+TI IWR6843 AOP ──UART──▶ Raspberry Pi ──STOMP/WebSocket──▶ Spring Boot ──▶ InfluxDB ──▶ React
+   (Radar)              (dieses Verzeichnis)                  (Backend)
+```
+
+1. `sensor/receiver.py` sendet beim Start den Chirp-Config an den Sensor (CFG-Port) und
+   parst danach die binären Frames vom DATA-Port (`read_frame()`).
+2. `main.py` liest pro Frame die Personenzahl, legt sie in eine Queue und lässt den
+   `sender/` (STOMP) sie ans Backend pushen. Optional rendert `visualizer/` live mit.
+3. Mit `USE_MOCK = True` in `main.py` läuft alles ohne Sensor gegen `mock_data.py`.
+
+## Diese Doku
+
+| Datei | Inhalt |
+|---|---|
+| [hardware.md](hardware.md) | Sensor, Firmware, Overhead-Montage, UART-Ports |
+| [radar-physics.md](radar-physics.md) | FMCW-Grundlagen (Range, Doppler, Winkel) und warum radial ≠ lateral |
+| [data-format.md](data-format.md) | UART-Ausgabeformat (TLV-Frames), das `receiver.py` dekodiert |
+| [config-reference.md](config-reference.md) | Der aktive Chirp-Config Zeile für Zeile + abgeleitete Systemwerte |
+| [decisions.md](decisions.md) | Setup-/Architektur-Entscheidungen (z. B. Wand → Overhead) |
+
+## Code-Einstieg
+- Frame-Parsing: `sensor/receiver.py` → `read_frame()`
+- Hauptloop & Throttling: `main.py`
+- Ports / Grenzen / Visualizer-Boundary: `config.py`
+- Live-Visualisierung: `visualizer/visualizer.py`

--- a/raspberry/docs/config-reference.md
+++ b/raspberry/docs/config-reference.md
@@ -1,0 +1,73 @@
+# Chirp-Config-Referenz
+
+Erklärt den **aktiven** Config, den `receiver.py` an den Sensor sendet:
+`chirp_configs/pt_6843_3d_aop_overhead_3m_radial_staticRetention.cfg` (TI-Overhead-Demo, für
+unsere Deckenmontage). Gesetzt in `receiver.py:CONFIG_FILE`.
+
+> Parameter folgen der mmWave-SDK-Konvention.
+
+## Abgeleitete Systemwerte
+
+```
+profileCfg 0 61.2 60.00 17.00 50 131586 0 55.27 1 64 2000.00 2 1 36
+frameCfg   0 2 112 0 120.00 1 0
+```
+
+| Größe | Wert | Herleitung |
+|---|---|---|
+| Startfrequenz | 61.2 GHz | profileCfg |
+| Chirp-Slope | 55.27 MHz/µs | profileCfg |
+| Genutzte Bandbreite | ≈ 1.77 GHz | 64 Samples / 2000 ksps = 32 µs × Slope |
+| **Range-Auflösung** | **≈ 8.5 cm** | c / (2·B) |
+| Wellenlänge λ | ≈ 4.9 mm | c / f |
+| Chirp-Periode | 110 µs | idle 60 + ramp 50 |
+| **Frame-Periode** | 120 ms → **≈ 8.3 fps** | frameCfg |
+
+> ⚠️ **Stale-Kommentare:** `main.py`/`visualizer.py` sprechen noch von „55 ms/Frame, ~18 fps"
+> (Wand-Config). Dieser Overhead-Config liefert nur **~8 fps**, unter dem
+> `VISUALIZER_MAX_FPS=10`-Cap; das Throttle feuert also nicht. Bei Gelegenheit angleichen.
+
+## Sensor-Frontend (SDK)
+| Zeile | Bedeutung |
+|---|---|
+| `channelCfg 15 7 0` | 4 RX (0b1111), 3 TX (0b111) → 12 virtuelle Kanäle |
+| `dfeDataOutputMode 1` | frame-basierte Ausgabe |
+| `adcCfg` / `adcbufCfg` | ADC-Format & -Puffer |
+
+## Detection-Layer
+| Zeile | Bedeutung |
+|---|---|
+| `chirpCfg 0/1/2` | je ein TX pro Chirp (TDM-MIMO) |
+| `dynamicRACfarCfg` / `staticRACfarCfg` | CFAR-Schwellen für bewegte / statische Punkte |
+| `fineMotionCfg -1 1 2.0 10 2` | hält fein-bewegte (sitzende) Personen in der Detektion |
+| `fovCfg -1 64.0 64.0` | Sichtfeld ±64° |
+
+## Tracker-Layer
+| Zeile | Wert | Bedeutung |
+|---|---|---|
+| `boundaryBox` | `-4 4 -4 4 -0.5 3` | Tracking-Volumen, symmetrisch um den Sensor |
+| `staticBoundaryBox` | `-3 3 -3 3 -0.5 3` | Zone, in der statische Ziele überleben |
+| `presenceBoundaryBox` | `-4 4 -4 4 0.5 2.5` | Zone für die Presence-Indication |
+| `sensorPosition` | `2.9 0 90` | **Höhe 2.9 m, 90° Tilt**, muss zur Montage passen |
+| `maxAcceleration` | `1 0.1 1` | max. Beschleunigung [X Y Z] m/s² (s. Hinweis) |
+| `gatingParam` / `stateParam` / `allocationParam` | … | Track-Assoziation / -Lebenszyklus / -Allokation |
+| `trackingCfg 1 4 800 20 37 33 120 1` | … | GTrack-Grundparameter |
+
+> ⚠️ **`maxAcceleration 1 0.1 1`** ist der TI-Factory-Wert und wirkt für eine zentrale
+> Deckenmontage unintuitiv (Y niedrig, Z hoch), obwohl in der Höhe Z kaum Beschleunigung
+> auftritt. Der frühere Entwurf in `AOP_6m_default.cfg` nutzte `0.5 0.5 0.1` (X/Y symmetrisch,
+> Z niedrig), passend zur Overhead-Geometrie. Kandidat zum Nachtunen, falls laterale Tracks
+> träge wirken (Mensch beschleunigt ~0.5–2 m/s²).
+
+## sensorPosition vs. echte Montagehöhe
+`receiver.py` transformiert die Punktwolke mit Höhe+Tilt **aus dieser Zeile**. Aktiver Config:
+**2.9 m**; frühere Messung (`AOP_6m_default.cfg`-Entwurf): **2.2 m**. Vor dem Verlassen auf die
+z-Werte abgleichen, sonst ist die Punktwolken-Höhe um die Differenz verschoben.
+
+## Weitere AOP-Configs in `chirp_configs/`
+| Datei | Unterschied |
+|---|---|
+| `…aop_overhead_3m_radial_staticRetention.cfg` | **aktiv**, mit Static-Retention (sitzende Personen) |
+| `…aop_overhead_3m_radial.cfg` | Overhead ohne Static-Retention |
+| `…aop_overhead_3m_radial_low_bw.cfg` | geringere Bandbreite (weniger Last/Auflösung) |
+| `AOP_6m_default.cfg`, `AOP_9m_sensitive.cfg`, `AOP_overhead_staticRetention.cfg` | ältere/eigene Tuning-Varianten (Wand + Overhead) |

--- a/raspberry/docs/data-format.md
+++ b/raspberry/docs/data-format.md
@@ -1,0 +1,84 @@
+# UART-Ausgabeformat (TLV-Frames)
+
+Das Binärformat, das der Sensor über den DATA-Port schickt und das
+`sensor/receiver.py` → `read_frame()` dekodiert. Identisch für *normales* und *Overhead*
+3D People Tracking (beide nutzen denselben mmW-Demo-/GTrack-Output).
+
+> Alle Feldlayouts unten sind gegen `receiver.py` gegengeprüft.
+
+## Frame-Aufbau
+
+```
+[ Magic Word (8 B) ][ Frame Header (32 B) ][ TLV 1 ][ TLV 2 ] … [ TLV N ]
+```
+
+- **Magic Word**: `02 01 04 03 06 05 08 07` (`receiver.py:MAGIC_WORD`). Der Parser liest
+  byteweise, bis dieses 8-Byte-Fenster passt. So findet er den Frame-Anfang wieder.
+- **Frame Header** (32 B, 8 × `uint32`, little-endian → `struct '8I'`):
+
+  | Feld | Typ | Bedeutung |
+  |---|---|---|
+  | version | uint32 | Firmware-Version |
+  | totalPacketLen | uint32 | Gesamtlänge des Frames in Bytes |
+  | platform | uint32 | Chip-Platform |
+  | frameNumber | uint32 | fortlaufende Frame-Nummer |
+  | timeCpuCycles | uint32 | Zeitstempel (CPU-Cycles) |
+  | numDetectedObj | uint32 | Anzahl Punkte in der Punktwolke |
+  | numTLVs | uint32 | Anzahl folgender TLVs |
+  | subFrameNumber | uint32 | Subframe-Index |
+
+- **TLV-Header** (je 8 B): `type` (uint32) + `length` (uint32, Payload-Bytes).
+
+## TLV-Typen
+
+| Typ | Name | Von `receiver.py` genutzt |
+|---|---|---|
+| `1010` | Target Object List | ✅ → Personen-Tracks |
+| `1011` | Target Index | ⬜ übersprungen |
+| `1012` | Target Height | ⬜ übersprungen |
+| `1020` | Point Cloud (compressed) | ✅ → Punktwolke |
+| `1021` | Presence Indication | ⬜ übersprungen (s. u.) |
+
+### `1020`: Point Cloud
+Ein **Unit-Header** (5 × `float` = 20 B), dann N komprimierte Punkte à 8 B:
+
+```
+Header:  elevationUnit, azimuthUnit, dopplerUnit, rangeUnit, snrUnit   (5×float)
+Punkt:   elevation:int8  azimuth:int8  doppler:int16  range:uint16  snr:uint16   → struct '2bhHH'
+```
+
+`N = (length − 20) / 8`. `receiver.py` multipliziert jeden Rohwert mit seinem Unit, rechnet
+Sphärik → Kartesisch und rotiert dann um Montageneigung plus Montagehöhe, damit die Punkte im
+selben Raum-Frame liegen wie die Tracks (Boden = z 0, Sensor bei z = `SENSOR_HEIGHT_M`):
+
+```
+x   = r·cos(elev)·sin(azim)
+y_r = r·cos(elev)·cos(azim)        z_r = r·sin(elev)
+y   = y_r·cosTilt + z_r·sinTilt
+z   = SENSOR_HEIGHT_M + z_r·cosTilt − y_r·sinTilt
+```
+
+`SENSOR_HEIGHT_M` / Tilt kommen aus `sensorPosition` im Chirp-Config (`_read_sensor_mounting()`).
+
+### `1010`: Target Object List
+**112 Bytes pro Target** (`receiver.py:TRACK_SIZE_BYTES = 112`):
+
+```
+tid:uint32 | posX,posY,posZ:float | velX,velY,velZ:float | accX,accY,accZ:float
+          | errorCov[16]:float | g:float (gating gain) | confidenceLevel:float
+```
+
+`receiver.py` liest pro Target nur die **ersten 28 B** (`struct 'I6f'` → tid + pos + vel) und
+überspringt den Rest (Beschleunigung, Fehlerkovarianz, Gain, Confidence). Anzahl Targets =
+`length / 112`.
+
+### `1021`: Presence Indication
+Vorhanden, aber aktuell **ungenutzt**: fällt in `receiver.py` in den generischen
+„Payload lesen & verwerfen"-Zweig. Kandidat für eine spätere reine Anwesenheitserkennung
+(ohne vollen Track).
+
+## Robustheit beim Parsen
+`receiver.py` validiert jeden Frame gegen Plausibilitätsgrenzen (`MAX_TLVS`, `MAX_TLV_BYTES`,
+`MAX_FRAME_BYTES`). Bei unplausiblen Werten oder unvollständigen Reads (typisch nach Byte-Verlust
+durch Serial-Buffer-Overflow) leert `_resync()` den Input-Buffer und setzt auf das nächste Magic
+Word neu auf, statt blockierend weiterzulesen.

--- a/raspberry/docs/decisions.md
+++ b/raspberry/docs/decisions.md
@@ -1,0 +1,33 @@
+# Entscheidungen (ADR-light)
+
+Kurze Logbuch-Einträge zu Setup-/Architektur-Entscheidungen, bewusst knapp, als
+institutionelles Gedächtnis (auch für KI-Kontext).
+
+---
+
+## 1. Wand-Montage → Overhead-Montage (GELÖST)
+
+**Kontext.** Ursprünglich hing der Sensor an der **Wand** (normales 3D People Tracking, kleiner
+Downtilt). Im Visualizer trackte der Sensor **radial** laufende Personen (auf ihn zu/weg) präzise;
+bei **lateraler** Bewegung (seitlich, konstanter Abstand) blieb der Track-Kreis fast stehen.
+
+**Ursache.** Zwei Dinge greifen ineinander:
+- **Physik:** Doppler misst nur die **radiale** Geschwindigkeit → laterale Bewegung landet im
+  Zero-Doppler-Bin und sieht fast statisch aus (siehe [radar-physics.md](radar-physics.md)).
+- **Tracker-Tuning:** sehr konservatives `maxAcceleration 0.1` ließ dem Kalman-Filter kaum
+  laterale Geschwindigkeitsänderung → der Track „coastete" und blieb stehen.
+
+**Sackgasse.** Reines Nachtunen am Wand-Setup (`maxAcceleration` 0.1 → 0.4, CFAR-Schwellen)
+brachte nur graduelle Besserung. Das Grundproblem blieb: laterale Bewegung ist am Wand-Sensor
+radial unsichtbar.
+
+**Entscheidung.** Umstieg auf **Overhead-/Deckenmontage** mit der **Overhead 3D People
+Tracking**-Firmware + zugehörigem Config (`pt_6843_3d_aop_overhead_3m_radial_staticRetention.cfg`).
+
+**Warum das funktioniert.** Senkrecht von oben sind Personen gut separierbare „Blobs", und keine
+radiale Achse zeichnet sich aus, auf der laterale Bewegung verschwände. Jede Geh-Richtung zählt
+gleich. `fineMotionCfg` + Static-Retention halten zusätzlich sitzende Personen, das macht die
+Belegungszählung (unser Ziel) robust.
+
+**Status.** Gelöst. Aktiver Pfad: `receiver.py:CONFIG_FILE` → Overhead-Config; `config.py`
+Boundary symmetrisch `-4..4`; `receiver.py` rotiert die Punktwolke mit Höhe+Tilt in den Raum-Frame.

--- a/raspberry/docs/hardware.md
+++ b/raspberry/docs/hardware.md
@@ -1,0 +1,33 @@
+# Hardware & Montage
+
+## Sensor
+- **TI IWR6843 AOP**: 60-GHz-mmWave-Radar, *Antenna-on-Package* (Antennen im Chip-Package).
+- 3 TX × 4 RX → 12 virtuelle Kanäle (TDM-MIMO).
+- IWR6843-AOP-EVM, am Raspberry Pi über die zwei UART-Bridges des Boards angebunden.
+
+## Firmware
+- Geflasht: **Overhead 3D People Tracking**-Demo (IWR6843-AOP-Prebuilt-Binary).
+- Der gesendete Chirp-Config **muss zur geflashten Firmware passen**: bei uns die
+  **Overhead**-Variante, nicht das normale Wand-People-Tracking (siehe [decisions.md](decisions.md)).
+
+## Montage (Overhead / Decke)
+- Sensor blickt aus der Raummitte **senkrecht nach unten**.
+- Aktiver Config: `sensorPosition 2.9 0 90` → 2.9 m Höhe, 90° Tilt.
+- `receiver.py` rotiert die Punktwolke mit **Höhe + Tilt aus dieser Zeile** in den Raum-Frame
+  (`_read_sensor_mounting()`), Boden = z 0. **Der Wert muss der echten Montagehöhe entsprechen**,
+  sonst verschiebt sich die z-Achse. ⚠️ Aktiver Config sagt 2.9 m, eine frühere Messung 2.2 m;
+  vor dem Verlassen auf z-Werte abgleichen (siehe [config-reference.md](config-reference.md)).
+- Boundary-Boxen symmetrisch um den Sensor (`-4 4 -4 4`), passend zu `BOUNDARY_*` in `config.py`.
+
+## UART (aus `config.py`)
+| Port | Variable | Baud | Zweck |
+|---|---|---|---|
+| CFG  | `SERIAL_CFG_PORT`  | 115200 | Chirp-Config senden, Quittungen lesen |
+| DATA | `SERIAL_DATA_PORT` | 921600 | Binär-Frames (TLV) lesen |
+
+Per Env überschreibbar (z. B. `SERIAL_CFG_PORT=COM3` unter Windows).
+
+## Flashen (Kurz)
+SOP-Pins in den Flash-Mode → mit TI **UniFlash** das Overhead-People-Tracking-Binary auf den
+IWR6843 AOP flashen → zurück in den Functional-Mode, Board neu starten. Danach sendet
+`receiver.py` beim Start automatisch den Config (`send_config()`).

--- a/raspberry/docs/radar-physics.md
+++ b/raspberry/docs/radar-physics.md
@@ -1,0 +1,65 @@
+# Radar-Physik: FMCW, Range, Doppler, Winkel
+
+Wie der TI **IWR6843 AOP** (60-GHz-mmWave) misst. Allgemeine Grundlagen. Die konkreten, aus
+unserem Config berechneten Systemwerte stehen in [config-reference.md](config-reference.md).
+
+## FMCW-Prinzip
+
+FMCW = *Frequency Modulated Continuous Wave*. Der Sensor sendet dauerhaft (kein Puls-Radar)
+einen **Chirp**: eine Frequenzrampe (Sägezahn). Vorteil: geringe Spitzenleistung, klein,
+günstig.
+
+### Entfernung (Range)
+Das reflektierte Signal kommt zeitversetzt zurück. Da die Sendefrequenz inzwischen
+weitergewandert ist, entsteht eine Differenzfrequenz zwischen TX und RX, die **Beat-Frequenz**,
+proportional zur Entfernung:
+
+```
+R = (c · f_beat) / (2 · Slope)
+```
+
+Die **Range-Auflösung** hängt nur von der genutzten Bandbreite ab: `ΔR = c / (2·B)`.
+
+### Geschwindigkeit (Doppler)
+Der Sensor misst sie über die **Phasendifferenz zwischen aufeinanderfolgenden Chirps**
+(Slow-Time-FFT). Bewegt sich ein Ziel zwischen zwei Chirps um Bruchteile der Wellenlänge
+(λ ≈ 4.9 mm bei 60 GHz), dreht sich die Phase des Beat-Signals messbar. FFT über M Chirps ergibt
+die Range-Doppler-Map, danach trennt **CFAR** Ziele vom Rauschen.
+
+> Doppler misst nur die **radiale** Geschwindigkeitskomponente (auf den Sensor zu oder weg).
+> Tangentiale (laterale) Bewegung erzeugt fast keine Phasendrehung, Doppler ≈ 0. Diese radiale
+> Beschränkung macht die Montage-Geometrie entscheidend (siehe [decisions.md](decisions.md)).
+
+### Winkel (Azimut/Elevation)
+Über das Antennenarray: 3 TX × 4 RX = 12 virtuelle Antennen (TDM-MIMO, daher die drei
+`chirpCfg`-Zeilen mit TX-Masken 1/2/4). Phasenunterschiede zwischen den virtuellen Antennen
+ergeben den Einfallswinkel. **Die Winkelauflösung ist um Größenordnungen gröber als die
+Range-Auflösung.** Bei einigen Metern Abstand bedeuten wenige Grad Unsicherheit schnell
+30–50 cm laterale Ungenauigkeit.
+
+## Konsequenz für die Positionsschätzung
+
+| Komponente | Quelle | Güte |
+|---|---|---|
+| Radiale Entfernung | Beat-Frequenz | cm-genau (Range-Auflösung, siehe config-reference) |
+| Radiale Geschwindigkeit | Doppler (Phase über Chirps) | fein (≈ 0.1 m/s), aber **nur radial** |
+| Lateraler Ort | Winkelschätzung (Array) | grob, verrauscht |
+
+Der Sensor löst radiale Bewegung cm-genau auf; die laterale Position kommt nur aus der groben
+Winkelschätzung. Der **Tracker** (GTrack, Kalman-basiert) glättet daraus Tracks. Wie aggressiv
+er laterale Sprünge zulässt, steuern `maxAcceleration`, `gatingParam` und `stateParam` (siehe
+[config-reference.md](config-reference.md)).
+
+## Pipeline im Sensor (Layer)
+
+1. **Detection-Layer:** Range-/Doppler-/Angle-FFT + CFAR erzeugen die **Punktwolke**
+   (TLV `1020`). Getrennte Pfade für bewegte (`dynamicRACfarCfg`) und statische
+   (`staticRACfarCfg`) Punkte.
+2. **Tracker-Layer:** GTrack gruppiert Punkte zu **Targets** (TLV `1010`) und vergibt
+   stabile Track-IDs.
+
+Beide Layer steuert der Chirp-Config; ihr Ausgabeformat beschreibt
+[data-format.md](data-format.md).
+
+## Quellen
+- FMCW-Grundlagen-Videos (Doppler / Range-Doppler-Map)


### PR DESCRIPTION
## What

Adds reference documentation for the Raspberry Pi sensor module (#211). Until now the
`raspberry/` code had no written reference for the hardware, the radar physics, or the
UART data format — knowledge that only lived in people's heads and in the TI tooling.
This collects it under `raspberry/docs/` as a small, linked doc set (in German, matching
the rest of the in-repo sensor notes).

## Changes

- **`raspberry/docs/README.md`** — index: data pipeline diagram, how the pieces connect
  (`receiver.py` → `main.py` → `sender/`), and a table linking the other docs plus code
  entry points.
- **`raspberry/docs/hardware.md`** — TI IWR6843 AOP, firmware, overhead mounting, UART ports.
- **`raspberry/docs/radar-physics.md`** — FMCW basics (range, Doppler, angle) and why radial ≠ lateral resolution.
- **`raspberry/docs/data-format.md`** — the UART TLV frame format that `receiver.py` decodes.
- **`raspberry/docs/config-reference.md`** — the active chirp config line by line, plus the derived system values.
- **`raspberry/docs/decisions.md`** — setup/architecture decisions (e.g. wall → overhead mount).
- **`.gitignore`** — section for Python venv/cache files (`__pycache__/`, `.venv/`, etc.).

## Validation

- Docs-only change, no code touched — backend/frontend builds are unaffected.
- Relative links between the docs and the index table resolve (`hardware.md`, `radar-physics.md`, `data-format.md`, `config-reference.md`, `decisions.md`).

Closes #211
