### PR TITLE
fix: lock body scroll while room detail modal is open #238

### DIFF
--- a/frontend/src/components/RoomDetailModal.tsx
+++ b/frontend/src/components/RoomDetailModal.tsx
@@ -31,6 +31,14 @@ export const RoomDetailModal = ({room, isOpen, onClose}: RoomDetailModalProps) =
         return () => document.removeEventListener('keydown', handleEsc);
     }, [onClose]);
 
+    useEffect(() => {
+        if (!isOpen) return;
+        document.body.style.overflow = 'hidden';
+        return () => {
+            document.body.style.overflow = '';
+        };
+    }, [isOpen]);
+
     if (!isOpen) return null;
 
     return (


### PR DESCRIPTION
## Summary
Scrolling over the chart/heatmap area in the room detail modal caused the page behind the modal to scroll instead, since the `<body>` stayed scrollable while the modal was open.

## Changes
- `RoomDetailModal.tsx` — added a `useEffect` that sets `document.body.style.overflow = 'hidden'` while the modal is open, restoring it on close/unmount

## Verification
- Open room detail modal → scroll over chart/heatmap → background page no longer moves
- Close modal → background page scrolls normally again

Closes #238