### PR TITLE
Fix/room detail modal error boundary #236

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,29 @@
+import { Component } from 'react';
+import type { ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+    children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+    hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+    state: ErrorBoundaryState = { hasError: false};
+
+    static getDerivedStateFromError() {
+        return { hasError: true};
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return (
+                <div className="bg-gray-50 rounded-lg p-6 text-center text-gray-400">
+                    Diese Ansicht konnte nicht geladen werden.
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}

--- a/frontend/src/components/RoomDetailModal.tsx
+++ b/frontend/src/components/RoomDetailModal.tsx
@@ -4,6 +4,8 @@ import { fetchForecast, fetchHistory, fetchWeekPattern } from "../utils/api";
 import { OccupancyChart } from "./OccupancyChart";
 import { WeekPatternHeatmap } from "./WeekPatternHeatmap"
 import { useRoomStore} from "../hooks/useRoomStore";
+import { Clock } from 'lucide-react';
+import { ErrorBoundary} from "./ErrorBoundary";
 
 interface RoomDetailModalProps {
   room: Room;
@@ -69,31 +71,41 @@ export const RoomDetailModal = ({room, isOpen, onClose}: RoomDetailModalProps) =
                 </div>
 
                 {/* Occupancy Chart */}
-                {history && forecast && (
-                    <div className="mb-6">
-                        <div className="flex items-center justify-between mb-2">
-                            <h3 className="text-lg font-semibold"> Verlauf & Prognose</h3>
-                            <div className="flex gap-1">
-                                {[1, 3, 12, 24, 168].map(h => (
-                                    <button key={h} onClick={() => setTimeRange(h)}
-                                    className={`px-3 py-1 text-sm rounded-lg ${timeRange === h ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
-                                        {h === 168 ? '1W' : `${h}h`}
-                                    </button>
-                                ))}
+                <ErrorBoundary>
+                    {history && forecast && (
+                        <div className="mb-6">
+                            <div className="flex items-center justify-between mb-2">
+                                <h3 className="text-lg font-semibold"> Verlauf & Prognose</h3>
+                                <div className="flex gap-1">
+                                    {[1, 3, 12, 24, 168].map(h => (
+                                        <button key={h} onClick={() => setTimeRange(h)}
+                                        className={`px-3 py-1 text-sm rounded-lg ${timeRange === h ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
+                                            {h === 168 ? '1W' : `${h}h`}
+                                        </button>
+                                    ))}
+                                </div>
                             </div>
+                            <OccupancyChart historyPoints={history.points} forecastPoints={forecast.forecast} capacity={room.capacity} />
+                            {forecast.forecast.length === 0 ? (
+                                <p className="text-sm text-gray-400 mt-1 flex items-center gap-1">
+                                    <Clock className="w-4 h-4"/> Prognose benötigt mehr Daten
+                                </p>
+                            ) : (
+                            <p className="text-sm text-gray-400 mt-1">Backend-Forecast · Konfidenz {Math.round(forecast.confidence * 100)}%</p>
+                                )}
                         </div>
-                        <OccupancyChart historyPoints={history.points} forecastPoints={forecast.forecast} capacity={room.capacity} />
-                        <p className="text-sm text-gray-400 mt-1">Backend-Forecast · Konfidenz {Math.round(forecast.confidence * 100)}%</p>
-                    </div>
-                )}
+                    )}
+                </ErrorBoundary>
 
                 {/* Weekly Pattern Heatmap */}
-                {weekPattern && (
-                    <div>
-                        <h3 className="text-lg font-semibold mb-2"> Wochenmuster (Ø der letzten {weekPattern.weeks} Wochen)</h3>
-                        <WeekPatternHeatmap pattern={weekPattern.pattern} peakTime={weekPattern.peakTime} quietTime={weekPattern.quietTime} />
-                    </div>
-                )}
+                <ErrorBoundary>
+                    {weekPattern && (
+                        <div>
+                            <h3 className="text-lg font-semibold mb-2"> Wochenmuster (Ø der letzten {weekPattern.weeks} Wochen)</h3>
+                            <WeekPatternHeatmap pattern={weekPattern.pattern} peakTime={weekPattern.peakTime} quietTime={weekPattern.quietTime} />
+                        </div>
+                    )}
+                </ErrorBoundary>
 
 
             </div>


### PR DESCRIPTION
## Summary
The room detail modal could still crash from other null/empty API
responses (e.g. empty forecast `points`), and there was no fallback UI
if a component threw — a crash anywhere in the chart/heatmap section
white-screened the entire app.

## Changes
- New `ErrorBoundary.tsx` — class component implementing
  `getDerivedStateFromError`, renders a neutral fallback message
  instead of crashing the tree
- `RoomDetailModal.tsx` — wraps the chart section and the heatmap
  section in separate `ErrorBoundary` instances, so a crash in one
  doesn't take down the other or the KPI cards
- `RoomDetailModal.tsx` — when `forecast.forecast` is empty, shows
  "Prognose benötigt mehr Daten" instead of a bare forecast line with
  no explanation
- KPI cards stay outside both boundaries, so they remain visible even
  if chart/heatmap crash

## Verification
- Open room detail modal for a room with no forecast data → hint shown
  instead of blank chart area
- Manually forced a throw inside the chart component → only the chart
  section shows the fallback message, KPI cards and heatmap unaffected
- Normal room with full data → unchanged behavior

Closes #236