### PR TITLE
fix: guard WeekPatternHeatmap against null peakTime and quietTime #217

### DIFF
--- a/frontend/src/components/WeekPatternHeatmap.tsx
+++ b/frontend/src/components/WeekPatternHeatmap.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { WeekPatternSlot, TimeSlotSummary} from "../types/room";
+import { Clock } from 'lucide-react'
 
 interface WeekPattern {
     pattern: WeekPatternSlot[];
@@ -7,9 +8,19 @@ interface WeekPattern {
     quietTime: TimeSlotSummary | null;
 }
 
-export const WeekPatternHeatmap = ({ pattern, peakTime, quietTime}: WeekPattern) => {
+const EmptyTimeCard = ({ label }: { label: string }) => (
+    <div className="bg-gray-50 rounded-lg p-4">
+        <p className="text-sm text-gray-500">{label}</p>
+        <p className="text-sm text-gray-400 flex items-center gap-1">
+            <Clock className="w-4 h-4"/> Noch nicht genügend Daten
+        </p>
+        <p className="text-sm text-gray-400 invisible">Platzhalter</p>
+    </div>
+)
+
+export const WeekPatternHeatmap = ({pattern, peakTime, quietTime}: WeekPattern) => {
     const weekDays = ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"];
-    const hours =  Array.from({ length: 24 }, (_, i) => i);
+    const hours = Array.from({length: 24}, (_, i) => i);
 
     const dayLabels: Record<string, string> = {
         MONDAY: "Mo", TUESDAY: "Di", WEDNESDAY: "Mi", THURSDAY: "Do", FRIDAY: "Fr", SATURDAY: "Sa", SUNDAY: "So"
@@ -48,29 +59,27 @@ export const WeekPatternHeatmap = ({ pattern, peakTime, quietTime}: WeekPattern)
 
             <div className="grid grid-cols-2 gap-4 mt-4">
                 {peakTime ? (
-                <div className="bg-red-50 rounded-lg p-4">
-                    <p className="text-sm text-gray-500">Stoßzeit</p>
-                    <p className="text-lg font-bold text-red-600">{dayLabels[peakTime.dayOfWeek]} {peakTime.hour}:00</p>
-                    <p className="text-sm text-gray-400">{Math.round(peakTime.avgRate * 100)}% Auslastung</p>
-                </div>
+                    <div className="bg-red-50 rounded-lg p-4">
+                        <p className="text-sm text-gray-500">Stoßzeit</p>
+                        <p className="text-lg font-bold text-red-600">{dayLabels[peakTime.dayOfWeek]} {peakTime.hour}:00</p>
+                        <p className="text-sm text-gray-400">{Math.round(peakTime.avgRate * 100)}% Auslastung</p>
+                    </div>
                 ) : (
-                <div className="bg-gray-50 rounded-lg p-4">
-                    <p className="text-sm text-gray-500">Stoßzeit</p>
-                    <p className="text-sm text-gray-400">Noch nicht genügend Daten</p>
-                </div>
+
+                    <EmptyTimeCard label="Stoßzeit" />
+
                 )}
 
                 {quietTime ? (
-                <div className="bg-green-50 rounded-lg p-4">
-                    <p className="text-sm text-gray-500"> Beste Zeit (8-18 Uhr)</p>
-                    <p className="text-lg font-bold text-green-600">{dayLabels[quietTime.dayOfWeek]} {quietTime.hour}:00</p>
-                    <p className="text-sm text-gray-400">{Math.round(quietTime.avgRate * 100)}%</p>
-                </div>
-                ) : (
-                    <div className="bg-gray-50 rounded-lg p-4">
-                        <p className="text-sm text-gray-500">Beste Zeit (8-18 Uhr)</p>
-                        <p className="text-sm text-gray-400">Noch nicht genügend Daten</p>
+                    <div className="bg-green-50 rounded-lg p-4">
+                        <p className="text-sm text-gray-500"> Beste Zeit (8-18 Uhr)</p>
+                        <p className="text-lg font-bold text-green-600">{dayLabels[quietTime.dayOfWeek]} {quietTime.hour}:00</p>
+                        <p className="text-sm text-gray-400">{Math.round(quietTime.avgRate * 100)}%</p>
                     </div>
+                ) : (
+
+                    <EmptyTimeCard label="Beste Zeit (8-18 Uhr)" />
+
                 )}
             </div>
         </>

--- a/frontend/src/components/WeekPatternHeatmap.tsx
+++ b/frontend/src/components/WeekPatternHeatmap.tsx
@@ -3,8 +3,8 @@ import type { WeekPatternSlot, TimeSlotSummary} from "../types/room";
 
 interface WeekPattern {
     pattern: WeekPatternSlot[];
-    peakTime: TimeSlotSummary;
-    quietTime: TimeSlotSummary;
+    peakTime: TimeSlotSummary | null;
+    quietTime: TimeSlotSummary | null;
 }
 
 export const WeekPatternHeatmap = ({ pattern, peakTime, quietTime}: WeekPattern) => {
@@ -45,17 +45,33 @@ export const WeekPatternHeatmap = ({ pattern, peakTime, quietTime}: WeekPattern)
                     </React.Fragment>
                 ))}
             </div>
+
             <div className="grid grid-cols-2 gap-4 mt-4">
+                {peakTime ? (
                 <div className="bg-red-50 rounded-lg p-4">
                     <p className="text-sm text-gray-500">Stoßzeit</p>
                     <p className="text-lg font-bold text-red-600">{dayLabels[peakTime.dayOfWeek]} {peakTime.hour}:00</p>
                     <p className="text-sm text-gray-400">{Math.round(peakTime.avgRate * 100)}% Auslastung</p>
                 </div>
+                ) : (
+                <div className="bg-gray-50 rounded-lg p-4">
+                    <p className="text-sm text-gray-500">Stoßzeit</p>
+                    <p className="text-sm text-gray-400">Noch nicht genügend Daten</p>
+                </div>
+                )}
+
+                {quietTime ? (
                 <div className="bg-green-50 rounded-lg p-4">
                     <p className="text-sm text-gray-500"> Beste Zeit (8-18 Uhr)</p>
                     <p className="text-lg font-bold text-green-600">{dayLabels[quietTime.dayOfWeek]} {quietTime.hour}:00</p>
                     <p className="text-sm text-gray-400">{Math.round(quietTime.avgRate * 100)}%</p>
                 </div>
+                ) : (
+                    <div className="bg-gray-50 rounded-lg p-4">
+                        <p className="text-sm text-gray-500">Beste Zeit (8-18 Uhr)</p>
+                        <p className="text-sm text-gray-400">Noch nicht genügend Daten</p>
+                    </div>
+                )}
             </div>
         </>
 

--- a/frontend/src/types/room.ts
+++ b/frontend/src/types/room.ts
@@ -53,8 +53,8 @@ export interface WeekPatternResponse {
     roomId: string;
     weeks: number;
     pattern: WeekPatternSlot[];
-    peakTime: TimeSlotSummary;
-    quietTime: TimeSlotSummary;
+    peakTime: TimeSlotSummary | null;
+    quietTime: TimeSlotSummary | null;
 }
 
 export interface Room {


### PR DESCRIPTION
## Summary
The room detail modal crashed with a white screen whenever the backend returned `null` for `peakTime` or `quietTime` (not enough data yet to compute peak/quiet times). This guards against that and shows a neutral placeholder card instead.

## Changes
- `WeekPatternHeatmap.tsx` — `peakTime`/`quietTime` props now typed as nullable; renders a neutral grey card with "Noch nicht genügend Daten" when null instead of crashing on `peakTime.dayOfWeek`
- `room.ts` — `WeekPatternResponse.peakTime`/`quietTime` typed as nullable to match

## Verification
- Open room detail modal for a room with insufficient history → neutral cards shown, no crash
- Open room detail modal for a room with full history → cards show as before

Part of #217