### PR TITLE
add: REST API for querying Pi health metrics #223

### DIFF
--- a/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
@@ -2,13 +2,18 @@ package com.occupi.feature.database.repository;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.Point;
+import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.database.InfluxTime;
 import com.occupi.feature.database.model.MetricsData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 @Slf4j
 @Repository
@@ -16,6 +21,11 @@ import java.util.List;
 public class MetricsRepository {
 
     static final String MEASUREMENT_NAME = "metrics";
+
+    /** Column list shared by every read query; order must match {@link #toMetricsData}. */
+    private static final String SELECT_COLUMNS =
+            "\"sensorId\", \"cpuPercentage\", \"memoryPercentage\", "
+                    + "\"queueSize\", \"sent\", \"dropped\", \"avgProcessTime\", time";
 
     private final InfluxDBClient influxDBClient;
 
@@ -54,6 +64,109 @@ public class MetricsRepository {
         influxDBClient.writePoints(points);
 
         log.debug("Saved batch of {} metrics measurements", batch.size());
+    }
+
+    /**
+     * Returns the most recent metrics row for a single sensor.
+     *
+     * @param sensorId the sensor to look up (alphanumeric and dashes only)
+     * @return the latest metrics, or empty if the sensor has no data
+     * @throws IllegalArgumentException if sensorId is null, blank or malformed
+     */
+    public Optional<MetricsData> findLatestBySensor(String sensorId) {
+        validateSensorId(sensorId);
+
+        String sql = """
+                SELECT %s
+                FROM "%s"
+                WHERE "sensorId" = '%s'
+                ORDER BY time DESC
+                LIMIT 1
+                """.formatted(SELECT_COLUMNS, MEASUREMENT_NAME, sensorId);
+
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            return rows.map(this::toMetricsData).findFirst();
+        }
+    }
+
+    /**
+     * Returns the most recent metrics row for every known sensor.
+     * Uses a window function to pick the latest row per sensorId in a single query.
+     *
+     * @return one latest row per sensor (empty list if no data exists)
+     */
+    public List<MetricsData> findAllLatest() {
+        String sql = """
+                SELECT %s
+                FROM (
+                    SELECT %s,
+                           ROW_NUMBER() OVER (PARTITION BY "sensorId" ORDER BY time DESC) AS rn
+                    FROM "%s"
+                )
+                WHERE rn = 1
+                """.formatted(SELECT_COLUMNS, SELECT_COLUMNS, MEASUREMENT_NAME);
+
+        List<MetricsData> result = new ArrayList<>();
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            rows.forEach(row -> result.add(toMetricsData(row)));
+        }
+        return result;
+    }
+
+    /**
+     * Returns all metrics rows for a sensor from {@code since} (inclusive) onward,
+     * ordered oldest first — for charts and history views.
+     *
+     * @param sensorId the sensor to look up (alphanumeric and dashes only)
+     * @param since    the start of the time window (inclusive)
+     * @return the matching rows in ascending time order (empty list if none)
+     * @throws IllegalArgumentException if sensorId is malformed or since is null
+     */
+    public List<MetricsData> findBySensorSince(String sensorId, Instant since) {
+        validateSensorId(sensorId);
+        if (since == null) {
+            throw new IllegalArgumentException("since must not be null");
+        }
+
+        String sql = """
+                SELECT %s
+                FROM "%s"
+                WHERE "sensorId" = '%s'
+                  AND time >= '%s'
+                ORDER BY time ASC
+                """.formatted(SELECT_COLUMNS, MEASUREMENT_NAME, sensorId, since);
+
+        List<MetricsData> result = new ArrayList<>();
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            rows.forEach(row -> result.add(toMetricsData(row)));
+        }
+        return result;
+    }
+
+    /**
+     * Maps a query result row to a MetricsData object.
+     * Expected column order: see {@link #SELECT_COLUMNS}.
+     */
+    private MetricsData toMetricsData(Object[] row) {
+        return MetricsData.builder()
+                .sensorId((String) row[0])
+                .cpuPercentage(((Number) row[1]).doubleValue())
+                .memoryPercentage(((Number) row[2]).doubleValue())
+                .queueSize(((Number) row[3]).intValue())
+                .sent(((Number) row[4]).intValue())
+                .dropped(((Number) row[5]).intValue())
+                .avgProcessTime(((Number) row[6]).floatValue())
+                .timestamp(InfluxTime.toInstant(row[7]))
+                .build();
+    }
+
+    private void validateSensorId(String sensorId) {
+        if (sensorId == null || sensorId.isBlank()) {
+            throw new IllegalArgumentException("sensorId must not be null or blank");
+        }
+        if (!sensorId.matches("[a-zA-Z0-9\\-]+")) {
+            throw new IllegalArgumentException("sensorId contains invalid characters: " + sensorId);
+        }
     }
 
     private Point toPoint(MetricsData metrics) {

--- a/backend/src/main/java/com/occupi/feature/provider/MetricsProviderController.java
+++ b/backend/src/main/java/com/occupi/feature/provider/MetricsProviderController.java
@@ -1,0 +1,90 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.provider.dto.MetricsResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+/**
+ * Read-only REST API exposing Pi health metrics to the Admin Panel (#153).
+ *
+ * <pre>
+ * GET /api/metrics                          → latest metrics for every sensor
+ * GET /api/metrics/{sensorId}               → latest metrics for one sensor
+ * GET /api/metrics/{sensorId}/history?since → metrics from {@code since} onward
+ * </pre>
+ *
+ * Every endpoint is admin-only: the metrics section lives exclusively in the Admin
+ * Panel, so the whole controller carries a class-level {@code @PreAuthorize} (method
+ * security is enabled in {@code SecurityConfig}, #219).
+ */
+@RestController
+@RequestMapping("/api/metrics")
+@PreAuthorize("hasRole('ADMIN')")
+public class MetricsProviderController {
+
+    private final MetricsProviderService providerService;
+
+    public MetricsProviderController(MetricsProviderService providerService) {
+        this.providerService = providerService;
+    }
+
+    /**
+     * Returns the latest metrics for every known sensor.
+     *
+     * @return 200 OK with a list of {@link MetricsResponse} (possibly empty)
+     */
+    @GetMapping
+    public ResponseEntity<List<MetricsResponse>> getAllMetrics() {
+        return ResponseEntity.ok(providerService.getLatestForAllSensors());
+    }
+
+    /**
+     * Returns the latest metrics for the given sensor.
+     *
+     * @param sensorId the sensor identifier
+     * @return 200 OK with {@link MetricsResponse}, 400 if sensorId is blank,
+     *         or 404 if the sensor has no data
+     */
+    @GetMapping("/{sensorId}")
+    public ResponseEntity<MetricsResponse> getMetrics(@PathVariable String sensorId) {
+        if (sensorId == null || sensorId.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        return providerService.getLatestForSensor(sensorId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    /**
+     * Returns the metrics history for the given sensor from {@code since} onward.
+     *
+     * @param sensorId the sensor identifier
+     * @param since    the start of the window as an ISO-8601 UTC instant
+     *                 (e.g. {@code 2026-06-14T10:00:00Z})
+     * @return 200 OK with a list of {@link MetricsResponse}, or 400 if sensorId is
+     *         blank or {@code since} is not a parseable instant
+     */
+    @GetMapping("/{sensorId}/history")
+    public ResponseEntity<List<MetricsResponse>> getHistory(@PathVariable String sensorId,
+                                                            @RequestParam String since) {
+        if (sensorId == null || sensorId.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        Instant sinceInstant;
+        try {
+            sinceInstant = Instant.parse(since);
+        } catch (DateTimeParseException e) {
+            return ResponseEntity.badRequest().build();
+        }
+        return ResponseEntity.ok(providerService.getHistoryForSensor(sensorId, sinceInstant));
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/provider/MetricsProviderService.java
+++ b/backend/src/main/java/com/occupi/feature/provider/MetricsProviderService.java
@@ -1,0 +1,38 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.provider.dto.MetricsResponse;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Read-only service exposing Pi health metrics to the Admin Panel.
+ * Maps persisted samples to {@link MetricsResponse} DTOs and never writes.
+ */
+public interface MetricsProviderService {
+
+    /**
+     * Returns the latest metrics for a single sensor.
+     *
+     * @param sensorId the sensor identifier
+     * @return the latest metrics, or empty if the sensor has no data
+     */
+    Optional<MetricsResponse> getLatestForSensor(String sensorId);
+
+    /**
+     * Returns the latest metrics for every known sensor.
+     *
+     * @return one entry per sensor (empty list if no data exists)
+     */
+    List<MetricsResponse> getLatestForAllSensors();
+
+    /**
+     * Returns the metrics history for a sensor from {@code since} onward.
+     *
+     * @param sensorId the sensor identifier
+     * @param since    the start of the time window (inclusive)
+     * @return the matching samples in ascending time order (empty list if none)
+     */
+    List<MetricsResponse> getHistoryForSensor(String sensorId, Instant since);
+}

--- a/backend/src/main/java/com/occupi/feature/provider/MetricsProviderServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/provider/MetricsProviderServiceImpl.java
@@ -1,0 +1,60 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.database.model.MetricsData;
+import com.occupi.feature.database.repository.MetricsRepository;
+import com.occupi.feature.provider.dto.MetricsResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Default {@link MetricsProviderService} implementation.
+ * Reads Pi health metrics from {@link MetricsRepository} and maps them to the
+ * public {@link MetricsResponse} DTO. Read-only — performs no writes.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MetricsProviderServiceImpl implements MetricsProviderService {
+
+    private final MetricsRepository metricsRepository;
+
+    @Override
+    public Optional<MetricsResponse> getLatestForSensor(String sensorId) {
+        log.debug("Fetching latest metrics for sensor={}", sensorId);
+        return metricsRepository.findLatestBySensor(sensorId).map(this::toResponse);
+    }
+
+    @Override
+    public List<MetricsResponse> getLatestForAllSensors() {
+        log.debug("Fetching latest metrics for all sensors");
+        return metricsRepository.findAllLatest().stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    @Override
+    public List<MetricsResponse> getHistoryForSensor(String sensorId, Instant since) {
+        log.debug("Fetching metrics history for sensor={} since={}", sensorId, since);
+        return metricsRepository.findBySensorSince(sensorId, since).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private MetricsResponse toResponse(MetricsData data) {
+        return new MetricsResponse(
+                data.getSensorId(),
+                data.getCpuPercentage(),
+                data.getMemoryPercentage(),
+                data.getQueueSize(),
+                data.getSent(),
+                data.getDropped(),
+                data.getAvgProcessTime(),
+                data.getTimestamp()
+        );
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/provider/dto/MetricsResponse.java
+++ b/backend/src/main/java/com/occupi/feature/provider/dto/MetricsResponse.java
@@ -1,0 +1,28 @@
+package com.occupi.feature.provider.dto;
+
+import java.time.Instant;
+
+/**
+ * Read-only response DTO exposing a single Pi health-metrics sample to the Admin Panel.
+ * Decoupled from the internal {@code MetricsData} model so the read API stays stable
+ * even if the persistence layer changes.
+ *
+ * @param sensorId          the Pi/sensor the sample belongs to
+ * @param cpuPercentage     CPU load in percent [0, 100]
+ * @param memoryPercentage  memory usage in percent
+ * @param queueSize         number of buffered messages awaiting send
+ * @param sent              messages sent since the device started
+ * @param dropped           messages dropped since the device started
+ * @param avgProcessTime    average per-message processing time in milliseconds
+ * @param timestamp         when the sample was captured
+ */
+public record MetricsResponse(
+        String sensorId,
+        double cpuPercentage,
+        double memoryPercentage,
+        int queueSize,
+        int sent,
+        int dropped,
+        float avgProcessTime,
+        Instant timestamp
+) {}

--- a/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
@@ -2,6 +2,7 @@ package com.occupi.feature.database.repository;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.Point;
+import com.influxdb.v3.client.query.QueryOptions;
 import com.occupi.feature.database.model.MetricsData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,13 +12,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("MetricsRepository")
@@ -43,6 +49,19 @@ class MetricsRepositoryTest {
                 .dropped(1)
                 .avgProcessTime(12.5f)
                 .timestamp(Instant.parse("2026-06-14T10:00:00Z"));
+    }
+
+    /** Mirrors how InfluxDB 3 returns the time column: nanoseconds since epoch. */
+    private static BigInteger nanos(Instant t) {
+        return BigInteger.valueOf(t.getEpochSecond())
+                .multiply(BigInteger.valueOf(1_000_000_000L))
+                .add(BigInteger.valueOf(t.getNano()));
+    }
+
+    /** A query row in the column order produced by {@code MetricsRepository.SELECT_COLUMNS}. */
+    private static Object[] row(String sensorId, double cpu, double mem, long queue,
+                                long sent, long dropped, double avgProcess, Instant ts) {
+        return new Object[]{sensorId, cpu, mem, queue, sent, dropped, avgProcess, nanos(ts)};
     }
 
     @Nested
@@ -126,6 +145,136 @@ class MetricsRepositoryTest {
         @DisplayName("should reject a null batch")
         void shouldRejectNullBatch() {
             assertThrows(IllegalArgumentException.class, () -> repository.saveBatch(null));
+        }
+    }
+
+    @Nested
+    @DisplayName("findLatestBySensor()")
+    class FindLatestBySensor {
+
+        @Test
+        @DisplayName("should map the latest row to MetricsData")
+        void shouldMapLatestRow() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            row("sensor-A", 42.0, 60.0, 3L, 100L, 1L, 12.5, ts)));
+
+            Optional<MetricsData> result = repository.findLatestBySensor("sensor-A");
+
+            assertTrue(result.isPresent());
+            MetricsData data = result.get();
+            assertEquals("sensor-A", data.getSensorId());
+            assertEquals(42.0, data.getCpuPercentage());
+            assertEquals(60.0, data.getMemoryPercentage());
+            assertEquals(3, data.getQueueSize());
+            assertEquals(100, data.getSent());
+            assertEquals(1, data.getDropped());
+            assertEquals(12.5f, data.getAvgProcessTime());
+            assertEquals(ts, data.getTimestamp());
+        }
+
+        @Test
+        @DisplayName("should return empty when no rows are found")
+        void shouldReturnEmptyWhenNoRows() {
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty());
+
+            assertTrue(repository.findLatestBySensor("ghost").isEmpty());
+        }
+
+        @Test
+        @DisplayName("should reject blank sensorId")
+        void shouldRejectBlankSensorId() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.findLatestBySensor("  "));
+        }
+
+        @Test
+        @DisplayName("should reject sensorId with invalid characters (SQL injection guard)")
+        void shouldRejectInvalidSensorId() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.findLatestBySensor("sensor'; DROP TABLE--"));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllLatest()")
+    class FindAllLatest {
+
+        @Test
+        @DisplayName("should map every returned row to MetricsData")
+        void shouldMapAllRows() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            row("sensor-A", 42.0, 60.0, 3L, 100L, 1L, 12.5, ts),
+                            row("sensor-B", 10.0, 30.0, 0L, 50L, 0L, 8.0, ts)));
+
+            List<MetricsData> result = repository.findAllLatest();
+
+            assertEquals(2, result.size());
+            assertEquals("sensor-A", result.get(0).getSensorId());
+            assertEquals(3, result.get(0).getQueueSize());
+            assertEquals("sensor-B", result.get(1).getSensorId());
+            assertEquals(50, result.get(1).getSent());
+        }
+
+        @Test
+        @DisplayName("should return an empty list when no data exists")
+        void shouldReturnEmptyList() {
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty());
+
+            assertTrue(repository.findAllLatest().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("findBySensorSince()")
+    class FindBySensorSince {
+
+        private final Instant since = Instant.parse("2026-06-14T00:00:00Z");
+
+        @Test
+        @DisplayName("should map every row in the window to MetricsData")
+        void shouldMapRowsInWindow() {
+            Instant t1 = Instant.parse("2026-06-14T10:00:00Z");
+            Instant t2 = Instant.parse("2026-06-14T11:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            row("sensor-A", 42.0, 60.0, 3L, 100L, 1L, 12.5, t1),
+                            row("sensor-A", 44.0, 61.0, 4L, 110L, 2L, 13.0, t2)));
+
+            List<MetricsData> result = repository.findBySensorSince("sensor-A", since);
+
+            assertEquals(2, result.size());
+            assertEquals(t1, result.get(0).getTimestamp());
+            assertEquals(t2, result.get(1).getTimestamp());
+            assertEquals(110, result.get(1).getSent());
+        }
+
+        @Test
+        @DisplayName("should return an empty list when no rows match")
+        void shouldReturnEmptyWhenNoRows() {
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty());
+
+            assertTrue(repository.findBySensorSince("sensor-A", since).isEmpty());
+        }
+
+        @Test
+        @DisplayName("should reject blank sensorId")
+        void shouldRejectBlankSensorId() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.findBySensorSince("  ", since));
+        }
+
+        @Test
+        @DisplayName("should reject a null since")
+        void shouldRejectNullSince() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> repository.findBySensorSince("sensor-A", null));
         }
     }
 }

