### PR TITLE
Feature/admin panel room crud #153

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,6 +74,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -257,33 +258,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -651,9 +629,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -671,9 +646,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -691,9 +663,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -711,9 +680,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -731,9 +697,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -751,9 +714,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -797,6 +757,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -983,9 +977,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,9 +994,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1023,9 +1011,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1043,9 +1028,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1220,6 +1202,7 @@
       "version": "24.12.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1228,6 +1211,7 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1292,6 +1276,7 @@
       "version": "8.59.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1500,6 +1485,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1626,6 +1612,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1986,6 +1973,7 @@
       "version": "10.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2717,9 +2705,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2741,9 +2726,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2765,9 +2747,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2789,9 +2768,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3023,6 +2999,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3048,6 +3025,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3094,6 +3072,7 @@
     "node_modules/react": {
       "version": "19.2.5",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3101,6 +3080,7 @@
     "node_modules/react-dom": {
       "version": "19.2.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3120,6 +3100,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3208,7 +3189,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3430,6 +3412,7 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3547,6 +3530,7 @@
       "version": "8.0.10",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3684,6 +3668,7 @@
       "version": "4.4.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -74,7 +74,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -256,6 +255,29 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1202,7 +1224,6 @@
       "version": "24.12.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1211,7 +1232,6 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1276,7 +1296,6 @@
       "version": "8.59.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1485,7 +1504,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1612,7 +1630,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1973,7 +1990,6 @@
       "version": "10.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2999,7 +3015,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3025,7 +3040,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3072,7 +3086,6 @@
     "node_modules/react": {
       "version": "19.2.5",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3080,7 +3093,6 @@
     "node_modules/react-dom": {
       "version": "19.2.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3100,7 +3112,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3189,8 +3200,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -3412,7 +3422,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3530,7 +3539,6 @@
       "version": "8.0.10",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3668,7 +3676,6 @@
       "version": "4.4.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,8 @@ import { Login } from './pages/Login';
 import Rooms from './pages/Rooms';
 import Analytics from './pages/Analytics';
 import { ProtectedRoute } from './components/ProtectedRoute';
-import { MainLayout } from './layouts/MainLayout.tsx';
+import { MainLayout } from './layouts/MainLayout';
+import AdminPanel from './pages/AdminPanel';
 
 function App() {
     // Auth state is restored synchronously when the store is created
@@ -24,6 +25,13 @@ function App() {
                         <Route path="/dashboard" element={<Dashboard />} />
                         <Route path="/rooms" element={<Rooms />} />
                         <Route path="/analytics" element={<Analytics />} />
+                    </Route>
+                </Route>
+
+                {/* admin routes */}
+                <Route element={<ProtectedRoute role="admin" />}>
+                    <Route element={<MainLayout />}>
+                        <Route path="/admin" element={<AdminPanel />} />
                     </Route>
                 </Route>
 

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,12 +1,21 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuthStore } from '../hooks/useAuthStore';
 
-export const ProtectedRoute = () => {
+interface ProtectedRouteProps {
+    role?: string;
+}
+
+export const ProtectedRoute = ({ role }: ProtectedRouteProps) => {
     const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+    const user = useAuthStore((state) => state.user);
 
     // If not logged in, redirect to login page
     if (!isAuthenticated) {
         return <Navigate to="/login" replace />;
+    }
+
+    if (role && user?.role !== role){
+        return <Navigate to="/dashboard" replace />;
     }
 
     // if logged in, render the protected route

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { LayoutDashboard, ChartColumn, DoorOpen, PanelLeftOpen, PanelLeftClose, LogOut } from 'lucide-react';
+import { LayoutDashboard, ChartColumn, DoorOpen, PanelLeftOpen, PanelLeftClose, LogOut, Shield } from 'lucide-react';
 import { useAuthStore} from "../hooks/useAuthStore";
 
 export const Sidebar = () => {
     const location = useLocation(); // reads the current location (link gets correspondingly highlighted in color)
 
     const navigate = useNavigate();
+
+    const user = useAuthStore((state) => state.user);
 
     // memory of sidebar state
     const [isCollapsed, setIsCollapsed] = useState(() => {
@@ -25,6 +27,8 @@ export const Sidebar = () => {
         { path: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
         { path: '/rooms', label: 'Räume', icon: DoorOpen },
         { path: '/analytics', label: 'Analytics', icon: ChartColumn },
+        //if admin
+        ...(user?.role === 'admin' ? [{ path: '/admin', label: 'Admin', icon: Shield}] : [])
     ];
 
     //switch for the pop-up (default: false = closed)

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { Pencil, Trash2 } from 'lucide-react';
 import api from '../utils/api';
 import { createRoom, updateRoom, deleteRoom} from "../utils/api";
@@ -14,6 +14,8 @@ const AdminPanel = () => {
     const [editingId, setEditingId] = useState<string | null>(null);
     const [showDeleteDialog, setShowDeleteDialog] = useState<string | null>(null);
 
+    const [initialized, setInitialized] = useState(false);
+
     const refreshRooms = useCallback (async () => {
         try {
             const res = await api.get<RoomResponse[]>('/rooms');
@@ -27,7 +29,10 @@ const AdminPanel = () => {
         }
     }, []);
 
-    useEffect(() => { void refreshRooms(); }, [refreshRooms]);
+    if (!initialized) {
+        setInitialized(true);
+        refreshRooms();
+    }
 
     return (
         <div className="p-6 space-y-8">

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -19,14 +19,15 @@ const AdminPanel = () => {
             const res = await api.get<RoomResponse[]>('/rooms');
             setRooms(res.data);
             setError(null);
-        } catch (err: any) {
-            setError(err.response?.status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Laden der Räume');
+        } catch (err: unknown) {
+            const status = (err as { response?: { status?: number }})?.response?.status;
+            setError(status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Laden der Räume.');
         } finally {
             setLoading(false);
         }
     }, []);
 
-    useEffect(() => { refreshRooms(); }, [refreshRooms]);
+    useEffect(() => { void refreshRooms(); }, [refreshRooms]);
 
     return (
         <div className="p-6 space-y-8">
@@ -50,8 +51,9 @@ const AdminPanel = () => {
                         setFormData(emptyForm);
                         setEditingId(null);
                         await refreshRooms();
-                    } catch (err: any) {
-                        setError(err.response?.status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Speichern');
+                    } catch (err: unknown) {
+                        const status = (err as { response?: { status?: number }})?.response?.status;
+                        setError(status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Speichern.');
                     }
                 }}>
                     <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">
@@ -179,9 +181,9 @@ const AdminPanel = () => {
                                     await deleteRoom(showDeleteDialog!);
                                     setShowDeleteDialog(null);
                                     await refreshRooms();
-                                } catch (err: any) {
-                                    setError(err.response?.status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Löschen.');
-                                    setShowDeleteDialog(null);
+                                } catch (err: unknown) {
+                                    const status = (err as { response?: { status?: number }})?.response?.status;
+                                    setError(status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Löschen.');
                                 }
                             }}
                             className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg"

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -121,7 +121,7 @@ const AdminPanel = () => {
                             <th className="pb-3">Gebäude</th>
                             <th className="pb-3">Etage</th>
                             <th className="pb-3">Kapazität</th>
-                            <th className="pb-3">Actions</th>
+                            <th className="pb-3">Aktionen</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -1,9 +1,204 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Pencil, Trash2 } from 'lucide-react';
+import api from '../utils/api';
+import { createRoom, updateRoom, deleteRoom} from "../utils/api";
+import type { RoomResponse } from '../types/room';
 
+const emptyForm = { roomId: '', name: '', building: '', floor: 0, capacity: 0};
 
 const AdminPanel = () => {
+    const [rooms, setRooms] = useState<RoomResponse[]> ([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [formData, setFormData] = useState(emptyForm);
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [showDeleteDialog, setShowDeleteDialog] = useState<string | null>(null);
+
+    const refreshRooms = useCallback (async () => {
+        try {
+            const res = await api.get<RoomResponse[]>('/rooms');
+            setRooms(res.data);
+            setError(null);
+        } catch (err: any) {
+            setError(err.response?.status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Laden der Räume');
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => { refreshRooms(); }, [refreshRooms]);
+
     return (
-        <div className="p-6">
+        <div className="p-6 space-y-8">
             <h1 className="text-3xl font-bold text-gray-900">Admin Panel</h1>
+
+            {error && <p className="text-red-600">{error}</p>}
+
+            {/* Add/Edit Room Form */}
+            <section className="bg-white rounded-xl shadow p-6">
+                <h2 className="text-xl font-semibold text-gray-900 mb-4">
+                    {editingId ? 'Raum bearbeiten' : 'Raum hinzufügen'}
+                </h2>
+                <form onSubmit={async (e) => {
+                    e.preventDefault();
+                    try {
+                        if (editingId) {
+                            await updateRoom(editingId, formData);
+                        } else {
+                            await createRoom(formData);
+                        }
+                        setFormData(emptyForm);
+                        setEditingId(null);
+                        await refreshRooms();
+                    } catch (err: any) {
+                        setError(err.response?.status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Speichern');
+                    }
+                }}>
+                    <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">
+                        <input
+                            type="text"
+                            placeholder="Raum-ID"
+                            value={formData.roomId}
+                            onChange={(e) => setFormData({...formData, roomId: e.target.value})}
+                            disabled={editingId !== null}
+                            className="border border-gray-300 rounded-lg px-3 py-2 text-sm disabled:bg-gray-100"
+                        />
+
+                        <input
+                            type="text"
+                            placeholder="Name"
+                            value={formData.name}
+                            onChange={(e) => setFormData({...formData, name: e.target.value})}
+                            className="border border-gray-300 rounded-lg px-3 py-2 text-sm disabled:bg-gray-100"
+                        />
+
+                        <input
+                            type="text"
+                            placeholder="Gebäude"
+                            value={formData.building}
+                            onChange={(e) => setFormData({...formData, building: e.target.value})}
+                            className="border border-gray-300 rounded-lg px-3 py-2 text-sm disabled:bg-gray-100"
+                        />
+
+                        <input
+                            type="number"
+                            placeholder="Etage (z.B. 2)"
+                            value={formData.floor || ''}
+                            onChange={(e) => setFormData({...formData, floor: Number(e.target.value)})}
+                            className="border border-gray-300 rounded-lg px-3 py-2 text-sm disabled:bg-gray-100"
+                        />
+
+                        <input
+                            type="number"
+                            placeholder="Kapazität (z.B. 50)"
+                            value={formData.capacity || ''}
+                            onChange={(e) => setFormData({...formData, capacity: Number(e.target.value)})}
+                            className="border border-gray-300 rounded-lg px-3 py-2 text-sm disabled:bg-gray-100"
+                        />
+                    </div>
+                    <div className="flex gap-2">
+                        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-700">
+                            {editingId ? 'Aktualisieren' : 'Hinzufügen'}
+                        </button>
+                        {editingId && (
+                            <button type="button" onClick={() => { setFormData(emptyForm); setEditingId(null); }}
+                                    className="bg-gray-100 text-gray-700 px-4 py-2 rounded-lg text-sm hover:bg-gray-200">
+                                Abbrechen
+                            </button>
+                        )}
+                    </div>
+                </form>
+            </section>
+
+            {/* Room Table */}
+            <section className="bg-white rounded-xl shadow p-6">
+                <h2 className="text-xl font-semibold text-gray-900 mb-4">Rooms</h2>
+                <table className="w-full text-left">
+                    <thead>
+                        <tr className="border-b border-gray-200 text-gray-500 text-sm">
+                            <th className="pb-3">Raum-ID</th>
+                            <th className="pb-3">Name</th>
+                            <th className="pb-3">Gebäude</th>
+                            <th className="pb-3">Etage</th>
+                            <th className="pb-3">Kapazität</th>
+                            <th className="pb-3">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {loading ? (
+                        [...Array(3)].map((_, i) =>(
+                            <tr key={i} className="border-b border-gray-100">
+                                {[...Array(6)].map((_, j) => (
+                                    <td key={j} className="py-3">
+                                        <div className="h-4 bg-gray-100 rounded animate-pulse w-3/4" />
+                                    </td>
+                                ))}
+                            </tr>
+                        ))
+                    ) : ( rooms.map((room) =>
+                    <tr key={room.roomId} className="border-b border-gray-100">
+                        <td className="py-3">{room.roomId}</td>
+                        <td className="py-3">{room.name}</td>
+                        <td className="py-3">{room.building}</td>
+                        <td className="py-3">{room.floor}</td>
+                        <td className="py-3">{room.capacity}</td>
+                        <td className="py-3 flex gap-2">
+                            <button onClick={() => { setFormData(room);
+                            setEditingId(room.roomId); }}
+                                className="p-1.5 text-gray-500 hover:text-blue-600">
+                                <Pencil size={16} />
+                            </button>
+                            <button onClick={() => setShowDeleteDialog(room.roomId)}
+                                    className="p-1.5 text-gray-500 hover:text-red-600">
+                                <Trash2 size={16} />
+                            </button>
+                        </td>
+                    </tr>
+                    ))}
+                    </tbody>
+                </table>
+            </section>
+
+            {/* Delete Confirmation Dialog*/}
+            {showDeleteDialog && (
+                <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center">
+                    <div className="bg-white rounded-xl shadow-2xl p-6 max-w-sm w-full mx-4">
+                        <h2 className="text-xl font-bold text-gray-900 mb-2">Raum löschen</h2>
+                        <p className="text-gray-500 mb-6">
+                            Raum <strong>{showDeleteDialog}</strong> wirklich löschen?
+                        </p>
+                        <div className="flex justify-end space-x-3">
+                            <button onClick={() => setShowDeleteDialog(null)}
+                                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg"
+                                    >
+                                Abbrechen
+                            </button>
+
+                            <button onClick={async () => {
+                                try {
+                                    await deleteRoom(showDeleteDialog!);
+                                    setShowDeleteDialog(null);
+                                    await refreshRooms();
+                                } catch (err: any) {
+                                    setError(err.response?.status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Löschen.');
+                                    setShowDeleteDialog(null);
+                                }
+                            }}
+                            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg"
+                                >
+                                Löschen
+                            </button>
+                        </div>
+                    </div>
+
+                </div>
+            )}
+
+            {/* Metrics Placeholder #224 */}
+            <section className="bg-white rounded-xl shadow p-6">
+                <h2 className="text-xl font-semibold text-gray-900 mb-2">Pi Metrics</h2>
+                <p className="text-gray-400">Coming soon with Issue #224</p>
+            </section>
         </div>
     );
 };

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -1,0 +1,11 @@
+
+
+const AdminPanel = () => {
+    return (
+        <div className="p-6">
+            <h1 className="text-3xl font-bold text-gray-900">Admin Panel</h1>
+        </div>
+    );
+};
+
+export default AdminPanel;

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useAuthStore, TOKEN_ENDPOINT, CLIENT_ID } from "../hooks/useAuthStore";
-import type { ForecastResponse, HistoryResponse, WeekPatternResponse } from "../types/room";
+import type { ForecastResponse, HistoryResponse, WeekPatternResponse, RoomResponse } from "../types/room";
 
 const api = axios.create({
     baseURL: import.meta.env.VITE_API_URL,
@@ -86,6 +86,18 @@ export function fetchForecast(roomId: string, forecastHours: number = 12): Promi
 export function fetchWeekPattern(roomId: string, weeks: number = 8): Promise<WeekPatternResponse> {
     return api.get<WeekPatternResponse>('/occupancy/weekpattern',
         { params: { roomId, weeks } }).then(res => res.data);
+}
+
+export function createRoom(data: { roomId: string; name: string; building: string; floor: number; capacity: number}) {
+    return api.post<RoomResponse>('/rooms',data).then(res => res.data);
+}
+
+export function updateRoom(id: string, data: {roomId: string; name: string; building: string; floor: number; capacity: number})  {
+    return api.put<RoomResponse>(`/rooms/${id}`,data).then(res => res.data);
+}
+
+export function deleteRoom(id: string) {
+    return api.delete(`/rooms/${id}`)
 }
 
 export default api;


### PR DESCRIPTION
## Summary
The admin panel page was a placeholder with just a heading. This adds full room CRUD management so admins can create, edit, and delete rooms directly from the `/admin` page without touching the database. The backend CRUD endpoints already exist (#219).

## Changes
- **`frontend/src/utils/api.ts`** — added `createRoom()`, `updateRoom()`, `deleteRoom()` functions using the existing axios instance; added `RoomResponse` to the type import
- **`frontend/src/pages/AdminPanel.tsx`** — replaced placeholder with full admin page:
  - Add/edit form with five fields (Room-ID, Name, Building, Floor, Capacity); Room-ID disabled during edit since it is the primary key
  - Room table with skeleton loading animation while `GET /api/rooms` resolves
  - Edit and delete action buttons per row (Pencil/Trash2 icons from lucide-react)
  - Delete confirmation dialog (same overlay pattern as the logout dialog in Sidebar)
  - Error handling for 403 and general API failures
  - Metrics placeholder section for future Pi health display (#224)

## Verification
- Create room: fill form, click "Hinzufügen" → room appears in table
- Edit room: click pencil icon → form fills with room data, heading switches to "Raum bearbeiten", submit updates the room
- Delete room: click trash icon → confirmation dialog, confirm → room removed from table
- Skeleton loading: animated placeholder rows shown while rooms are fetched
- Error handling: "Keine Berechtigung" shown on 403

Closes #153