### PR TITLE
Fix/backend degradation resilience #269

### DIFF
--- a/frontend/src/components/RoomStatus.tsx
+++ b/frontend/src/components/RoomStatus.tsx
@@ -2,15 +2,17 @@ import type { Room } from '../types/room';
 
 export function StatusBadge({ occupancyRate }: { occupancyRate: Room['occupancyRate'] }) {
     const styles = {
-        low:    'bg-green-100 text-green-800',
-        medium: 'bg-yellow-100 text-yellow-800',
-        high:   'bg-red-100 text-red-800',
+        low:        'bg-green-100 text-green-800',
+        medium:     'bg-yellow-100 text-yellow-800',
+        high:       'bg-red-100 text-red-800',
+        unknown:    'bg-gray-100 text-gray-500',
     };
 
     const labels = {
         low: 'Niedrig',
         medium: 'Mittel',
         high: 'Hoch',
+        unknown: 'Unbekannt',
     };
     return (
         <span className={`text-xs px-2 py-1 rounded-md font-medium ${styles[occupancyRate]}`}>
@@ -20,8 +22,17 @@ export function StatusBadge({ occupancyRate }: { occupancyRate: Room['occupancyR
 
 }
 
-export function OccupancyBar({count, capacity}: {count: number; capacity: number}) {
+export function OccupancyBar({count, capacity, unavailable}: {count: number; capacity: number; unavailable?: boolean}) {
     const pct = capacity > 0 ? Math.round((count / capacity)*100) : 0;
+
+    if (unavailable) {
+        return (
+            <div className="flex items-center gap-2">
+                <div className="w-24 h-2 bg-gray-100 rounded-full" />
+                <span className="text-gray-400 text-xs">—</span>
+            </div>
+        )
+    }
 
     return (
         <div className="flex items-center gap-2">

--- a/frontend/src/hooks/useFetchRooms.ts
+++ b/frontend/src/hooks/useFetchRooms.ts
@@ -9,33 +9,42 @@ export function useFetchRooms() {
     const { setRooms, isConnected, setIsMockData } = useRoomStore();
 
     const fetchRooms = useCallback (async() => {
-        try {
-            const [roomsRes, occupancyRes] = await Promise.all([
-                api.get<RoomResponse[]>('/rooms'),
-                api.get<Occupancy[]>('/occupancy/all')
-            ]);
+        const [roomsResult, occupancyResult] = await Promise.allSettled([
+            api.get<RoomResponse[]>('/rooms'),
+            api.get<Occupancy[]>('/occupancy/all'),
+        ]);
 
-            const combined: Room[] = roomsRes.data.map((room) => {
-                const occ = occupancyRes.data.find((o) => o.roomId === room.roomId);
-                const ratio = (occ?.count ?? 0) / room.capacity;
-                const occupancyRate = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
-                return {
-                    ...room,
-                    count: occ?.count ?? 0,
-                    confidence: occ?.confidence ?? 0,
-                    timestamp: occ?.timestamp ?? '',
-                    occupancyRate,
-                };
-            });
-
-            // as long as there are no room data in the DB, show / use mock data
-            setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
-            setIsMockData(combined.length === 0);
-        } catch (error) {
-            console.error("Fehler beim Laden:", error);
+        // Only fall back to mock data if the /rooms call itself fails
+        if (roomsResult.status === 'rejected') {
+            console.error("Fehler beim Laden der Räume:", roomsResult.reason);
             setRooms(MOCK_ROOMS);
             setIsMockData(true);
+            return;
         }
+
+        const occupancyAvailable = occupancyResult.status === 'fulfilled';
+        // inline status check so TypeScript narrows to the fulfilled result
+        const occupancyData = occupancyAvailable ? occupancyResult.value.data : [];
+
+        const combined: Room[] = roomsResult.value.data.map((room) => {
+            // Occupancy call failed → occupancy is UNKNOWN, not 0
+            if (!occupancyAvailable) {
+                return { ...room, count: 0, confidence: 0, timestamp: '', occupancyRate: 'unknown' };
+            }
+            const occ = occupancyData.find((o) => o.roomId === room.roomId);
+            const ratio = (occ?.count ?? 0) / room.capacity;
+            const occupancyRate = ratio < 0.5 ? 'low' : ratio < 0.8 ? 'medium' : 'high';
+            return {
+                ...room,
+                count: occ?.count ?? 0,
+                confidence: occ?.confidence ?? 0,
+                timestamp: occ?.timestamp ?? '',
+                occupancyRate,
+            };
+        });
+
+        setRooms(combined.length > 0 ? combined : MOCK_ROOMS);
+        setIsMockData(combined.length === 0);
     }, [setRooms, setIsMockData]);
 
     useEffect(() => {

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -45,6 +45,7 @@ export default function Analytics() {
     const totalCapacity = rooms.reduce((sum, r) => sum + r.capacity, 0);
     const totalPeople = rooms.reduce((sum, r) => sum + r.count, 0);
     const occupancyPct = totalCapacity > 0 ? Math.round((totalPeople / totalCapacity) * 100) : 0;
+    const occupancyUnavailable = rooms.some((r) => r.occupancyRate === 'unknown');
 
     const columns = ['Raum', 'Gebäude', 'Belegung', 'Auslastung'];
 
@@ -57,8 +58,8 @@ export default function Analytics() {
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
                 <SummaryCard label="Räume" value={totalRooms}/>
                 <SummaryCard label="Kapazität" value={totalCapacity}/>
-                <SummaryCard label="Personen anwesend" value={totalPeople}/>
-                <SummaryCard label="Auslastung" value={`${occupancyPct}%`}/>
+                <SummaryCard label="Personen anwesend" value={occupancyUnavailable ? '—' : totalPeople}/>
+                <SummaryCard label="Auslastung" value={occupancyUnavailable ? '—' : `${occupancyPct}%`}/>
             </div>
 
             <div className="flex flex-wrap gap-3 mb-4">
@@ -125,7 +126,7 @@ export default function Analytics() {
                                 <span className="ml-2 text-gray-400 font-normal">{room.roomId}</span>
                             </td>
                             <td className="px-4 py-3 text-sm text-gray-600">{room.building}</td>
-                            <td className="px-4 py-3 text-sm text-gray-600">{room.count} / {room.capacity}</td>
+                            <td className="px-4 py-3 text-sm text-gray-600">{room.occupancyRate === 'unknown' ? '—' : `${room.count} / ${room.capacity}`}</td>
                             <td className="px-4 py-3 text-sm">
                                 <StatusBadge occupancyRate={room.occupancyRate} />
                             </td>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ export default function Dashboard() {
     useFetchRooms();
 
     const [selectedRoom, setSelectedRoom] = useState<Room | null>(null);
+    const occupancyUnavailable = rooms.some((r) => r.occupancyRate === 'unknown');
 
     return (
         <div className="max-w-7xl mx-auto">
@@ -34,6 +35,12 @@ export default function Dashboard() {
                 </div>
             )}
 
+            {occupancyUnavailable && (
+                <div className="mb-4 p-3 bg-orange-50 border border-orange-200 rounded-lg text-sm text-orange-800">
+                    Live-Belegung aktuell nicht verfügbar | Räume werden ohne aktuelle Auslastung angezeigt
+                </div>
+            )}
+
             {/* grid for rooms */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {rooms.map((room) => (
@@ -46,15 +53,16 @@ export default function Dashboard() {
                             </div>
                             {/* traffic light system */}
                             <div className={`w-3 h-3 rounded-full ${
+                                room.occupancyRate === 'unknown' ? 'bg-gray-300' :
                                 room.occupancyRate === 'low' ? 'bg-green-500' :
-                                    room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
+                                room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
                             }`} />
                         </div>
 
                         <div className="flex items-center justify-between">
                             <div className="flex items-center space-x-2 text-gray-600">
                                 <Users size={20} />
-                                <span className="text-2xl font-semibold">{room.count}</span>
+                                <span className="text-2xl font-semibold">{room.occupancyRate === 'unknown' ? '—' : room.count}</span>
                                 <span className="text-gray-400">/ {room.capacity}</span>
                             </div>
                             <Activity size={20} className="text-blue-500 opacity-20" />
@@ -64,8 +72,9 @@ export default function Dashboard() {
                         <div className="mt-4 w-full bg-gray-100 rounded-full h-2">
                             <div
                                 className={`h-2 rounded-full transition-all duration-500 ${
+                                    room.occupancyRate === 'unknown' ? 'bg-gray-300' :
                                     room.occupancyRate === 'low' ? 'bg-green-500' :
-                                        room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
+                                    room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
                                 }`}
                                 style={{ width: `${room.capacity > 0 ? (room.count / room.capacity) * 100 : 0}%` }}
                             />
@@ -74,7 +83,7 @@ export default function Dashboard() {
                 ))}
             </div>
             {selectedRoom && (
-            <RoomDetailModal room={selectedRoom!} isOpen={selectedRoom !== null} onClose={() => setSelectedRoom(null)} />
+            <RoomDetailModal room={selectedRoom} isOpen={true} onClose={() => setSelectedRoom(null)} />
             )}
         </div>
     );

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -10,7 +10,7 @@ const columns: { label: string; render: (r: Room) => React.ReactNode }[] = [
     {label: 'Raum', render: (r) => r.name },
     {label: 'Gebäude', render: (r) => r.building},
     {label: 'Etage', render: (r) => String(r.floor) },
-    {label: 'Belegung', render: (r) => <OccupancyBar count={r.count} capacity={r.capacity} /> },
+    {label: 'Belegung', render: (r) => <OccupancyBar count={r.count} capacity={r.capacity} unavailable={r.occupancyRate === 'unknown'} /> },
     {label: 'Auslastung', render: (r) => <StatusBadge occupancyRate={r.occupancyRate}/> },
     {label: 'Aktualisiert', render: (r) => formatTime(r.timestamp) },
 

--- a/frontend/src/types/room.ts
+++ b/frontend/src/types/room.ts
@@ -66,7 +66,7 @@ export interface Room {
     count: number; // How many people are in the room?
     confidence: number;
     timestamp: string; //
-    occupancyRate: 'low' | 'medium' | 'high'; // status
+    occupancyRate: 'low' | 'medium' | 'high' | 'unknown'; // status
 }
 
 export interface RoomResponse {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -4,6 +4,7 @@ import type { ForecastResponse, HistoryResponse, WeekPatternResponse, RoomRespon
 
 const api = axios.create({
     baseURL: import.meta.env.VITE_API_URL,
+    timeout: 8000,
     headers: {
         'Content-Type': 'application/json',
     },


### PR DESCRIPTION
## Summary
Two complementary resilience improvements so the frontend degrades gracefully when the backend is slow or InfluxDB is unavailable:
- **#269:** a client-side request timeout so requests fail fast instead of waiting ~60s for an Nginx 504.
- **#275:** the room list now renders from Postgres (`/rooms`) even when occupancy (`/occupancy/all`, InfluxDB) is unavailable, instead of falling back entirely to mock data.

## Changes
- `api.ts` — added `timeout: 8000` to the axios instance (#269)
- `useFetchRooms.ts` — `Promise.allSettled` so a successful `/rooms` alone renders rooms; mock fallback only when `/rooms` itself fails; occupancy-less rooms marked `occupancyRate: 'unknown'` instead of a misleading `count: 0` (#275)
- `types/room.ts` — `occupancyRate` gains an `'unknown'` state
- `RoomStatus.tsx`, `Dashboard.tsx`, `Rooms.tsx`, `Analytics.tsx` — render occupancy as a neutral "—" / grey when unknown, instead of a green 0
- `Dashboard.tsx` — banner shown when live occupancy is unavailable

## Verification
- `npm run build` green
- Backend hanging → requests fail after ~8s instead of ~60s
- `/occupancy/all` unavailable but `/rooms` OK → real rooms shown with neutral "—" occupancy + banner, not mock
- Normal operation → unchanged

Closes #269
Closes #275