### PR TITLE
add: real-time point cloud & target visualizer for the sensor #107

### DIFF
--- a/raspberry/chirp_configs/aop_overhead_3m_radial.cfg
+++ b/raspberry/chirp_configs/aop_overhead_3m_radial.cfg
@@ -1,0 +1,43 @@
+% SDK Parameters
+% See the SDK user's guide for more information
+% "C:\ti\mmwave_sdk_[VER]\docs\mmwave_sdk_user_guide.pdf"
+sensorStop
+flushCfg
+dfeDataOutputMode 1
+channelCfg 15 7 0
+adcCfg 2 1
+adcbufCfg -1 0 1 1 1
+lowPower 0 0
+
+% Detection Layer Parameters
+% See the Detection Layer Tuning Guide for more information
+% "<RADAR_TOOLBOX_INSTALL_DIR>\source\ti\examples\People_Tracking\docs\IWR6843_People_Tracking_PDFs\3D_people_tracking_detection_layer_tuning_guide.pdf"
+profileCfg 0 61.2 60.00 17.00 50 328965 0 55.27 1 64 2000.00 2 1 36
+chirpCfg 0 0 0 0 0 0 0 1
+chirpCfg 1 1 0 0 0 0 0 2
+chirpCfg 2 2 0 0 0 0 0 4
+frameCfg 0 2 224 0 120.00 1 0
+dynamicRACfarCfg -1 10 1 1 1 8 8 6 4 4.00 6.00 0.50 1 1
+staticRACfarCfg -1 4 4 2 2 8 16 4 6 6.00 13.00 0.50 0 0
+dynamicRangeAngleCfg -1 7.000 0.0010 2 0
+dynamic2DAngleCfg -1 5 1 1 1.00 15.00 2
+staticRangeAngleCfg -1 0 1 1
+antGeometry0 -1 -1 0 0 -3 -3 -2 -2 -1 -1 0 0
+antGeometry1 -1 0 -1 0 -3 -2 -3 -2 -3 -2 -3 -2
+antPhaseRot 1 -1 1 -1 1 -1 1 -1 1 -1 1 -1
+fovCfg -1 64.0 64.0
+compRangeBiasAndRxChanPhase 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0
+
+% Tracker Layer Parameters
+% See the Tracking Layer Tuning Guide for more information
+% "C:\ti\radar_toolbox_[VER]\source\ti\examples\People_Tracking\docs\IWR6843_People_Tracking_PDFs\3D_people_tracking_tracker_layer_tuning_guide.pdf"
+staticBoundaryBox -3 3 -3 3 -0.5 3
+boundaryBox -4 4 -4 4 -0.5 3
+sensorPosition 2.9 0 90
+gatingParam 3 2 2 3 4
+stateParam 3 3 6 20 3 1000
+allocationParam 20 20 0.05 20 1.5 20
+maxAcceleration 1 0.1 1
+trackingCfg 1 4 800 20 37 33 120 1
+presenceBoundaryBox -4 4 -4 4 0.5 2.5
+sensorStart

--- a/raspberry/chirp_configs/pt_6843_3d_aop_overhead_3m_radial_low_bw.cfg
+++ b/raspberry/chirp_configs/pt_6843_3d_aop_overhead_3m_radial_low_bw.cfg
@@ -1,0 +1,43 @@
+% SDK Parameters
+% See the SDK user's guide for more information
+% "C:\ti\mmwave_sdk_[VER]\docs\mmwave_sdk_user_guide.pdf"
+sensorStop
+flushCfg
+dfeDataOutputMode 1
+channelCfg 15 7 0
+adcCfg 2 1
+adcbufCfg -1 0 1 1 1
+lowPower 0 0
+
+% Detection Layer Parameters
+% See the Detection Layer Tuning Guide for more information
+% "<RADAR_TOOLBOX_INSTALL_DIR>\source\ti\examples\People_Tracking\docs\IWR6843_People_Tracking_PDFs\3D_people_tracking_detection_layer_tuning_guide.pdf"
+profileCfg 0 61.0 60.00 11.00 44 328965 0 9.05 1 64 2000.00 2 1 40
+chirpCfg 0 0 0 0 0 0 0 1
+chirpCfg 1 1 0 0 0 0 0 2
+chirpCfg 2 2 0 0 0 0 0 4
+frameCfg 0 2 224 0 110.00 1 0
+dynamicRACfarCfg -1 2 39 1 1 4 8 4 4 4.00 6.00 0.50 1 1
+staticRACfarCfg -1 1 39 2 2 8 16 4 6 6.00 13.00 0.50 0 0
+dynamicRangeAngleCfg -1 7.000 0.0010 2 0
+dynamic2DAngleCfg -1 5 1 1 1.00 15.00 2
+staticRangeAngleCfg -1 0 1 1
+antGeometry0 -1 -1 0 0 -3 -3 -2 -2 -1 -1 0 0
+antGeometry1 -1 0 -1 0 -3 -2 -3 -2 -3 -2 -3 -2
+antPhaseRot 1 -1 1 -1 1 -1 1 -1 1 -1 1 -1
+fovCfg -1 64.0 64.0
+compRangeBiasAndRxChanPhase 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0
+
+% Tracker Layer Parameters
+% See the Tracking Layer Tuning Guide for more information
+% "C:\ti\radar_toolbox_[VER]\source\ti\examples\People_Tracking\docs\IWR6843_People_Tracking_PDFs\3D_people_tracking_tracker_layer_tuning_guide.pdf"
+staticBoundaryBox -3 3 -3 3 -0.5 3
+boundaryBox -4 4 -4 4 -0.5 3
+sensorPosition 2.9 0 90
+gatingParam 3 2 2 3 4
+stateParam 3 3 6 20 3 50
+allocationParam 20 20 0.05 7 1.5 20
+maxAcceleration 1 1 1
+trackingCfg 1 4 800 20 37 33 110 0
+presenceBoundaryBox -4 4 -4 4 0.5 2.5
+sensorStart

