### PR TITLE
fix: cap occupancy history point count so the room detail chart stays responsive

### DIFF
--- a/backend/src/main/java/com/occupi/feature/chart/ChartService.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartService.java
@@ -10,8 +10,9 @@ public interface ChartService {
 
     /**
      * Returns the occupancy history for a room over the last {@code hours}.
-     * Raw points are returned for short windows; longer windows are downsampled
-     * into fixed slots.
+     * Raw points are returned when the window holds at most
+     * {@code chart.history.max-points} readings; busier windows are downsampled
+     * into adaptively-sized slots so the series never exceeds that cap.
      *
      * @param roomId the room to query
      * @param hours  the look-back window in hours (must be &gt; 0)

--- a/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
@@ -43,13 +43,9 @@ public class ChartServiceImpl implements ChartService {
     @Value("${influxdb.measurement:occupancy}")
     private String measurement;
 
-    /** Windows up to this length return raw points; longer windows are downsampled. */
-    @Value("${chart.history.downsample-threshold-hours:24}")
-    private int downsampleThresholdHours;
-
-    /** Slot width used when downsampling a long history window. */
-    @Value("${chart.history.slot-minutes:30}")
-    private int slotMinutes;
+    /** Hard cap on the number of points {@code GET /api/occupancy/history} returns. */
+    @Value("${chart.history.max-points:500}")
+    private int maxPoints;
 
     /** Earliest hour (inclusive) considered when picking the quiet time. */
     @Value("${chart.weekpattern.quiet-start-hour:8}")
@@ -76,12 +72,12 @@ public class ChartServiceImpl implements ChartService {
 
         List<Object[]> rows = queryReadings(roomId, start, end, "\"count\", \"confidence\", time");
 
-        List<HistoryPoint> points = hours <= downsampleThresholdHours
+        List<HistoryPoint> points = rows.size() <= maxPoints
                 ? toRawPoints(rows)
-                : toDownsampledPoints(rows);
+                : toDownsampledPoints(rows, slotMinutesFor(hours));
 
         log.debug("History for room={} window={}h: rows={} points={} downsampled={}",
-                roomId, hours, rows.size(), points.size(), hours > downsampleThresholdHours);
+                roomId, hours, rows.size(), points.size(), rows.size() > maxPoints);
 
         return new HistoryResponse(roomId, points, start, end);
     }
