### PR TITLE
add: send Pi health metrics to the backend via STOMP #110

### DIFF
--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -5,7 +5,7 @@ ROOM_ID   = os.getenv("ROOM_ID",   "room-01")
 SENSOR_ID = os.getenv("SENSOR_ID", "sensor-01")
 
 # --- Sensor Mode ---
-# "mock" generates realistic fake occupancy data (no hardware needed) — used by the
+# "mock" generates realistic fake occupancy data (no hardware needed), used by the
 # container and for local testing. "real" reads from the mmWave sensor over serial.
 # Flip this in one place: the SENSOR_MODE entry of your .env file.
 SENSOR_MODE = os.getenv("SENSOR_MODE", "mock").strip().lower()
@@ -29,6 +29,7 @@ BACKEND_HOST        = os.getenv("BACKEND_HOST",        "localhost")
 BACKEND_PORT        = int(os.getenv("BACKEND_PORT",    "8080"))
 BACKEND_WS_PATH     = os.getenv("BACKEND_WS_PATH",     "/ws")
 STOMP_DESTINATION   = os.getenv("STOMP_DESTINATION",   "/app/data")
+STOMP_METRICS_DESTINATION = os.getenv("STOMP_METRICS_DESTINATION", "/app/metrics")
 
 # Connect over TLS (wss) instead of plain ws. Needed to reach the production
 # backend through the Nginx endpoint (occupi.mi.hdm-stuttgart.de:443). Leave off

--- a/raspberry/main.py
+++ b/raspberry/main.py
@@ -4,17 +4,19 @@ import queue
 import sys
 import threading
 import time
+from datetime import datetime, timezone
+
 import serial
 import stomp
 import certifi
 
 from config import (
     BACKEND_HOST, BACKEND_PORT,
-    STOMP_DESTINATION,
+    STOMP_DESTINATION, STOMP_METRICS_DESTINATION,
     QUEUE_MAX_SIZE,
     WS_RECONNECT_DELAY, WS_MAX_RETRIES, BACKEND_WS_PATH,
     BACKEND_TLS, BACKEND_TLS_CA,
-    SENSOR_MODE, ROOM_ID, MOCK_ROOM_IDS,
+    SENSOR_MODE, SENSOR_ID, ROOM_ID, MOCK_ROOM_IDS,
 )
 from sensor.receiver import open_ports, send_config, read_frame, CONFIG_FILE
 from sensor.metrics import ThroughputMetrics, start_metrics_monitor
@@ -34,6 +36,10 @@ log = logging.getLogger(__name__)
 # frame per room each tick, so the queue must hold more than the room count.
 _queue: queue.Queue = queue.Queue(maxsize=max(QUEUE_MAX_SIZE, len(MOCK_ROOM_IDS) * 3))
 _metrics = ThroughputMetrics()
+
+# Shared STOMP connection, owned by the sender loop. The metrics thread reads it
+# to forward snapshots over the same link (set once the sender connects).
+_conn: "stomp.WSStompConnection | None" = None
 
 def enqueue_frame(frame: dict) -> None:
     """
@@ -69,6 +75,7 @@ def _sender_loop() -> None:
     Maintains the STOMP connection and sends frames from the queue.
     Reconnects automatically on failure.
     """