--- a/raspberry/chirp_configs/pt_6843_3d_aop_overhead_3m_radial_staticRetention.cfg
+++ b/raspberry/chirp_configs/pt_6843_3d_aop_overhead_3m_radial_staticRetention.cfg
@@ -1,0 +1,44 @@
+% SDK Parameters
+% See the SDK user's guide for more information
+% "C:\ti\mmwave_sdk_[VER]\docs\mmwave_sdk_user_guide.pdf"
+sensorStop
+flushCfg
+dfeDataOutputMode 1
+channelCfg 15 7 0
+adcCfg 2 1
+adcbufCfg -1 0 1 1 1
+lowPower 0 0
+
+% Detection Layer Parameters
+% See the Detection Layer Tuning Guide for more information
+% "<RADAR_TOOLBOX_INSTALL_DIR>\source\ti\examples\People_Tracking\docs\IWR6843_People_Tracking_PDFs\3D_people_tracking_detection_layer_tuning_guide.pdf"
+profileCfg 0 61.2 60.00 17.00 50 131586 0 55.27 1 64 2000.00 2 1 36
+chirpCfg 0 0 0 0 0 0 0 1
+chirpCfg 1 1 0 0 0 0 0 2
+chirpCfg 2 2 0 0 0 0 0 4
+frameCfg 0 2 112 0 120.00 1 0
+dynamicRACfarCfg -1 10 1 1 1 8 8 6 4 4.00 6.00 0.50 1 1
+staticRACfarCfg -1 4 4 2 2 8 16 4 6 6.00 13.00 0.50 0 0
+dynamicRangeAngleCfg -1 7.000 0.0010 2 0
+dynamic2DAngleCfg -1 5 1 1 1.00 15.00 2
+staticRangeAngleCfg -1 0 1 1
+fineMotionCfg -1 1 2.0 10 2
+antGeometry0 -1 -1 0 0 -3 -3 -2 -2 -1 -1 0 0
+antGeometry1 -1 0 -1 0 -3 -2 -3 -2 -3 -2 -3 -2
+antPhaseRot 1 -1 1 -1 1 -1 1 -1 1 -1 1 -1
+fovCfg -1 64.0 64.0
+compRangeBiasAndRxChanPhase 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0
+
+% Tracker Layer Parameters
+% See the Tracking Layer Tuning Guide for more information
+% "C:\ti\radar_toolbox_[VER]\source\ti\examples\People_Tracking\docs\IWR6843_People_Tracking_PDFs\3D_people_tracking_tracker_layer_tuning_guide.pdf"
+staticBoundaryBox -3 3 -3 3 -0.5 3
+boundaryBox -4 4 -4 4 -0.5 3
+sensorPosition 2.9 0 90
+gatingParam 3 2 2 3 4
+stateParam 3 3 6 40 3 400
+allocationParam 20 20 0.05 20 1.5 20
+maxAcceleration 1 0.1 1
+trackingCfg 1 4 800 20 37 33 120 1
+presenceBoundaryBox -4 4 -4 4 0.5 2.5
+sensorStart

--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -46,3 +46,19 @@ METRICS_INTERVAL = float(os.getenv("METRICS_INTERVAL", "10")) # seconds between 
 # --- WebSocket Reconnect ---
 WS_RECONNECT_DELAY = int(os.getenv("WS_RECONNECT_DELAY", "5"))  # seconds until next try
 WS_MAX_RETRIES     = int(os.getenv("WS_MAX_RETRIES", "0"))  # 0 = infinite retries