@@ -145,8 +141,9 @@ public class ChartServiceImpl implements ChartService {
     }
 
     /**
-     * Returns one {@link HistoryPoint} per reading, untouched. Used for short
-     * windows where the raw resolution is already small enough for the client.
+     * Returns one {@link HistoryPoint} per reading, untouched. Used when the window
+     * holds at most {@link #maxPoints} readings, i.e. the raw resolution already
+     * fits within the cap.
      */
     private List<HistoryPoint> toRawPoints(List<Object[]> rows) {
         List<HistoryPoint> points = new ArrayList<>(rows.size());
@@ -162,10 +159,10 @@ public class ChartServiceImpl implements ChartService {
     }
 
     /**
-     * Aggregates readings into fixed {@link #slotMinutes}-wide slots (count and
-     * confidence averaged), so a long window doesn't ship thousands of points.
+     * Aggregates readings into fixed {@code slotMinutes}-wide slots (count and
+     * confidence averaged), so a busy window doesn't ship thousands of points.
      */
-    private List<HistoryPoint> toDownsampledPoints(List<Object[]> rows) {
+    private List<HistoryPoint> toDownsampledPoints(List<Object[]> rows, int slotMinutes) {
         long slotSeconds = slotMinutes * 60L;
         // slot start (epoch seconds) → [sumCount, sumConfidence, sampleCount]
         Map<Long, double[]> slots = new LinkedHashMap<>();
@@ -194,6 +191,19 @@ public class ChartServiceImpl implements ChartService {
                     return new HistoryPoint(Instant.ofEpochSecond(e.getKey()), avgCount, avgConfidence);
                 })
                 .toList();
+    }
+
+    /**
+     * Picks the slot width (minutes) for downsampling from the window length, so the
+     * returned series stays at or below {@link #maxPoints} regardless of the sensor's
+     * write rate. Targets {@code maxPoints - 1} full slots; because the window edges
+     * are not aligned to the slot grid, at most one extra partial slot can appear,
+     * keeping the total within the cap.
+     */
+    private int slotMinutesFor(int hours) {
+        long windowMinutes = (long) hours * 60L;
+        long targetSlots = Math.max(1L, maxPoints - 1L);
+        return (int) Math.max(1L, (long) Math.ceil((double) windowMinutes / targetSlots));
     }
 
     private WeekPatternExtreme toExtreme(WeekPatternSlot slot) {

--- a/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,8 +61,7 @@ class ChartServiceImplTest {
     void setUp() {
         service = new ChartServiceImpl(influxDBClient, roomService);
         ReflectionTestUtils.setField(service, "measurement", "occupancy");
-        ReflectionTestUtils.setField(service, "downsampleThresholdHours", 24);
-        ReflectionTestUtils.setField(service, "slotMinutes", 30);
+        ReflectionTestUtils.setField(service, "maxPoints", 500);
         ReflectionTestUtils.setField(service, "quietStartHour", 8);
         ReflectionTestUtils.setField(service, "quietEndHour", 18);
     }
@@ -69,8 +69,8 @@ class ChartServiceImplTest {
     // ---------- history ----------
 
     @Test
-    @DisplayName("history returns raw points unchanged for windows within the threshold")
-    void getHistory_shortWindow_returnsRawPoints() {
+    @DisplayName("history returns raw points unchanged when the readings fit within the cap")
+    void getHistory_readingsWithinCap_returnsRawPoints() {
         Instant t1 = Instant.parse("2025-01-13T10:00:00Z");
         Instant t2 = Instant.parse("2025-01-13T10:05:00Z");
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
@@ -90,10 +90,13 @@ class ChartServiceImplTest {
     }
 
     @Test
-    @DisplayName("history downsamples long windows into averaged slots")
-    void getHistory_longWindow_downsamplesIntoSlots() {
-        // three readings in the same 30-min slot [10:00,10:30) → avg count 20,
-        // one reading in the next aligned slot [11:00,11:30) → count 8
+    @DisplayName("history downsamples into averaged slots once the readings exceed the cap")
+    void getHistory_moreReadingsThanCap_downsamplesIntoSlots() {
+        // A cap of 3 with 4 readings forces the downsample branch. For a 1h window
+        // the adaptive slot width is slotMinutesFor(1) = ceil(60 / (3 - 1)) = 30 min,
+        // so the readings fall into the same epoch-aligned 30-min slots as before:
+        //   three readings in [10:00,10:30) → avg count 20, one in [11:00,11:30) → 8.
+        ReflectionTestUtils.setField(service, "maxPoints", 3);
         Instant a = Instant.parse("2025-01-13T10:00:00Z");
         Instant b = Instant.parse("2025-01-13T10:10:00Z");
         Instant c = Instant.parse("2025-01-13T10:20:00Z");
@@ -105,14 +108,36 @@ class ChartServiceImplTest {
                         new Object[]{30, 0.9, nanos(c)},
                         new Object[]{8, 0.9, nanos(d)}));
 
-        HistoryResponse response = service.getHistory("room-1", 48);
+        HistoryResponse response = service.getHistory("room-1", 1);
 
+        assertThat(response.points()).hasSizeLessThanOrEqualTo(3);
         assertThat(response.points()).hasSize(2);
         assertThat(response.points().get(0).time()).isEqualTo(Instant.parse("2025-01-13T10:00:00Z"));
         assertThat(response.points().get(0).count()).isEqualTo(20);
         assertThat(response.points().get(0).confidence()).isCloseTo(0.9, within(1e-9));
         assertThat(response.points().get(1).time()).isEqualTo(Instant.parse("2025-01-13T11:00:00Z"));
         assertThat(response.points().get(1).count()).isEqualTo(8);
+    }
+
+    @Test
+    @DisplayName("history never returns more than max-points, however dense the window")
+    void getHistory_denseWindow_neverExceedsMaxPoints() {
+        int cap = 10;
+        ReflectionTestUtils.setField(service, "maxPoints", cap);
+        // One reading every 5 minutes across a full week → 2016 readings, far above
+        // the cap and all within the 168h window.
+        Instant base = Instant.parse("2025-01-13T00:00:00Z");
+        List<Object[]> readings = IntStream.range(0, 2016)
+                .mapToObj(i -> new Object[]{i % 50, 0.9, nanos(base.plusSeconds(i * 300L))})
+                .toList();
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> readings.stream());
+
+        HistoryResponse response = service.getHistory("room-1", 168);
+
+        assertThat(response.points()).isNotEmpty();
+        assertThat(response.points()).hasSizeLessThanOrEqualTo(cap);
+        assertThat(response.points().size()).isLessThan(readings.size());
     }
 
     @Test


### PR DESCRIPTION
## Problem

Opening the room detail chart for a busy room (e.g. Seminarraum 137) froze the browser tab. `ChartServiceImpl.getHistory` only downsampled when the window was longer than 24 h, so the default 24 h view — and every range button except "1W" — hit the raw branch and returned every point. With ~70k accumulated sensor frames that handed tens of thousands of points to Recharts, which locked up while drawing the area path and doing tooltip hit-testing.

## Change

Replace the window-length threshold with a point-count cap, `chart.history.max-points` (default 500):

- Return raw points only when the window holds at most the cap.
- Otherwise downsample into fixed slots whose width is derived from the window length, so any range stays within the cap while keeping useful resolution.

The endpoint now never returns more than `max-points` points, regardless of the window length or the sensor's write rate. The fix is purely backend — the frontend renders whatever it receives, so no UI change was needed. This is distinct from #259 (which only clamps how far back a window may reach); even a normal 24 h window froze because the *number* of points was unbounded.

## Tests

- Reworked `ChartServiceImplTest`: raw points when the readings fit under the cap, downsampling once they exceed it, and a new test asserting the returned count never exceeds the cap for a week-long dense window (2016 readings).
- Full backend suite green: 167 tests, 0 failures.

Closes #264
