### PR TITLE
add: secure room CRUD endpoints to admin role #219

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `dialout` group, so on the Pi a plain `docker compose up` with `SENSOR_MODE=real` streams
   live occupancy for room 137 (#201).
 
+### Security
+- Room create, update and delete (`POST`/`PUT`/`DELETE /api/rooms`) now require the
+  Keycloak `admin` realm role, enforced with method security (`@PreAuthorize`) on the
+  controller on top of the existing URL rules. Reads (`GET`) stay open to any
+  authenticated user (#219).
+
 ## [0.1.0] - 2026-06-20
 
 First full release. The complete OccuPi system now runs live on the HdM server:

--- a/backend/src/main/java/com/occupi/feature/authentication/SecurityConfig.java
+++ b/backend/src/main/java/com/occupi/feature/authentication/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
@@ -21,13 +22,18 @@ import org.springframework.security.web.SecurityFilterChain;
  * <ul>
  *   <li>{@code /ws/**} — public (Raspberry Pi STOMP ingestion)</li>
  *   <li>OpenAPI / Swagger UI — public</li>
- *   <li>Room mutations (POST/PUT/DELETE {@code /api/rooms/**}) — {@code ADMIN} only</li>
+ *   <li>Room mutations (POST/PUT/DELETE {@code /api/rooms/**}) — {@code admin} role only,
+ *       enforced both here at the URL level and via {@code @PreAuthorize} on the controller</li>
  *   <li>everything else — any authenticated user with a valid JWT</li>
  * </ul>
+ *
+ * {@link EnableMethodSecurity} turns on the {@code @PreAuthorize} checks used by the
+ * room write endpoints (#219).
  */
 @Profile("!test & !dev")
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     @Bean

--- a/backend/src/main/java/com/occupi/feature/room/RoomController.java
+++ b/backend/src/main/java/com/occupi/feature/room/RoomController.java
@@ -4,6 +4,7 @@ import com.occupi.feature.room.dto.RoomRequest;
 import com.occupi.feature.room.dto.RoomResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,8 +27,8 @@ import java.util.List;
  * DELETE /api/rooms/{id}   → delete room    (admin only)
  * </pre>
  *
- * Note: admin-only enforcement (role checks) is wired in with the authentication
- * feature (#20 / #34). Until then these endpoints follow the global SecurityConfig.
+ * Write operations are restricted to the Keycloak {@code admin} realm role via
+ * {@code @PreAuthorize} (method security); reads stay open to any authenticated user (#219).
  */
 @RestController
 @RequestMapping("/api/rooms")
@@ -52,18 +53,21 @@ public class RoomController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<RoomResponse> createRoom(@RequestBody RoomRequest request) {
         RoomResponse created = roomService.createRoom(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<RoomResponse> updateRoom(@PathVariable String id,
                                                    @RequestBody RoomRequest request) {
         return ResponseEntity.ok(roomService.updateRoom(id, request));
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteRoom(@PathVariable String id) {
         roomService.deleteRoom(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/test/java/com/occupi/feature/authentication/SecurityConfigTest.java
+++ b/backend/src/test/java/com/occupi/feature/authentication/SecurityConfigTest.java
@@ -17,8 +17,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
@@ -75,5 +77,43 @@ class SecurityConfigTest {
                         .content("{\"roomId\":\"room-1\",\"name\":\"X\",\"building\":\"M\",\"floor\":1,\"capacity\":10}")
                         .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
                 .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("rejects a room update with 403 when the token lacks ADMIN")
+    void updateRoom_nonAdmin_returns403() throws Exception {
+        mvc.perform(put("/api/rooms/room-1")
+                        .contentType("application/json")
+                        .content("{\"roomId\":\"room-1\",\"name\":\"X\",\"building\":\"M\",\"floor\":1,\"capacity\":10}")
+                        .with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("allows a room update for an ADMIN token")
+    void updateRoom_admin_returns200() throws Exception {
+        when(roomService.updateRoom(any(), any()))
+                .thenReturn(new RoomResponse("room-1", "X", "M", 1, 10));
+
+        mvc.perform(put("/api/rooms/room-1")
+                        .contentType("application/json")
+                        .content("{\"roomId\":\"room-1\",\"name\":\"X\",\"building\":\"M\",\"floor\":1,\"capacity\":10}")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("rejects a room deletion with 403 when the token lacks ADMIN")
+    void deleteRoom_nonAdmin_returns403() throws Exception {
+        mvc.perform(delete("/api/rooms/room-1").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("allows a room deletion for an ADMIN token")
+    void deleteRoom_admin_returns204() throws Exception {
+        mvc.perform(delete("/api/rooms/room-1")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isNoContent());
     }
 }

--- a/backend/src/test/java/com/occupi/feature/room/RoomControllerMethodSecurityTest.java
+++ b/backend/src/test/java/com/occupi/feature/room/RoomControllerMethodSecurityTest.java
@@ -1,0 +1,101 @@
+package com.occupi.feature.room;
+
+import com.occupi.feature.room.dto.RoomResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies the {@code @PreAuthorize} method security on {@link RoomController} in
+ * isolation: the imported filter chain permits every request at the URL level, so a
+ * 403 can only come from the controller's method-level role check — not from the
+ * production URL rules in {@code SecurityConfig}. This keeps the test honest about
+ * what enforces admin-only access (#219).
+ */
+@WebMvcTest(RoomController.class)
+@Import(RoomControllerMethodSecurityTest.MethodSecurityConfig.class)
+@DisplayName("RoomController method security (@PreAuthorize)")
+class RoomControllerMethodSecurityTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private RoomService roomService;
+
+    // Satisfies OAuth2ResourceServerAutoConfiguration; the test injects auth via jwt().
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    private static final String BODY =
+            "{\"roomId\":\"room-1\",\"name\":\"X\",\"building\":\"M\",\"floor\":1,\"capacity\":10}";
+
+    @Test
+    @DisplayName("blocks a create for a non-admin token (403)")
+    void createRoom_nonAdmin_returns403() throws Exception {
+        mvc.perform(post("/api/rooms").contentType("application/json").content(BODY).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("allows a create for an admin token (201)")
+    void createRoom_admin_returns201() throws Exception {
+        when(roomService.createRoom(any())).thenReturn(new RoomResponse("room-1", "X", "M", 1, 10));
+
+        mvc.perform(post("/api/rooms").contentType("application/json").content(BODY)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @DisplayName("blocks an update for a non-admin token (403)")
+    void updateRoom_nonAdmin_returns403() throws Exception {
+        mvc.perform(put("/api/rooms/room-1").contentType("application/json").content(BODY).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("blocks a delete for a non-admin token (403)")
+    void deleteRoom_nonAdmin_returns403() throws Exception {
+        mvc.perform(delete("/api/rooms/room-1").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Method security enabled over a deliberately permissive URL layer, so the only
+     * thing that can deny a request is {@code @PreAuthorize} on the controller.
+     */
+    @TestConfiguration
+    @EnableWebSecurity
+    @EnableMethodSecurity
+    static class MethodSecurityConfig {
+
+        @Bean
+        SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## What

Restricts the room write endpoints to the Keycloak `admin` realm role (#219):

- `POST /api/rooms`, `PUT /api/rooms/{id}`, `DELETE /api/rooms/{id}` now require `admin`.
- `GET /api/rooms` and `GET /api/rooms/{id}` stay open to any authenticated user.

## How

- `@EnableMethodSecurity` on `SecurityConfig` and `@PreAuthorize("hasRole('ADMIN')")` on the three write methods in `RoomController`.
- The existing URL rules in `SecurityConfig` (`requestMatchers(...).hasRole("ADMIN")`) are kept as a first layer — method security is added on top, in line with the issue ("this issue only adds authorization").

## Note on the role name

The issue text suggests `hasRole('admin')` (lowercase). `KeycloakRealmRoleConverter` maps each realm role to `ROLE_<UPPERCASE>`, so the Keycloak `admin` role becomes the authority `ROLE_ADMIN`. The check therefore uses `hasRole('ADMIN')` — consistent with the existing URL rules and the converter's own test. Lowercase `'admin'` would look for `ROLE_admin` and never match, locking admins out. (Task 3 verified: the converter is already correct, no change needed.)

## Tests

- `SecurityConfigTest` — extended with PUT and DELETE: non-admin → 403, admin → 200/204 (POST was already covered).
- `RoomControllerMethodSecurityTest` (new) — proves `@PreAuthorize` enforces admin-only in isolation: the imported filter chain permits every request at the URL level, so a 403 can only come from the method-level check. This test fails if the `@PreAuthorize` annotations are removed.
- Full backend suite green: 138 tests.

Closes #219