+
+# --- Visualizer ---
+# Live matplotlib view of the point cloud and tracked targets. Only used in real
+# (sensor) mode; mock mode never opens it. Off by default so the headless/
+# containerised sensor isn't affected — run with USE_VISUALIZER=true on a Pi or
+# desktop that has a display.
+USE_VISUALIZER     = os.getenv("USE_VISUALIZER", "false").strip().lower() in ("1", "true", "yes")
+# Cap redraws so rendering never starves the serial read loop (sensor sends ~18fps).
+VISUALIZER_MAX_FPS = float(os.getenv("VISUALIZER_MAX_FPS", "10"))
+
+# Floor map boundary (metres). Ceiling mount: the sensor sits in the room centre
+# looking down, so the map is centred on the sensor (origin) and symmetric.
+BOUNDARY_X_MIN = -4
+BOUNDARY_X_MAX = 4
+BOUNDARY_Y_MIN = -4
+BOUNDARY_Y_MAX = 4

--- a/raspberry/main.py
+++ b/raspberry/main.py
@@ -15,6 +15,7 @@ from config import (
     WS_RECONNECT_DELAY, WS_MAX_RETRIES, BACKEND_WS_PATH,
     BACKEND_TLS, BACKEND_TLS_CA,
     SENSOR_MODE, ROOM_ID, MOCK_ROOM_IDS,
+    USE_VISUALIZER, VISUALIZER_MAX_FPS,
 )
 from sensor.receiver import open_ports, send_config, read_frame, CONFIG_FILE
 from sensor.metrics import ThroughputMetrics, start_metrics_monitor
@@ -138,10 +139,28 @@ if __name__ == '__main__':
             log.info("Starting in REAL mode — reading from the mmWave sensor.")
             cfg_port, data_port = open_ports()
             send_config(cfg_port, CONFIG_FILE)
+
+            # The live view pulls in matplotlib, so only import it when actually
+            # enabled — keeps the headless/mock path free of GUI dependencies.
+            visualizer_update = None
+            if USE_VISUALIZER:
+                from visualizer.visualizer import start_visualizer, update as visualizer_update
+                start_visualizer()
+            render_interval = 1.0 / VISUALIZER_MAX_FPS
+            last_render = 0.0
+
             while True:
                 t_start = time.monotonic()
-                frame_num, people_count = read_frame(data_port)
+                frame_num, people_count, point_cloud, targets = read_frame(data_port)
                 enqueue_frame({"frameNum": frame_num, "numDetectedTracks": people_count})
+
+                # Throttled redraw: a full render can take longer than one sensor
+                # frame, and rendering every frame backs up the serial buffer until
+                # it overflows and the parser desyncs.
+                if visualizer_update is not None and t_start - last_render >= render_interval:
+                    visualizer_update(point_cloud, targets)
+                    last_render = t_start
+
                 latency = (time.monotonic() - t_start) * 1000  # ms
                 log.info(f"Frame {frame_num}: Detected {people_count} people | Latency: {latency:.1f}ms")
 

--- a/raspberry/requirements.txt
+++ b/raspberry/requirements.txt
@@ -2,3 +2,5 @@ pyserial==3.5
 stomp.py==8.1.2
 psutil==7.2.2
 certifi==2026.6.17
+matplotlib>=3.8
+numpy>=1.26

--- a/raspberry/sensor/receiver.py
+++ b/raspberry/sensor/receiver.py
@@ -1,3 +1,5 @@
+import math
+
 import serial
 import os
 import logging
@@ -30,6 +32,33 @@ TLV_POINT_CLOUD = 1020
 TLV_TARGET_INDEX = 1011
 TLV_TARGET_HEIGHT = 1012
 
+# Sanity limits: values beyond these mean we are reading garbage after byte
+# loss (serial buffer overflow) and must resync instead of blocking on reads
+MAX_TLVS = 16
+MAX_TLV_BYTES = 16384
+MAX_FRAME_BYTES = 65536
+
+
+def _read_sensor_mounting():
+    """Reads sensorPosition (height, elevation tilt) from the chirp config so the
+    point cloud can be transformed into the same room frame the tracker uses."""
+    try:
+        with open(CONFIG_FILE) as f:
+            for line in f:
+                if line.startswith('sensorPosition'):
+                    vals = line.split()[1:]
+                    return float(vals[0]), math.radians(float(vals[2]))
+    except (OSError, ValueError, IndexError):
+        pass
+    return 0.0, 0.0
+
+
+SENSOR_HEIGHT_M, SENSOR_TILT_RAD = _read_sensor_mounting()
+_COS_TILT = math.cos(SENSOR_TILT_RAD)
+_SIN_TILT = math.sin(SENSOR_TILT_RAD)
+
+# Logging is configured once in main.py; here we only grab the module logger
+# (re-running basicConfig would duplicate every log line — see #104).
 log = logging.getLogger(__name__)
 
 
@@ -66,41 +95,102 @@ def send_config(cfg_port, config_file):
             log.info(f"Sent: {line.strip()} | Response: {response.strip()}")
 
 
+def _resync(data_port, reason: str) -> None:
+    """Drops buffered bytes after a desync so we re-lock on the next magic word."""
+    log.warning(f"Serial desync ({reason}) – flushing input buffer and resyncing.")
+    data_port.reset_input_buffer()
+
+
 # Read the data from the data port, parse the frames, and extract the people count
 def read_frame(data_port):
