### PR TITLE
fix: stop unbounded InfluxDB "latest" query from crashing the server (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,23 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `dialout` group, so on the Pi a plain `docker compose up` with `SENSOR_MODE=real` streams
   live occupancy for room 137 (#201).
 
+### Changed
+- The InfluxDB container now runs under a hard resource ceiling in the production
+  compose (0.5 CPU, 2 GiB memory) so one heavy query can never starve the single-core
+  host again. InfluxDB 3 Core does not cancel a running query when the client
+  disconnects, so this cap is the backstop that keeps the box reachable. Auto-deploy
+  only recreates backend/frontend, so applying it needs a manual
+  `docker compose ... up -d influxdb` (#273).
+
+### Fixed
+- The "latest per room / per sensor" reads no longer scan the entire InfluxDB history
+  on every call. The window-function queries in `OccupancyRepository.findAllLatest`
+  and `MetricsRepository.findAllLatest` are now bounded to a configurable recent
+  window (`occupancy.latest-lookback-days` / `metrics.latest-lookback-days`, default
+  7 days). An unbounded scan of a full year of data took about 7 minutes and, polled
+  every 30 s by the frontend, pinned the single-core server's only CPU and made the
+  whole machine unreachable over SSH; the bounded query returns in under a second (#273).
+
 ### Security
 - Room create, update and delete (`POST`/`PUT`/`DELETE /api/rooms`) now require the
   Keycloak `admin` realm role, enforced with method security (`@PreAuthorize`) on the

--- a/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
@@ -7,9 +7,11 @@ import com.occupi.feature.database.InfluxTime;
 import com.occupi.feature.database.model.MetricsData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -28,6 +30,15 @@ public class MetricsRepository {
                     + "\"queueSize\", \"sent\", \"dropped\", \"avgProcessTime\", time";
 
     private final InfluxDBClient influxDBClient;
+
+    /**
+     * How many days back {@link #findAllLatest()} scans for the newest row per sensor.
+     * The scan MUST be bounded: without a time predicate InfluxDB reads the whole
+     * measurement history and sorts it on every call, which pegged the single-core
+     * server CPU once a large amount of data had accumulated (#273).
+     */
+    @Value("${metrics.latest-lookback-days:7}")
+    private int latestLookbackDays = 7;
 
     public void save(MetricsData metrics) {
         validate(metrics);
@@ -91,20 +102,25 @@ public class MetricsRepository {
 
     /**
      * Returns the most recent metrics row for every known sensor.
-     * Uses a window function to pick the latest row per sensorId in a single query.
+     * Uses a window function to pick the latest row per sensorId in a single query,
+     * scanning only the last {@link #latestLookbackDays} days so the query stays
+     * cheap regardless of how much history has accumulated (see #273).
      *
-     * @return one latest row per sensor (empty list if no data exists)
+     * @return one latest row per sensor within the lookback window
+     *         (empty list if no sensor has reported in that window)
      */
     public List<MetricsData> findAllLatest() {
+        Instant since = Instant.now().minus(latestLookbackDays, ChronoUnit.DAYS);
         String sql = """
                 SELECT %s
                 FROM (
                     SELECT %s,
                            ROW_NUMBER() OVER (PARTITION BY "sensorId" ORDER BY time DESC) AS rn
                     FROM "%s"
+                    WHERE time >= '%s'
                 )
                 WHERE rn = 1
-                """.formatted(SELECT_COLUMNS, SELECT_COLUMNS, MEASUREMENT_NAME);
+                """.formatted(SELECT_COLUMNS, SELECT_COLUMNS, MEASUREMENT_NAME, since);
 
         List<MetricsData> result = new ArrayList<>();
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {

--- a/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
@@ -7,9 +7,11 @@ import com.occupi.feature.database.InfluxTime;
 import com.occupi.feature.database.model.OccupancyData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +29,16 @@ public class OccupancyRepository {
     static final String MEASUREMENT_NAME = "occupancy";
 
     private final InfluxDBClient influxDBClient;
+
+    /**
+     * How many days back {@link #findAllLatest()} scans for the newest row per room.
+     * The scan MUST be bounded: without a time predicate InfluxDB reads the whole
+     * measurement history and sorts it on every call, which pegged the single-core
+     * server CPU once a large amount of data had accumulated (#273). A room that has
+     * been silent longer than this window simply won't appear until it reports again.
+     */
+    @Value("${occupancy.latest-lookback-days:7}")
+    private int latestLookbackDays = 7;
 
     /**
      * Saves a single occupancy measurement to InfluxDB.
@@ -94,20 +106,25 @@ public class OccupancyRepository {
 
     /**
      * Returns the most recent occupancy measurement for every known room.
-     * Uses a window function to pick the latest row per roomId in a single query.
+     * Uses a window function to pick the latest row per roomId in a single query,
+     * scanning only the last {@link #latestLookbackDays} days so the query stays
+     * cheap regardless of how much history has accumulated (see #273).
      *
-     * @return one latest measurement per room (empty list if no data exists)
+     * @return one latest measurement per room within the lookback window
+     *         (empty list if no room has reported in that window)
      */
     public List<OccupancyData> findAllLatest() {
+        Instant since = Instant.now().minus(latestLookbackDays, ChronoUnit.DAYS);
         String sql = """
                 SELECT "roomId", "sensorId", "count", "confidence", time
                 FROM (
                     SELECT "roomId", "sensorId", "count", "confidence", time,
                            ROW_NUMBER() OVER (PARTITION BY "roomId" ORDER BY time DESC) AS rn
                     FROM "%s"
+                    WHERE time >= '%s'
                 )
                 WHERE rn = 1
-                """.formatted(MEASUREMENT_NAME);
+                """.formatted(MEASUREMENT_NAME, since);
 
         List<OccupancyData> result = new ArrayList<>();
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -26,6 +26,15 @@ influxdb:
   database: occupi
   token: ""
 
+# "Latest per room / per sensor" reads only scan this many days back, so the
+# InfluxDB window-function query never walks the full measurement history. An
+# unbounded scan pinned the single-core server CPU and crashed it once a large
+# amount of data had accumulated (#273).
+occupancy:
+  latest-lookback-days: 7
+metrics:
+  latest-lookback-days: 7
+
 logging:
   level:
     com.occupi: DEBUG

--- a/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -227,6 +228,21 @@ class MetricsRepositoryTest {
                     .thenAnswer(inv -> Stream.empty());
 
             assertTrue(repository.findAllLatest().isEmpty());
+        }
+
+        @Test
+        @DisplayName("should bound the scan with a time predicate (guards #273)")
+        void shouldBoundScanByTime() {
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty());
+
+            repository.findAllLatest();
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getValue().contains("time >="),
+                    "findAllLatest must constrain the scan with a time predicate, "
+                            + "otherwise it reads the entire measurement history");
         }
     }
 

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyInfluxIntegrationTest.java
@@ -107,4 +107,25 @@ class OccupancyInfluxIntegrationTest {
                             .contains("itroom-b1", "itroom-b2");
                 });
     }
+
+    @Test
+    @DisplayName("findAllLatest ignores rooms whose last reading is older than the lookback window")
+    void findAllLatestExcludesStaleRooms() {
+        // Well outside the default 7-day lookback — the row that used to force a
+        // full-history scan (#273) and must no longer surface in the latest view.
+        Instant stale = Instant.now().minus(400, ChronoUnit.DAYS);
+        repository.save(OccupancyData.builder()
+                .roomId("stale-room").sensorId("s").count(7).confidence(0.5).timestamp(stale).build());
+
+        Instant fresh = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        repository.save(OccupancyData.builder()
+                .roomId("fresh-room").sensorId("s").count(4).confidence(0.9).timestamp(fresh).build());
+
+        await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    List<OccupancyData> all = repository.findAllLatest();
+                    assertThat(all).extracting(OccupancyData::getRoomId).contains("fresh-room");
+                    assertThat(all).extracting(OccupancyData::getRoomId).doesNotContain("stale-room");
+                });
+    }
 }

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -251,6 +252,21 @@ class OccupancyRepositoryTest {
                     .thenAnswer(inv -> Stream.empty());
 
             assertTrue(repository.findAllLatest().isEmpty());
+        }
+
+        @Test
+        @DisplayName("should bound the scan with a time predicate (guards #273)")
+        void shouldBoundScanByTime() {
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty());
+
+            repository.findAllLatest();
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getValue().contains("time >="),
+                    "findAllLatest must constrain the scan with a time predicate, "
+                            + "otherwise it reads the entire measurement history");
         }
     }
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -60,6 +60,22 @@ In prod:
 - Keycloak runs with `KC_HOSTNAME` / `KC_HOSTNAME_STRICT=true` / `KC_PROXY_HEADERS=xforwarded`
   and is served under **`/auth`** (`KC_HTTP_RELATIVE_PATH=/auth`), behind the host Nginx.
 