--- a/backend/src/test/java/com/occupi/feature/provider/MetricsProviderControllerMethodSecurityTest.java
+++ b/backend/src/test/java/com/occupi/feature/provider/MetricsProviderControllerMethodSecurityTest.java
@@ -1,0 +1,96 @@
+package com.occupi.feature.provider;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies the class-level {@code @PreAuthorize} on {@link MetricsProviderController} in
+ * isolation: the imported filter chain permits every request at the URL level, so a 403
+ * can only come from the controller's method-level role check — proving the metrics read
+ * API is admin-only regardless of the production URL rules in {@code SecurityConfig}.
+ */
+@WebMvcTest(MetricsProviderController.class)
+@Import(MetricsProviderControllerMethodSecurityTest.MethodSecurityConfig.class)
+@DisplayName("MetricsProviderController method security (@PreAuthorize)")
+class MetricsProviderControllerMethodSecurityTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private MetricsProviderService providerService;
+
+    // Satisfies OAuth2ResourceServerAutoConfiguration; the test injects auth via jwt().
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @Test
+    @DisplayName("blocks the all-metrics list for a non-admin token (403)")
+    void getAll_nonAdmin_returns403() throws Exception {
+        mvc.perform(get("/api/metrics").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("allows the all-metrics list for an admin token (200)")
+    void getAll_admin_returns200() throws Exception {
+        when(providerService.getLatestForAllSensors()).thenReturn(List.of());
+
+        mvc.perform(get("/api/metrics")
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("blocks a single-sensor read for a non-admin token (403)")
+    void getOne_nonAdmin_returns403() throws Exception {
+        mvc.perform(get("/api/metrics/sensor-A").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("blocks a history read for a non-admin token (403)")
+    void getHistory_nonAdmin_returns403() throws Exception {
+        mvc.perform(get("/api/metrics/sensor-A/history")
+                        .param("since", "2026-06-14T00:00:00Z").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Method security enabled over a deliberately permissive URL layer, so the only
+     * thing that can deny a request is {@code @PreAuthorize} on the controller.
+     */
+    @TestConfiguration
+    @EnableWebSecurity
+    @EnableMethodSecurity
+    static class MethodSecurityConfig {
+
+        @Bean
+        SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/provider/MetricsProviderControllerTest.java
+++ b/backend/src/test/java/com/occupi/feature/provider/MetricsProviderControllerTest.java
@@ -1,0 +1,124 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.provider.dto.MetricsResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MetricsProviderController")
+class MetricsProviderControllerTest {
+
+    @Mock
+    private MetricsProviderService providerService;
+
+    @InjectMocks
+    private MetricsProviderController controller;
+
+    private static final MetricsResponse SAMPLE =
+            new MetricsResponse("sensor-A", 42.0, 60.0, 3, 100, 1, 12.5f,
+                    Instant.parse("2026-06-14T10:00:00Z"));
+
+    @Test
+    @DisplayName("returns 200 with the list of all sensors' metrics")
+    void getAllMetrics_returns200() {
+        List<MetricsResponse> all = List.of(
+                SAMPLE,
+                new MetricsResponse("sensor-B", 10.0, 30.0, 0, 50, 0, 8.0f,
+                        Instant.parse("2026-06-14T10:05:00Z"))
+        );
+        when(providerService.getLatestForAllSensors()).thenReturn(all);
+
+        ResponseEntity<List<MetricsResponse>> response = controller.getAllMetrics();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2).isEqualTo(all);
+    }
+
+    @Test
+    @DisplayName("returns 200 with an empty list when no sensors have data")
+    void getAllMetrics_empty_returns200() {
+        when(providerService.getLatestForAllSensors()).thenReturn(List.of());
+
+        ResponseEntity<List<MetricsResponse>> response = controller.getAllMetrics();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("returns 200 with metrics for a known sensor")
+    void getMetrics_known_returns200() {
+        when(providerService.getLatestForSensor("sensor-A")).thenReturn(Optional.of(SAMPLE));
+
+        ResponseEntity<MetricsResponse> response = controller.getMetrics("sensor-A");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(SAMPLE);
+    }
+
+    @Test
+    @DisplayName("returns 404 when the sensor has no data")
+    void getMetrics_unknown_returns404() {
+        when(providerService.getLatestForSensor("ghost")).thenReturn(Optional.empty());
+
+        ResponseEntity<MetricsResponse> response = controller.getMetrics("ghost");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("returns 400 when sensorId is blank")
+    void getMetrics_blank_returns400() {
+        ResponseEntity<MetricsResponse> response = controller.getMetrics("  ");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(providerService);
+    }
+
+    @Test
+    @DisplayName("returns 200 with the history for a valid since")
+    void getHistory_valid_returns200() {
+        Instant since = Instant.parse("2026-06-14T00:00:00Z");
+        List<MetricsResponse> history = List.of(SAMPLE);
+        when(providerService.getHistoryForSensor("sensor-A", since)).thenReturn(history);
+
+        ResponseEntity<List<MetricsResponse>> response =
+                controller.getHistory("sensor-A", "2026-06-14T00:00:00Z");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(history);
+    }
+
+    @Test
+    @DisplayName("returns 400 when sensorId is blank for history")
+    void getHistory_blankSensor_returns400() {
+        ResponseEntity<List<MetricsResponse>> response =
+                controller.getHistory("  ", "2026-06-14T00:00:00Z");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(providerService);
+    }
+
+    @Test
+    @DisplayName("returns 400 when since is not a parseable instant")
+    void getHistory_badSince_returns400() {
+        ResponseEntity<List<MetricsResponse>> response =
+                controller.getHistory("sensor-A", "not-a-timestamp");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        verifyNoInteractions(providerService);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/provider/MetricsProviderServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/provider/MetricsProviderServiceImplTest.java
@@ -1,0 +1,116 @@
+package com.occupi.feature.provider;
+
+import com.occupi.feature.database.model.MetricsData;
+import com.occupi.feature.database.repository.MetricsRepository;
+import com.occupi.feature.provider.dto.MetricsResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MetricsProviderServiceImpl")
+class MetricsProviderServiceImplTest {
+
+    @Mock
+    private MetricsRepository metricsRepository;
+
+    @InjectMocks
+    private MetricsProviderServiceImpl service;
+
+    private static final Instant TS = Instant.parse("2026-06-14T10:00:00Z");
+
+    private MetricsData data(String sensorId, double cpu) {
+        return MetricsData.builder()
+                .sensorId(sensorId).cpuPercentage(cpu).memoryPercentage(60.0)
+                .queueSize(3).sent(100).dropped(1).avgProcessTime(12.5f).timestamp(TS)
+                .build();
+    }
+
+    @Test
+    @DisplayName("maps the latest sample to a response DTO for a known sensor")
+    void getLatestForSensor_known_returnsMappedDto() {
+        when(metricsRepository.findLatestBySensor("sensor-A"))
+                .thenReturn(Optional.of(data("sensor-A", 42.0)));
+
+        Optional<MetricsResponse> result = service.getLatestForSensor("sensor-A");
+
+        assertThat(result).isPresent();
+        MetricsResponse r = result.get();
+        assertThat(r.sensorId()).isEqualTo("sensor-A");
+        assertThat(r.cpuPercentage()).isEqualTo(42.0);
+        assertThat(r.memoryPercentage()).isEqualTo(60.0);
+        assertThat(r.queueSize()).isEqualTo(3);
+        assertThat(r.sent()).isEqualTo(100);
+        assertThat(r.dropped()).isEqualTo(1);
+        assertThat(r.avgProcessTime()).isEqualTo(12.5f);
+        assertThat(r.timestamp()).isEqualTo(TS);
+    }
+
+    @Test
+    @DisplayName("returns empty when the sensor has no data")
+    void getLatestForSensor_unknown_returnsEmpty() {
+        when(metricsRepository.findLatestBySensor("ghost")).thenReturn(Optional.empty());
+
+        assertThat(service.getLatestForSensor("ghost")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("maps every sensor's latest sample for the all-sensors query")
+    void getLatestForAllSensors_returnsMappedList() {
+        when(metricsRepository.findAllLatest()).thenReturn(List.of(
+                data("sensor-A", 42.0),
+                data("sensor-B", 10.0)
+        ));
+
+        List<MetricsResponse> result = service.getLatestForAllSensors();
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(MetricsResponse::sensorId)
+                .containsExactly("sensor-A", "sensor-B");
+        assertThat(result).extracting(MetricsResponse::cpuPercentage)
+                .containsExactly(42.0, 10.0);
+    }
+
+    @Test
+    @DisplayName("returns an empty list when no sensors have data")
+    void getLatestForAllSensors_noData_returnsEmptyList() {
+        when(metricsRepository.findAllLatest()).thenReturn(List.of());
+
+        assertThat(service.getLatestForAllSensors()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("maps the history window to response DTOs for a sensor")
+    void getHistoryForSensor_returnsMappedList() {
+        Instant since = Instant.parse("2026-06-14T00:00:00Z");
+        when(metricsRepository.findBySensorSince("sensor-A", since)).thenReturn(List.of(
+                data("sensor-A", 42.0),
+                data("sensor-A", 44.0)
+        ));
+
+        List<MetricsResponse> result = service.getHistoryForSensor("sensor-A", since);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(MetricsResponse::cpuPercentage)
+                .containsExactly(42.0, 44.0);
+    }
+
+    @Test
+    @DisplayName("returns an empty list when the history window has no data")
+    void getHistoryForSensor_noData_returnsEmptyList() {
+        Instant since = Instant.parse("2026-06-14T00:00:00Z");
+        when(metricsRepository.findBySensorSince("sensor-A", since)).thenReturn(List.of());
+
+        assertThat(service.getHistoryForSensor("sensor-A", since)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
Adds a read-only REST API exposing the Pi health metrics already collected via STOMP, so the Admin Panel (#153) can display them. Built on the existing **provider feature** (`com.occupi.feature.provider`), mirroring `OccupancyProvider*`.

Closes #223.

## Endpoints (all admin-only)
- `GET /api/metrics` — latest metrics per sensor
- `GET /api/metrics/{sensorId}` — latest metrics for one sensor (404 if unknown)
- `GET /api/metrics/{sensorId}/history?since=<ISO-8601>` — time-range query (400 on a missing/unparseable `since`)

Access is restricted by a class-level `@PreAuthorize("hasRole('ADMIN')")`; method security is already enabled in `SecurityConfig` (#219).

## Changes
- **`MetricsRepository`** — three query methods (`findLatestBySensor`, `findAllLatest` via a window function, `findBySensorSince`), reusing the InfluxDB 3 idioms from `OccupancyRepository` and `ChartServiceImpl.queryReadings()`. `sensorId` is validated against `[a-zA-Z0-9-]+` as an injection guard, and the `time` column is converted with `InfluxTime`.
- **`MetricsProviderService` / `MetricsProviderServiceImpl`** — read from the repository and map `MetricsData` → `MetricsResponse`; the write-side `database.service.MetricsService` is left untouched.
- **`MetricsResponse`** — response record in `provider.dto`, next to `OccupancyResponse`.
- **`MetricsProviderController`** — the three endpoints above.

## Note on the issue
The original issue placed the controller in `feature.receiver` and routed reads through the write-side `MetricsService`. I corrected it to follow the provider pattern (see the issue's edit and comment): `receiver` is STOMP ingestion only, and the occupancy provider reads straight from its repository. The endpoints and behaviour are unchanged.

## Tests
28 new tests, all green:
- Repository: 10 — the three query methods (mapping, empty result, blank/invalid `sensorId`, null `since`)
- Provider service: 6 — mapping and delegation
- Controller: 8 — 200, 404 for an unknown sensor, 400 for a blank `sensorId` or bad `since`
- Method security: 4 — `@WebMvcTest` slice proving 403 for a non-admin token and 200 for an admin token