-    # We read byte by byte until we find the magic word that indicates the start of a frame.
-    # Then we read the header and TLVs to extract the number of detected people.
-    buffer = bytearray()
+    window = bytearray()
     while True:
         byte = data_port.read(1)
-        buffer += byte
-        if buffer[-8:] == MAGIC_WORD:
-            log.debug("Magic word found")
+        if not byte:
+            continue  # read timeout, keep waiting for data
+        window += byte
+        if len(window) > 8:
+            del window[:-8]
+        if window != MAGIC_WORD:
+            continue
 
-            # Empty buffer to save memory
-            buffer = bytearray()
+        log.debug("Magic word found")
+        window.clear()
 
-            # Refer to the User Guide for Frame Structure and Header details
-            header_bytes = data_port.read(32)
-            (version,
-             total_length,
-             platform,
-             frame_num,
-             time_cpu_cycles,
-             num_detected_obj,
-             num_tlvs,
-             sub_frame) = struct.unpack('8I', header_bytes)
+        header_bytes = data_port.read(32)
+        if len(header_bytes) < 32:
+            _resync(data_port, "incomplete frame header")
+            continue
+        (version,
+         total_length,
+         platform,
+         frame_num,
+         time_cpu_cycles,
+         num_detected_obj,
+         num_tlvs,
+         sub_frame) = struct.unpack('8I', header_bytes)
 
-            # Iterate through TLVs and export people count
-            num_targets = 0
-            for _ in range(num_tlvs):
-                tlv_header = data_port.read(8)
-                tlv_type, tlv_length = struct.unpack('2I', tlv_header)
+        if num_tlvs > MAX_TLVS or total_length > MAX_FRAME_BYTES:
+            _resync(data_port, f"implausible header (tlvs={num_tlvs}, frameLength={total_length})")
+            continue
 
-                if tlv_type == TLV_TARGET_LIST:
-                    num_targets = tlv_length // TRACK_SIZE_BYTES
-                    log.debug(f"Detected person: {num_targets} targets")
-                else:
-                    data_port.read(tlv_length)  # advance past payload to stay in sync
-            return frame_num, num_targets
+        num_targets = 0
+        targets = []
+        point_cloud = []
+        corrupted = None
+
+        for _ in range(num_tlvs):
+            tlv_header = data_port.read(8)
+            if len(tlv_header) < 8:
+                corrupted = "incomplete TLV header"
+                break
+            tlv_type, tlv_length = struct.unpack('2I', tlv_header)
+            if tlv_length > MAX_TLV_BYTES:
+                corrupted = f"implausible TLV length {tlv_length} (type {tlv_type})"
+                break
+            payload = data_port.read(tlv_length)
+            if len(payload) < tlv_length:
+                corrupted = f"incomplete TLV payload ({len(payload)}/{tlv_length} bytes)"
+                break
+
+            if tlv_type == TLV_TARGET_LIST:
+                num_targets = tlv_length // TRACK_SIZE_BYTES
+                log.debug(f"Detected persons: {num_targets} targets")
+                for i in range(num_targets):
+                    tid, posX, posY, posZ, velX, velY, velZ = struct.unpack_from(
+                        'I6f', payload, i * TRACK_SIZE_BYTES)
+                    targets.append({
+                        "tid": tid,
+                        "posX": posX, "posY": posY, "posZ": posZ,
+                        "velX": velX, "velY": velY, "velZ": velZ,
+                    })
+
+            elif tlv_type == TLV_POINT_CLOUD:
+                num_points = (tlv_length - 20) // 8
+                elev_unit, azim_unit, dopp_unit, range_unit, snr_unit = struct.unpack_from('5f', payload, 0)
+                for i in range(num_points):
+                    elevation, azimuth, doppler, range_, snr = struct.unpack_from(
+                        '2bhHH', payload, 20 + i * 8)
+                    elev = elevation * elev_unit
+                    azim = azimuth * azim_unit
+                    r    = range_ * range_unit
+                    x   = r * math.cos(elev) * math.sin(azim)
+                    y_r = r * math.cos(elev) * math.cos(azim)
+                    z_r = r * math.sin(elev)
+                    # Rotate by the mounting tilt and add the mounting height so
+                    # points land in the room frame the tracker reports targets
+                    # in (floor = z 0, sensor at z = SENSOR_HEIGHT_M)
+                    y = y_r * _COS_TILT + z_r * _SIN_TILT
+                    z = SENSOR_HEIGHT_M + z_r * _COS_TILT - y_r * _SIN_TILT
+                    point_cloud.append({
+                        "x": x, "y": y, "z": z,
+                        "doppler": doppler * dopp_unit,
+                        "snr": snr * snr_unit,
+                    })
+
+        if corrupted:
+            _resync(data_port, corrupted)
+            continue
+
+        return frame_num, num_targets, point_cloud, targets
 