+### InfluxDB resource cap
+The prod overlay caps InfluxDB at **0.5 CPU and 2 GiB memory**. The dashboard's "latest
+per room" read once scanned the full measurement history on every 30 s poll; on this
+single-core, swapless host that one query pinned the CPU and took the whole machine (SSH
+included) down (#273). The query is now time-bounded in the backend, but the cap stays as
+a backstop — InfluxDB 3 Core does not cancel a running query when the client disconnects,
+so this is what keeps the host reachable if a heavy query ever slips through again.
+
+Auto-deploy only recreates `backend`/`frontend` (see [`../deploy/auto-deploy.sh`](../deploy/auto-deploy.sh)),
+so a normal deploy does **not** apply the cap — apply it once manually:
+```bash
+cd docker
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d influxdb
+docker inspect occupi-influxdb3 -f 'nanocpus={{.HostConfig.NanoCpus}} mem={{.HostConfig.Memory}}'
+```
+
 ### Host Nginx (already present on the server)
 The reverse proxy lives on the host (not in Compose). The versioned config is
 [`../deploy/nginx/occupi.conf`](../deploy/nginx/occupi.conf):

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -45,5 +45,24 @@ services:
     ports:
       - "127.0.0.1:8180:8080"   # host Nginx → keycloak
 
+  # Hard resource ceiling for InfluxDB. The dashboard's "latest per room" read
+  # used to scan the full measurement history; on this single-core host that one
+  # query pinned the CPU and took the whole machine (SSH included) down (#273).
+  # InfluxDB 3 Core does not cancel a running query when the client disconnects,
+  # so this cap is the backstop that keeps the box responsive even if a heavy
+  # query ever slips through again: at most half the core for InfluxDB, and if it
+  # balloons past 2 GiB Docker OOM-kills (and restarts) InfluxDB instead of the host.
+  #
+  # NOTE: auto-deploy only recreates backend/frontend (see deploy/auto-deploy.sh),
+  # so applying this cap needs a manual `docker compose ... up -d influxdb`.
+  influxdb:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 2g
+        reservations:
+          memory: 256m
+
   # influxdb & postgres intentionally have NO 'ports' here:
   # they stay on the internal Docker network and are not exposed to the host.


### PR DESCRIPTION
## Problem
The server became unreachable (SSH down, site dead). The dashboard polls `GET /api/occupancy/all` every 30 s (`useFetchRooms`), which runs `OccupancyRepository.findAllLatest` — a window function over the **entire** `occupancy` measurement with no time filter. Once a large amount of data had accumulated, each call scanned and sorted the full history; on the 1-core / swapless server this pinned the only CPU and took the whole box down. `MetricsRepository.findAllLatest` had the same unbounded pattern.

Measured on the server: `occupancy` held **525,600 rows** (one year of minute data). A plain `COUNT(*)` took **6 min 47 s**; the same count bounded to the last 7 days ran in **0.57 s**. InfluxDB 3 Core also does not cancel a running query when the client disconnects, and the container had no resource limits — so a single bad query could consume the whole host.

## Changes
- **Bound both `findAllLatest` queries** to a configurable recent window (`occupancy.latest-lookback-days` / `metrics.latest-lookback-days`, default 7 days). A room/sensor silent longer than the window drops out of the "latest" view until it reports again — correct for a live occupancy view.
- **Cap the InfluxDB container** in the prod overlay (0.5 CPU, 2 GiB memory) as a backstop, since the server won't cancel a runaway query on its own.
- **Tests**: unit tests assert the scan is time-bounded; a new integration test proves a stale row is excluded from `findAllLatest`.
- **Docs**: CHANGELOG + `docker/README.md`.

## Testing
- `./mvnw test` (backend): 37 unit tests green.
- Verified on the live server: the bounded `COUNT(*)` over the same data returns in 0.57 s vs 6 min 47 s unbounded.

## Operational notes (already done on the server, outside this PR)
- The 525,600 test rows in `occupancy` were deleted (the measurement is recreated on the next sensor write; the dashboard shows mock data until then).
- A live CPU cap (`docker update --cpus=0.5 occupi-influxdb3`) is already in place and survives reboots.
- **Applying the compose cap needs a manual `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d influxdb`** — auto-deploy only recreates backend/frontend.

## Follow-ups (not in scope)
- Make `findAllLatest` return empty instead of erroring when the measurement doesn't exist yet (fresh DB before the first write).
- Consider a short server-side query timeout / result-row cap, and memory limits for the other containers.

Closes #273.