+    global _conn
     conn = stomp.WSStompConnection(
         host_and_ports=[(BACKEND_HOST, BACKEND_PORT)],
         heartbeats=(25000, 25000),
@@ -81,6 +88,8 @@ def _sender_loop() -> None:
         conn.set_ssl(for_hosts=[(BACKEND_HOST, BACKEND_PORT)], ca_certs=ca_bundle)
         log.info("TLS enabled: connecting via wss, verifying server cert against %s", ca_bundle)
 
+    # Publish the connection so the metrics thread can send over the same link.
+    _conn = conn
     retries = 0
 
     while WS_MAX_RETRIES == 0 or retries < WS_MAX_RETRIES:
@@ -121,6 +130,30 @@ def start_sender() -> None:
     log.info("Sender thread started.")
 
 
+def _send_metrics(snapshot: dict) -> None:
+    """Forwards a metrics snapshot to the backend over the shared STOMP link (#110).
+    Tags it with the sensorId and a UTC timestamp, sent explicitly so the backend
+    does not have to assign one (see #186). Skips the send when the link is down."""
+    conn = _conn
+    if conn is None or not conn.is_connected():
+        log.debug("STOMP not connected, skipping metrics snapshot.")
+        return
+    payload = {
+        "sensorId": SENSOR_ID,
+        **snapshot,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    try:
+        conn.send(
+            destination=STOMP_METRICS_DESTINATION,
+            body=json.dumps(payload),
+            content_type="application/json",
+        )
+        log.debug(f"Sent metrics: {payload}")
+    except Exception as e:
+        log.warning(f"Failed to send metrics: {e}")
+
+
 # Main execution
 if __name__ == '__main__':
     cfg_port = None
@@ -128,14 +161,14 @@ if __name__ == '__main__':
 
     try:
         start_sender()
-        start_metrics_monitor(_queue, _metrics)
+        start_metrics_monitor(_queue, _metrics, send_fn=_send_metrics)
 
         if SENSOR_MODE == "mock":
             rooms = MOCK_ROOM_IDS or [ROOM_ID]
-            log.info("Starting in MOCK mode — fake occupancy for %d room(s).", len(rooms))
+            log.info("Starting in MOCK mode, fake occupancy for %d room(s).", len(rooms))
             mock_sensor_loop(enqueue_frame, rooms)  # runs until the process is stopped
         else:
-            log.info("Starting in REAL mode — reading from the mmWave sensor.")
+            log.info("Starting in REAL mode, reading from the mmWave sensor.")
             cfg_port, data_port = open_ports()
             send_config(cfg_port, CONFIG_FILE)
             while True:

--- a/raspberry/sensor/metrics.py
+++ b/raspberry/sensor/metrics.py
@@ -51,29 +51,48 @@ def get_system_metrics() -> dict:
         "memory_percent": psutil.virtual_memory().percent,
     }
 
-def log_snapshot(_queue, _metrics) -> None:
-    """Logs a single metrics snapshot."""
+def collect_snapshot(_queue, _metrics) -> dict:
+    """Collects one metrics snapshot in the backend's payload shape. The camelCase
+    field names match the Metrics DTO and the InfluxDB fields. sensorId and the
+    timestamp are added by the sender (see _send_metrics in main.py, #110)."""
     sys_m = get_system_metrics()
     thr_m = _metrics.snapshot()
+    return {
+        "cpuPercentage": sys_m["cpu_percent"],
+        "memoryPercentage": sys_m["memory_percent"],
+        "queueSize": _queue.qsize(),
+        "sent": thr_m["sent"],
+        "dropped": thr_m["dropped"],
+        "avgProcessTime": thr_m["avg_processing_ms"],
+    }
+
+def log_snapshot(snapshot: dict) -> None:
+    """Logs a single metrics snapshot."""
     log.info(
         f"[metrics] "
-        f"cpu={sys_m['cpu_percent']}% "
-        f"mem={sys_m['memory_percent']}% "
-        f"queue={_queue.qsize()}/{QUEUE_MAX_SIZE} "
-        f"sent={thr_m['sent']} "
-        f"dropped={thr_m['dropped']} "
-        f"avg_processing={thr_m['avg_processing_ms']}ms"
+        f"cpu={snapshot['cpuPercentage']}% "
+        f"mem={snapshot['memoryPercentage']}% "
+        f"queue={snapshot['queueSize']}/{QUEUE_MAX_SIZE} "
+        f"sent={snapshot['sent']} "
+        f"dropped={snapshot['dropped']} "
+        f"avg_processing={snapshot['avgProcessTime']}ms"
     )
 
-def _metrics_loop(_queue, _metrics) -> None:
-    """Periodically logs all system and throughput metrics (issue #16)."""
+def _metrics_loop(_queue, _metrics, send_fn=None) -> None:
+    """Periodically collects, logs, and (if wired) forwards a metrics snapshot
+    to the backend (#16 logging, #110 sending). One snapshot per interval, so the
+    logged and sent values match and the system is sampled once per interval."""
     while True:
         time.sleep(METRICS_INTERVAL)
-        log_snapshot(_queue, _metrics)
+        snapshot = collect_snapshot(_queue, _metrics)
+        log_snapshot(snapshot)
+        if send_fn is not None:
+            send_fn(snapshot)
 
 
-def start_metrics_monitor(_queue, _metrics) -> None:
-    """Starts the metrics loop in a daemon thread."""
-    t = threading.Thread(target=_metrics_loop, args=(_queue, _metrics), daemon=True)
+def start_metrics_monitor(_queue, _metrics, send_fn=None) -> None:
+    """Starts the metrics loop in a daemon thread. If send_fn is given, each
+    snapshot is also forwarded to the backend on every interval."""
+    t = threading.Thread(target=_metrics_loop, args=(_queue, _metrics, send_fn), daemon=True)
     t.start()
     log.info("Metrics monitor started.")


### PR DESCRIPTION
## What

The Pi already collects health metrics (CPU, memory, queue, throughput) and logs them locally. This forwards each snapshot to the backend over STOMP so they land in InfluxDB (#110).

## How

- `config.py`: adds `STOMP_METRICS_DESTINATION` (`/app/metrics`).
- `sensor/metrics.py`: `collect_snapshot()` builds the payload in the `Metrics` DTO shape (camelCase); the monitor loop takes a `send_fn` and forwards one snapshot per interval, logged and sent from the same sample.
- `main.py`: `_send_metrics()` adds the `sensorId` and a UTC timestamp and sends over the STOMP connection the sender already holds, skipping when the link is down. The Pi sets the timestamp so the backend does not assign one (#186).

Payload matches the `Metrics` record (`sensorId, cpuPercentage, memoryPercentage, queueSize, sent, dropped, avgProcessTime, timestamp`). No `roomId`: metrics are keyed by `sensorId` (the InfluxDB tag), and one Pi can serve several rooms.

## Tests

Verified end to end against the local stack (backend + InfluxDB) with the mock sender. Backend logs `Received metrics from sensor=sensor-01` and `Successfully processed Pi metrics`, and the values match the Pi's snapshot. No automated tests on the Pi side (no pytest setup).

Closes #110