--- a/raspberry/sensor/receiver.py
+++ b/raspberry/sensor/receiver.py
@@ -9,11 +9,11 @@ import struct
 # Configuration for the AOP 6m sensor
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 RASPBERRY_DIR = str(os.path.dirname(BASE_DIR))
-CONFIG_FILE = os.path.join(RASPBERRY_DIR, "chirp_configs", "AOP_6m_default.cfg")
+CONFIG_FILE = os.path.join(RASPBERRY_DIR, "chirp_configs", "aop_overhead_3m_radial.cfg")
 
 
 # Serial port settings loaded from config.py
-# Override via environment variables if needed for different device than raspberry pi(e.g. SERIAL_CFG_PORT=COM3 on Windows)
+# Override via environment variables if needed for a different device than raspberry pi (e.g. SERIAL_CFG_PORT=COM3 on Windows)
 sys.path.insert(0, RASPBERRY_DIR)
 from config import (
     SERIAL_CFG_PORT, SERIAL_DATA_PORT,
@@ -56,6 +56,20 @@ def _read_sensor_mounting():
 SENSOR_HEIGHT_M, SENSOR_TILT_RAD = _read_sensor_mounting()
 _COS_TILT = math.cos(SENSOR_TILT_RAD)
 _SIN_TILT = math.sin(SENSOR_TILT_RAD)
+
+
+def _rotate(x, y, z):
+    """Rotate sensor-frame coordinates by the mounting elevation tilt. Matches the
+    TI visualizer's eulerRot for a zero azimuth tilt (our overhead mount)."""
+    return x, y * _COS_TILT + z * _SIN_TILT, z * _COS_TILT - y * _SIN_TILT
+
+
+def _to_room_frame(x, y, z):
+    """Position in the room frame: rotate by the tilt, then lift by the mounting
+    height — the same transform the TI tracker applies to point cloud *and* tracks,
+    so circles and points end up in one coordinate system (floor = z 0)."""
+    rx, ry, rz = _rotate(x, y, z)
+    return rx, ry, SENSOR_HEIGHT_M + rz
 
 # Logging is configured once in main.py; here we only grab the module logger
 # (re-running basicConfig would duplicate every log line — see #104).
@@ -159,10 +173,15 @@ def read_frame(data_port):
                 for i in range(num_targets):
                     tid, posX, posY, posZ, velX, velY, velZ = struct.unpack_from(
                         'I6f', payload, i * TRACK_SIZE_BYTES)
+                    # Same room-frame transform as the point cloud, so the track
+                    # circles line up with the points (velocity is a direction, so
+                    # it is only rotated, not height-shifted).
+                    px, py, pz = _to_room_frame(posX, posY, posZ)
+                    vx, vy, vz = _rotate(velX, velY, velZ)
                     targets.append({
                         "tid": tid,
-                        "posX": posX, "posY": posY, "posZ": posZ,
-                        "velX": velX, "velY": velY, "velZ": velZ,
+                        "posX": px, "posY": py, "posZ": pz,
+                        "velX": vx, "velY": vy, "velZ": vz,
                     })
 
             elif tlv_type == TLV_POINT_CLOUD:
@@ -174,14 +193,11 @@ def read_frame(data_port):
                     elev = elevation * elev_unit
                     azim = azimuth * azim_unit
                     r    = range_ * range_unit
-                    x   = r * math.cos(elev) * math.sin(azim)
-                    y_r = r * math.cos(elev) * math.cos(azim)
-                    z_r = r * math.sin(elev)
-                    # Rotate by the mounting tilt and add the mounting height so
-                    # points land in the room frame the tracker reports targets
-                    # in (floor = z 0, sensor at z = SENSOR_HEIGHT_M)
-                    y = y_r * _COS_TILT + z_r * _SIN_TILT
-                    z = SENSOR_HEIGHT_M + z_r * _COS_TILT - y_r * _SIN_TILT
+                    x, y, z = _to_room_frame(
+                        r * math.cos(elev) * math.sin(azim),
+                        r * math.cos(elev) * math.cos(azim),
+                        r * math.sin(elev),
+                    )
                     point_cloud.append({
                         "x": x, "y": y, "z": z,
                         "doppler": doppler * dopp_unit,

--- a/raspberry/visualizer/visualizer.py
+++ b/raspberry/visualizer/visualizer.py
@@ -1,0 +1,312 @@
+import math
+import os
+import sys
+import time
+from collections import deque
+
+import matplotlib
+# Native backend on macOS, default backend elsewhere (e.g. TkAgg on the Pi)
+if sys.platform == 'darwin':
+    matplotlib.use('macosx')
+import matplotlib.pyplot as plt
+import matplotlib.patches as patches
+import numpy as np
+
+from config import (
+    BOUNDARY_X_MIN, BOUNDARY_X_MAX,
+    BOUNDARY_Y_MIN, BOUNDARY_Y_MAX,
+)
+
+fig = None
+ax = None
+_scatter = None
+_count_text = None
+_target_circles = []
+_target_labels = []
+_trail_lines = []
+_vel_lines = []
+_trails = {}  # tid -> deque of (x, y)
+
+# Blitting: redraw only the dynamic artists on top of a cached background
+# instead of re-rendering the whole figure every update
+_use_blit = False
+_background = None
+_dynamic_artists = []
+
+_cbar = None
+_color_mode = 'doppler'  # 'doppler' or 'height', toggled with the 'c' key
+
+# Periodic PNG snapshot of the live view (e.g. for remote debugging).
+# Set VISUALIZER_SNAPSHOT="" to disable.
+_SNAPSHOT_PATH = os.getenv('VISUALIZER_SNAPSHOT', '/tmp/occupi_live.png')
+_SNAPSHOT_INTERVAL = 2.0  # seconds
+_last_snapshot = 0.0
+
+x_range = BOUNDARY_X_MAX - BOUNDARY_X_MIN
+y_range = BOUNDARY_Y_MAX - BOUNDARY_Y_MIN
+_MAX_TARGETS = 10
+_TRAIL_LEN = 60        # frames of position history (~3s at 55ms/frame)
+_VEL_SCALE = 0.7       # arrow length = velocity * 0.7s lookahead
+_DOPPLER_RANGE = 1.0   # m/s mapped to colormap extremes
+_FOV_DEG = 70          # fovCfg azimuth FOV (+/- deg)
+
+_colormap = plt.get_cmap('tab10')
+
+
+def _target_color(tid: int):
+    return _colormap(tid % 10)
+
+
+def is_open() -> bool:
+    return fig is not None and plt.fignum_exists(fig.number)
+
+
+def update(point_cloud: list, targets: list):
+    if not is_open():
+        raise SystemExit("Visualizer window closed.")
+
+    # Point cloud: position, color = doppler or height (toggle: 'c'), size = SNR
+    if point_cloud:
+        xy = np.array([[p["x"], p["y"]] for p in point_cloud], dtype=np.float32)
+        if _color_mode == 'height':
+            values = np.array([p.get("z", 0.0) for p in point_cloud], dtype=np.float32)
+        else:
+            values = np.array([p.get("doppler", 0.0) for p in point_cloud], dtype=np.float32)
+        snr = np.array([p.get("snr", 10.0) for p in point_cloud], dtype=np.float32)
+        sizes = np.clip(4 + snr * 0.4, 4, 40)
+    else:
+        xy = np.empty((0, 2), dtype=np.float32)
+        values = np.empty(0, dtype=np.float32)
+        sizes = np.empty(0, dtype=np.float32)
+    _scatter.set_offsets(xy)
+    _scatter.set_array(values)
+    _scatter.set_sizes(sizes)
+
+    # Tracked targets: circle, label, velocity vector and trail per track
+    current_tids = set()
+    for i, t in enumerate(targets[:_MAX_TARGETS]):
+        tid, x, y = t["tid"], t["posX"], t["posY"]
+        vx, vy = t.get("velX", 0.0), t.get("velY", 0.0)
+        color = _target_color(tid)
+        current_tids.add(tid)
+
+        _target_circles[i].center = (x, y)
+        _target_circles[i].set_edgecolor(color)
+        _target_circles[i].set_visible(True)
+
+        speed = (vx * vx + vy * vy) ** 0.5
+        _target_labels[i].set_position((x, y + 0.45))
+        _target_labels[i].set_text(f'ID {tid} · {speed:.1f} m/s')
+        _target_labels[i].set_color(color)
+        _target_labels[i].set_visible(True)
+
+        _vel_lines[i].set_data([x, x + vx * _VEL_SCALE], [y, y + vy * _VEL_SCALE])
+        _vel_lines[i].set_color(color)
+        _vel_lines[i].set_visible(speed > 0.05)
+
+        trail = _trails.setdefault(tid, deque(maxlen=_TRAIL_LEN))
+        trail.append((x, y))
+        pts = np.array(trail)
+        _trail_lines[i].set_data(pts[:, 0], pts[:, 1])
+        _trail_lines[i].set_color(color)
+        _trail_lines[i].set_visible(len(trail) > 1)
+
+    for i in range(len(targets), _MAX_TARGETS):
+        _target_circles[i].set_visible(False)
+        _target_labels[i].set_visible(False)
+        _vel_lines[i].set_visible(False)
+        _trail_lines[i].set_visible(False)
+
+    # Drop history of tracks that disappeared
+    for tid in list(_trails):
+        if tid not in current_tids:
+            del _trails[tid]
+
+    _count_text.set_text(f'People: {len(targets)}   Points: {len(point_cloud)}')
+
+    canvas = fig.canvas
+    if _use_blit and _background is not None:
+        canvas.restore_region(_background)
+        for artist in _dynamic_artists:
+            ax.draw_artist(artist)
+        canvas.blit(fig.bbox)
+    else:
+        canvas.draw_idle()
+    canvas.flush_events()
+    _save_snapshot()
+
+
+def _save_snapshot():
+    """Periodically dumps the current canvas to a PNG so the live view can be
+    followed from outside the GUI (remote debugging / pair tuning)."""
+    global _last_snapshot
+    if not _SNAPSHOT_PATH:
+        return
+    now = time.monotonic()
+    if now - _last_snapshot < _SNAPSHOT_INTERVAL:
+        return
+    _last_snapshot = now
+    try:
+        rgba = np.asarray(fig.canvas.buffer_rgba())
+        tmp_path = _SNAPSHOT_PATH + '.tmp'
+        plt.imsave(tmp_path, rgba, format='png')
+        os.replace(tmp_path, _SNAPSHOT_PATH)  # atomic: readers never see partial files
+    except Exception:
+        pass  # snapshots are best-effort, never break the live view
+
+
+def _on_key(event):
+    global _color_mode
+    if event.key in ('q', 'escape'):
+        raise SystemExit("Visualizer exited by user.")
+    if event.key == 'c':
+        if _color_mode == 'doppler':
+            _color_mode = 'height'
+            _scatter.set_cmap('viridis')
+            _scatter.set_clim(0.0, 2.5)
+            _cbar.set_label('Height (m)', color='#cccccc')
+        else:
+            _color_mode = 'doppler'
+            _scatter.set_cmap('coolwarm')
+            _scatter.set_clim(-_DOPPLER_RANGE, _DOPPLER_RANGE)
+            _cbar.set_label('Radial velocity (m/s)', color='#cccccc')
+        fig.canvas.draw()  # full redraw updates the colorbar and re-caches the blit background
+
+
+def _on_draw(event):
+    # Fires on every full redraw (initial draw, resize): re-cache the background
+    global _background
+    _background = fig.canvas.copy_from_bbox(fig.bbox)
+
+
+def start_visualizer():
+    global fig, ax, _scatter, _count_text, _use_blit, _cbar
+
+    fig_h = 8.0
+    fig_w = fig_h * (x_range + 1) / (y_range + 1) + 1.5  # extra width for colorbar
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h))
+    fig.patch.set_facecolor('#101418')
+    ax.set_facecolor('#101418')
+    ax.set_xlim(BOUNDARY_X_MIN - 0.5, BOUNDARY_X_MAX + 0.5)
+    ax.set_ylim(BOUNDARY_Y_MIN - 0.5, BOUNDARY_Y_MAX + 0.5)
+    ax.set_aspect('equal')
+    ax.invert_yaxis()
+    ax.invert_xaxis()
+    ax.tick_params(colors='#aaaaaa')
+    for spine in ax.spines.values():
+        spine.set_color('#444444')
+    ax.grid(True, color='#2a2f36', linewidth=0.6, zorder=0)
+    ax.set_axisbelow(True)
+    ax.set_xlabel('X (m)', color='#cccccc')
+    ax.set_ylabel('Y (m)', color='#cccccc')
+    ax.set_title('OccuPi — Live Sensor View', color='white', fontsize=13)
+
+    # Sensor FOV overlay: a ceiling/overhead sensor sees a roughly circular
+    # patch of floor under it (cone hitting the floor), while a wall sensor
+    # fans out in an azimuth wedge. Pick the shape from the mounting tilt.
+    sensor_h, sensor_tilt = _read_sensor_mount()
+    if sensor_tilt > math.radians(60):  # boresight (mostly) downward -> overhead
+        coverage_r = sensor_h * math.tan(math.radians(_FOV_DEG))
+        ax.add_patch(patches.Circle(
+            (0, 0), coverage_r, facecolor='cyan', alpha=0.04,
+            edgecolor='cyan', linewidth=0.8, zorder=1
+        ))
+    else:
+        ax.add_patch(patches.Wedge(
+            (0, 0), BOUNDARY_Y_MAX, 90 - _FOV_DEG, 90 + _FOV_DEG,
+            facecolor='cyan', alpha=0.04, edgecolor='none', zorder=1
+        ))
+    ax.scatter([0], [0], marker='s', s=80, c='orange', zorder=6)
+    ax.text(0, -0.35, 'Sensor', color='orange', fontsize=9, ha='center', zorder=6)
+
+    # Tracker boundary box (outer tracking limit)
+    ax.add_patch(patches.Rectangle(
+        (BOUNDARY_X_MIN, BOUNDARY_Y_MIN), x_range, y_range,
+        linewidth=1.5, edgecolor='cyan', facecolor='none', zorder=2
+    ))
+
+    # Static boundary box from the chirp config (zone where static targets survive)
+    static_box = _read_static_boundary()
+    if static_box:
+        sx_min, sx_max, sy_min, sy_max = static_box[:4]
+        ax.add_patch(patches.Rectangle(
+            (sx_min, sy_min), sx_max - sx_min, sy_max - sy_min,
+            linewidth=1.2, edgecolor='#888888', facecolor='none',
+            linestyle='--', zorder=2
+        ))
+        ax.text(sx_min, sy_min - 0.15, 'static zone', color='#888888',
+                fontsize=8, ha='left', zorder=2)
+
+    # Point cloud, colored by radial velocity (blue = approaching, red = receding)
+    _scatter = ax.scatter(
+        [], [], s=8, c=[], cmap='coolwarm',
+        vmin=-_DOPPLER_RANGE, vmax=_DOPPLER_RANGE,
+        alpha=0.75, zorder=3, edgecolors='none'
+    )
+    _cbar = fig.colorbar(_scatter, ax=ax, fraction=0.04, pad=0.02)
+    _cbar.set_label('Radial velocity (m/s)', color='#cccccc')
+    _cbar.ax.tick_params(colors='#aaaaaa')
+    _cbar.outline.set_edgecolor('#444444')
+
+    for _ in range(_MAX_TARGETS):
+        c = patches.Circle((0, 0), radius=0.3,
+                           linewidth=2, edgecolor='red', facecolor='none',
+                           visible=False, zorder=5)
+        ax.add_patch(c)
+        _target_circles.append(c)
+
+        lbl = ax.text(0, 0, '', color='red', fontsize=8, ha='center',
+                      visible=False, zorder=6)
+        _target_labels.append(lbl)
+
+        trail, = ax.plot([], [], linewidth=1.5, alpha=0.45, visible=False, zorder=4)
+        _trail_lines.append(trail)
+
+        vel, = ax.plot([], [], linewidth=2, alpha=0.9, visible=False, zorder=5)
+        _vel_lines.append(vel)
+
+    _count_text = ax.text(
+        0.02, 0.98, 'People: 0', transform=ax.transAxes,
+        color='white', fontsize=12, va='top', zorder=6
+    )
+    ax.text(
+        0.98, 0.98, "q/esc: quit · c: doppler/height", transform=ax.transAxes,
+        color='#777777', fontsize=8, va='top', ha='right', zorder=6
+    )
+
+    # Draw order matters for blitting: scatter below trails below circles/labels
+    _dynamic_artists.extend([_scatter, *_trail_lines, *_vel_lines,
+                             *_target_circles, *_target_labels, _count_text])
+    _use_blit = fig.canvas.supports_blit
+    if _use_blit:
+        for artist in _dynamic_artists:
+            artist.set_animated(True)  # exclude from full redraws, drawn manually
+        fig.canvas.mpl_connect('draw_event', _on_draw)
+
+    fig.canvas.mpl_connect('key_press_event', _on_key)
+    fig.tight_layout()
+    plt.show(block=False)
+    fig.canvas.draw()
+
+
+def _read_sensor_mount():
+    """Sensor height (m) and tilt (rad) from the chirp config, so the FOV
+    overlay matches the actual mounting (wall = wedge, ceiling = floor disk)."""
+    try:
+        from sensor.receiver import SENSOR_HEIGHT_M, SENSOR_TILT_RAD
+        return SENSOR_HEIGHT_M, SENSOR_TILT_RAD
+    except Exception:
+        return 0.0, 0.0
+
+
+def _read_static_boundary():
+    """Parses staticBoundaryBox from the chirp config so the plot stays in sync with the sensor."""
+    try:
+        from sensor.receiver import CONFIG_FILE
+        with open(CONFIG_FILE) as f:
+            for line in f:
+                if line.startswith('staticBoundaryBox'):
+                    return [float(v) for v in line.split()[1:]]
+    except Exception:
+        pass
+    return None


### PR DESCRIPTION
## What

A real-time visualizer for the radar sensor, plus the overhead-mount setup it runs on:

- Live matplotlib view of the point cloud and tracked targets, driven from the sensor loop (#107).
- Point-cloud TLV parsing and a room-frame transform so points and track circles share one coordinate system (floor = z 0).
- Overhead ceiling-mount chirp configs and the matching `CONFIG_FILE` switch (#108).

## How

- `visualizer/visualizer.py` — matplotlib point cloud + track view with a render-FPS cap and a symmetric boundary.
- `sensor/receiver.py` — parse the point-cloud TLV; factor the tilt + height transform into `_rotate`/`_to_room_frame` and apply it to both the point cloud and the track positions (velocity is a direction, so it is only rotated, not height-shifted).
- `main.py` — wire the visualizer into the sensor loop with a render throttle.
- `config.py` — overhead mounting parameters (sensorPosition, boundary boxes).
- `chirp_configs/` — `aop_overhead_3m_radial.cfg` (now active) plus `low_bw` and `staticRetention` variants.
- `requirements.txt` — matplotlib / numpy.

## Tests

No automated tests for the Pi-side visualizer (matplotlib UI over live serial I/O). Verified manually against the overhead-mounted sensor: point cloud and track circles render in the same room frame.

Closes #107
Refs #108
