### PR TITLE
fix: freeze main layout height and fix sidebar scrolling #198

### DIFF
--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -6,7 +6,7 @@ import { useWebSocket } from '../hooks/useWebSocket';
 export const MainLayout = () => {
     useWebSocket();
     return (
-        <div className="min-h-screen flex bg-[#F3F4F6] text-[#1F2937] font-sans">
+        <div className="h-screen flex bg-[#F3F4F6] text-[#1F2937] font-sans overflow-hidden">
 
                 <Sidebar />
 


### PR DESCRIPTION
## Summary
When the content area had many items (e.g., a long room list), the entire page scrolled including the sidebar. This caused the logout button at the bottom of the sidebar to disappear off-screen. Now, the layout height is locked to the viewport so the sidebar stays fixed while only the content scrolls.

## Changes
- `MainLayout.tsx` — changed the outer container from `min-h-screen` to `h-screen` and added `overflow-hidden` to freeze the global layout height, preventing the sidebar from scrolling away.

## Verification
- Open a page with a long room list → scroll down the list → only the main content area scrolls, while the sidebar and the logout button stay perfectly fixed and visible on screen.
- Toggle sidebar collapse/expand → layout adjusts smoothly and remains fixed.

This PR closes #198