### PR TITLE
perf: cache room-detail chart/forecast/week-pattern reads (#280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   disconnects, so this cap is the backstop that keeps the box reachable. Auto-deploy
   only recreates backend/frontend, so applying it needs a manual
   `docker compose ... up -d influxdb` (#273).
+- The room-detail reads (`GET /api/occupancy/history`, `/api/forecast`,
+  `/api/occupancy/weekpattern`) are now cached in memory (Caffeine), keyed by room and
+  window. Opening a room or switching the hour filter re-ran all three — including a full
+  8-week week-pattern scan and the forecast's four lookback queries — every time and once
+  per concurrent viewer; on the single-core host these serialized on the CPU-capped
+  InfluxDB and everyone waited. Repeated and concurrent requests now share one
+  computation, with short per-endpoint TTLs and a bounded cache size (#280).
 
 ### Fixed
 - The "latest per room / per sensor" reads no longer scan the entire InfluxDB history

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -146,6 +146,17 @@
 			<version>${influxdb3.version}</version>
 		</dependency>
 
+		<!-- In-memory caching (Caffeine) for the room-detail chart/forecast reads (#280).
+		     Keeps repeated/concurrent requests for the same room off the CPU-capped InfluxDB. -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+		</dependency>
+
 		<!-- Mockito for TDD -->
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/backend/src/main/java/com/occupi/app/CacheConfig.java
+++ b/backend/src/main/java/com/occupi/app/CacheConfig.java
@@ -1,0 +1,69 @@
+package com.occupi.app;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+/**
+ * In-memory caching for the room-detail read path (history, forecast, week pattern).
+ *
+ * <p>Those three endpoints re-run the same expensive InfluxDB aggregations every time a
+ * room is opened or the hour filter is switched, and once per concurrent viewer. On the
+ * single-core host InfluxDB is capped at 0.5 CPU (#273), so identical queries serialize
+ * and every viewer waits. The results are identical for every viewer of a room and change
+ * slowly, so a short-lived cache lets concurrent/repeat requests share one computation
+ * instead of recomputing it (#280).
+ *
+ * <p>Caches are bounded by {@code chart.cache.max-entries} — the host has no swap, so an
+ * unbounded cache must never be able to exhaust the heap. The realistic key space is small
+ * (rooms × the five fixed hour ranges), so the default bound leaves ample headroom.
+ */
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    public static final String HISTORY = "occupancyHistory";
+    public static final String FORECAST = "occupancyForecast";
+    public static final String WEEK_PATTERN = "occupancyWeekPattern";
+
+    /** History changes as new points arrive, so it is cached only briefly. */
+    @Value("${chart.cache.history-ttl-seconds:60}")
+    private long historyTtlSeconds;
+
+    /** A forecast is built from weeks of history and barely moves within an hour. */
+    @Value("${chart.cache.forecast-ttl-seconds:600}")
+    private long forecastTtlSeconds;
+
+    /** The 8-week pattern is almost static; cache it the longest. */
+    @Value("${chart.cache.weekpattern-ttl-seconds:1800}")
+    private long weekPatternTtlSeconds;
+
+    /** Hard upper bound on entries per cache (swap-less host safety). */
+    @Value("${chart.cache.max-entries:2000}")
+    private long maxEntries;
+
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        // Never cache nulls; combined with the @Cacheable 'unless' this keeps empty
+        // results out of the cache so a room that just got data isn't stuck empty.
+        manager.setAllowNullValues(false);
+        manager.registerCustomCache(HISTORY, spec(historyTtlSeconds));
+        manager.registerCustomCache(FORECAST, spec(forecastTtlSeconds));
+        manager.registerCustomCache(WEEK_PATTERN, spec(weekPatternTtlSeconds));
+        return manager;
+    }
+
+    private com.github.benmanes.caffeine.cache.Cache<Object, Object> spec(long ttlSeconds) {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(ttlSeconds))
+                .maximumSize(maxEntries)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
@@ -2,6 +2,7 @@ package com.occupi.feature.chart;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.app.CacheConfig;
 import com.occupi.feature.chart.dto.HistoryPoint;
 import com.occupi.feature.chart.dto.HistoryResponse;
 import com.occupi.feature.chart.dto.WeekPatternExtreme;
@@ -11,6 +12,7 @@ import com.occupi.feature.database.InfluxTime;
 import com.occupi.feature.room.RoomService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.DayOfWeek;
@@ -61,6 +63,8 @@ public class ChartServiceImpl implements ChartService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheConfig.HISTORY, key = "#roomId + '@' + #hours",
+            unless = "#result == null || #result.points().isEmpty()")
     public HistoryResponse getHistory(String roomId, int hours) {
         validateRoomId(roomId);
         if (hours <= 0) {
@@ -83,6 +87,8 @@ public class ChartServiceImpl implements ChartService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheConfig.WEEK_PATTERN, key = "#roomId + '@' + #weeks",
+            unless = "#result == null || #result.pattern().isEmpty()")
     public WeekPatternResponse getWeekPattern(String roomId, int weeks) {
         validateRoomId(roomId);
         if (weeks <= 0) {

--- a/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
@@ -2,11 +2,13 @@ package com.occupi.feature.forecast;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.app.CacheConfig;
 import com.occupi.feature.database.InfluxTime;
 import com.occupi.feature.forecast.dto.ForecastPoint;
 import com.occupi.feature.forecast.dto.ForecastResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -39,6 +41,8 @@ public class ForecastServiceImpl implements ForecastService {
     }
 
     @Override
+    @Cacheable(cacheNames = CacheConfig.FORECAST, key = "#roomId + '@' + #forecastHours",
+            unless = "#result == null || #result.forecast().isEmpty()")
     public ForecastResponse forecast(String roomId, int forecastHours) {
         if (roomId == null || roomId.isBlank()) {
             throw new IllegalArgumentException("roomId must not be blank");

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -35,6 +35,16 @@ occupancy:
 metrics:
   latest-lookback-days: 7
 
+# Caches for the room-detail reads (history / forecast / week-pattern). These results
+# are identical for every viewer of a room and change slowly, so a short-lived cache
+# keeps repeated and concurrent requests off the CPU-capped InfluxDB (#280).
+chart:
+  cache:
+    history-ttl-seconds: 60
+    forecast-ttl-seconds: 600
+    weekpattern-ttl-seconds: 1800
+    max-entries: 2000
+
 logging:
   level:
     com.occupi: DEBUG

--- a/backend/src/test/java/com/occupi/app/ChartReadCacheTest.java
+++ b/backend/src/test/java/com/occupi/app/ChartReadCacheTest.java
@@ -1,0 +1,128 @@
+package com.occupi.app;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.chart.ChartService;
+import com.occupi.feature.forecast.ForecastService;
+import com.occupi.feature.room.RoomService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the room-detail read caching (#280): repeated or concurrent requests for the
+ * same room+window must reuse one InfluxDB computation instead of re-querying the
+ * CPU-capped InfluxDB every time.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("Room-detail read caching (#280)")
+class ChartReadCacheTest {
+
+    @MockitoBean
+    InfluxDBClient influxDBClient;
+
+    // ChartServiceImpl.getWeekPattern reads the room's capacity through this.
+    @MockitoBean
+    RoomService roomService;
+
+    @Autowired
+    ChartService chartService;
+
+    @Autowired
+    ForecastService forecastService;
+
+    @Autowired
+    CacheManager cacheManager;
+
+    /** InfluxDB 3 returns the time column as nanoseconds since epoch (BigInteger). */
+    private static BigInteger nanos(Instant t) {
+        return BigInteger.valueOf(t.getEpochSecond())
+                .multiply(BigInteger.valueOf(1_000_000_000L))
+                .add(BigInteger.valueOf(t.getNano()));
+    }
+
+    /** Return the given rows as a fresh stream on every query so aggregations aren't empty. */
+    private void stubRows(Object[]... rows) {
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.of(rows));
+    }
+
+    @BeforeEach
+    void clearCaches() {
+        cacheManager.getCacheNames().forEach(name -> cacheManager.getCache(name).clear());
+    }
+
+    @Test
+    @DisplayName("second identical history request is served from cache (one query)")
+    void historyCachedForSameArgs() {
+        stubRows(new Object[]{5L, 0.9, nanos(Instant.now().minusSeconds(600))});
+
+        chartService.getHistory("room-1", 24);
+        chartService.getHistory("room-1", 24);
+
+        verify(influxDBClient, times(1)).query(anyString(), any(QueryOptions.class));
+    }
+
+    @Test
+    @DisplayName("distinct room/window combinations are cached separately")
+    void historyDistinctArgsNotShared() {
+        stubRows(new Object[]{5L, 0.9, nanos(Instant.now().minusSeconds(600))});
+
+        chartService.getHistory("room-1", 24);
+        chartService.getHistory("room-1", 168);   // different window
+        chartService.getHistory("room-2", 24);      // different room
+
+        verify(influxDBClient, times(3)).query(anyString(), any(QueryOptions.class));
+    }
+
+    @Test
+    @DisplayName("empty results are not cached, so the query re-runs until data exists")
+    void emptyHistoryNotCached() {
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.empty());
+
+        chartService.getHistory("ghost", 24);
+        chartService.getHistory("ghost", 24);
+
+        verify(influxDBClient, times(2)).query(anyString(), any(QueryOptions.class));
+    }
+
+    @Test
+    @DisplayName("forecast (4 lookback queries) is computed once, then cached")
+    void forecastCachedForSameArgs() {
+        stubRows(new Object[]{5L, nanos(Instant.now().minusSeconds(3600))});
+
+        forecastService.forecast("room-1", 24);
+        forecastService.forecast("room-1", 24);
+
+        // forecast.lookback-weeks defaults to 4 -> 4 queries from the first call only
+        verify(influxDBClient, times(4)).query(anyString(), any(QueryOptions.class));
+    }
+
+    @Test
+    @DisplayName("week pattern is cached per room (flipping the hour filter reuses it)")
+    void weekPatternCachedForSameArgs() {
+        stubRows(new Object[]{5L, nanos(Instant.now().minusSeconds(3600))});
+
+        chartService.getWeekPattern("room-1", 8);
+        chartService.getWeekPattern("room-1", 8);
+
+        verify(influxDBClient, times(1)).query(anyString(), any(QueryOptions.class));
+    }
+}


### PR DESCRIPTION
Closes #280.

## Problem
Opening a room detail modal, and every click on the hour filter (1h/3h/12h/24h/1W), re-ran all three chart reads: `GET /api/occupancy/history`, `GET /api/forecast` (4 InfluxDB queries — one per lookback week) and `GET /api/occupancy/weekpattern` (a full 8-week scan) — ~6 InfluxDB queries per action, and the week-pattern was re-queried on every filter change even though it never depends on the filter. With several people on the same room, the same aggregations were recomputed in parallel; InfluxDB is capped at 0.5 CPU on the single-core host (#273), so the queries serialized and everyone waited.

## Fix
A bounded in-memory Caffeine cache in front of the three read services, keyed by (roomId, window):
- `spring-boot-starter-cache` + Caffeine; `CacheConfig` registers three caches with their own TTLs and a hard `maximumSize` (swap-less host).
- `@Cacheable` on `getHistory`, `forecast`, `getWeekPattern`. Only **non-empty** results are cached (`unless`), so a room that just got data isn't stuck empty.
- TTLs configurable under `chart.cache.*` (defaults: history 60s, forecast 10min, week-pattern 30min).

Concurrent/repeat requests now share one computation, and flipping the hour filter reuses the cached week-pattern instead of re-scanning 8 weeks.

## Testing
- `ChartReadCacheTest` (5 tests, `@SpringBootTest`): a repeated request hits the cache (one InfluxDB query), distinct room/window keys are cached separately, empty results are not cached, and the forecast's 4 lookback queries run once then serve from cache.
- Full affected suite green (`./mvnw test`, 25 selected tests, 0 failures).

## Scope & trade-offs (honest)
- **Only** the three room-detail reads are cached — **not** `/occupancy/all` (the dashboard), which was not the reported bottleneck and interacts with the live WebSocket.
- Cached data can be up to its TTL old — negligible here since these are slow-moving aggregates.
- The **first** viewer of a not-yet-cached (room, window) still pays full cost; caching helps repeated/concurrent access.

## Related frontend follow-ups (separate)
- Load the week-pattern once per open, not on every hour-filter change.
- Render each chart as it arrives instead of blocking on all three (`Promise.all`).