### PR TITLE
add: bucket occupancy history and forecast into regular time slots with gaps #278

### DIFF
--- a/backend/src/main/java/com/occupi/feature/chart/ChartService.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartService.java
@@ -9,14 +9,16 @@ import com.occupi.feature.chart.dto.WeekPatternResponse;
 public interface ChartService {
 
     /**
-     * Returns the occupancy history for a room over the last {@code hours}.
-     * Raw points are returned when the window holds at most
-     * {@code chart.history.max-points} readings; busier windows are downsampled
-     * into adaptively-sized slots so the series never exceeds that cap.
+     * Returns the occupancy history for a room over the last {@code hours} as a
+     * regular, window-scaled slot series (#278). The slot width is derived from the
+     * window (wider windows use wider slots, capped at
+     * {@code chart.history.max-points} slots), boundaries are aligned to a clean grid,
+     * and a slot with no readings is still emitted with a {@code null} count — so gaps
+     * stay visible and an empty slot is distinguishable from a real {@code count = 0}.
      *
      * @param roomId the room to query
      * @param hours  the look-back window in hours (must be &gt; 0)
-     * @return a {@link HistoryResponse} with the points and the queried window
+     * @return a {@link HistoryResponse} with the slot points and the queried window
      */
     HistoryResponse getHistory(String roomId, int hours);
 

--- a/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
@@ -13,7 +13,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
 import java.time.DayOfWeek;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -28,10 +30,12 @@ import java.util.stream.Stream;
 /**
  * Default {@link ChartService} implementation.
  *
- * <p>Reads raw occupancy points from InfluxDB and aggregates them in memory —
- * mirroring the {@code forecast} feature — so the read path stays consistent and
- * unit-testable against a mocked client. Aggregating in Java (rather than via SQL
- * {@code GROUP BY}) also keeps weekday/hour bucketing in the configured local zone.
+ * <p>Reads occupancy points from InfluxDB for the room detail view. The history
+ * series is bucketed into regular, window-scaled slots straight in the database via
+ * {@code date_bin} + {@code GROUP BY} (#278), with empty slots filled in afterwards so
+ * gaps stay visible. The weekly pattern still aggregates in memory — mirroring the
+ * {@code forecast} feature — so weekday/hour bucketing happens in the configured local
+ * zone rather than via SQL.
  */
 @Slf4j
 @Service
@@ -55,6 +59,9 @@ public class ChartServiceImpl implements ChartService {
     @Value("${chart.weekpattern.quiet-end-hour:18}")
     private int quietEndHour;
 
+    /** The wall clock the read window is measured against; overridable in tests. */
+    private Clock clock = Clock.systemUTC();
+
     public ChartServiceImpl(InfluxDBClient influxDBClient, RoomService roomService) {
         this.influxDBClient = influxDBClient;
         this.roomService = roomService;
@@ -67,19 +74,28 @@ public class ChartServiceImpl implements ChartService {
             throw new IllegalArgumentException("hours must be positive, got: " + hours);
         }
 
-        Instant end = Instant.now();
-        Instant start = end.minus(hours, ChronoUnit.HOURS);
+        int slotMinutes = TimeSlots.slotMinutes(hours, maxPoints);
+        Duration slot = Duration.ofMinutes(slotMinutes);
 
-        List<Object[]> rows = queryReadings(roomId, start, end, "\"count\", \"confidence\", time");
+        Instant end = clock.instant();
+        Instant gridStart = TimeSlots.floorToSlot(end.minus(hours, ChronoUnit.HOURS), slot);
 
-        List<HistoryPoint> points = rows.size() <= maxPoints
-                ? toRawPoints(rows)
-                : toDownsampledPoints(rows, slotMinutesFor(hours));
+        Map<Instant, double[]> buckets = queryHistoryBuckets(roomId, gridStart, end, slotMinutes);
 
-        log.debug("History for room={} window={}h: rows={} points={} downsampled={}",
-                roomId, hours, rows.size(), points.size(), rows.size() > maxPoints);
+        List<HistoryPoint> points = TimeSlots.grid(gridStart, end, slot).stream()
+                .map(slotStart -> {
+                    double[] agg = buckets.get(slotStart);
+                    if (agg == null) {
+                        return new HistoryPoint(slotStart, null, 0.0); // explicit gap
+                    }
+                    return new HistoryPoint(slotStart, (int) Math.round(agg[0]), agg[1]);
+                })
+                .toList();
 
-        return new HistoryResponse(roomId, points, start, end);
+        log.debug("History for room={} window={}h: slotMinutes={} slots={} filled={}",
+                roomId, hours, slotMinutes, points.size(), buckets.size());
+
+        return new HistoryResponse(roomId, points, gridStart, end);
     }
 
     @Override
@@ -89,7 +105,7 @@ public class ChartServiceImpl implements ChartService {
             throw new IllegalArgumentException("weeks must be positive, got: " + weeks);
         }
 
-        Instant end = Instant.now();
+        Instant end = clock.instant();
         Instant start = end.minus(weeks * 7L, ChronoUnit.DAYS);
 
         List<Object[]> rows = queryReadings(roomId, start, end, "\"count\", time");
@@ -141,69 +157,41 @@ public class ChartServiceImpl implements ChartService {
     }
 
     /**
-     * Returns one {@link HistoryPoint} per reading, untouched. Used when the window
-     * holds at most {@link #maxPoints} readings, i.e. the raw resolution already
-     * fits within the cap.
+     * Buckets the room's readings into fixed {@code slotMinutes}-wide slots straight in
+     * InfluxDB via {@code date_bin} + {@code GROUP BY}, so the heavy aggregation runs in
+     * the database (keeping the read path off the single-core server's heap — #259/#264)
+     * and only one row per non-empty slot crosses the wire. Bins are anchored to the
+     * Unix epoch, matching {@link TimeSlots#floorToSlot}, so each returned slot start
+     * lines up with a grid instant. Empty slots are filled in by {@link #getHistory}.
+     *
+     * @return slot-start instant → {@code [avgCount, avgConfidence]} for each non-empty slot
      */
-    private List<HistoryPoint> toRawPoints(List<Object[]> rows) {
-        List<HistoryPoint> points = new ArrayList<>(rows.size());
-        for (Object[] row : rows) {
-            if (row[0] == null || row[2] == null) {
-                continue;
-            }
-            int count = ((Number) row[0]).intValue();
-            double confidence = row[1] == null ? 0.0 : ((Number) row[1]).doubleValue();
-            points.add(new HistoryPoint(InfluxTime.toInstant(row[2]), count, confidence));
+    private Map<Instant, double[]> queryHistoryBuckets(String roomId, Instant start, Instant end, int slotMinutes) {
+        String sql = """
+                SELECT date_bin(INTERVAL '%d minutes', time, TIMESTAMP '1970-01-01T00:00:00Z') AS slot,
+                       avg("count") AS avg_count,
+                       avg("confidence") AS avg_confidence
+                FROM "%s"
+                WHERE "roomId" = '%s'
+                  AND time >= '%s'
+                  AND time < '%s'
+                GROUP BY slot
+                ORDER BY slot ASC
+                """.formatted(slotMinutes, measurement, roomId, start, end);
+
+        Map<Instant, double[]> buckets = new LinkedHashMap<>();
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            rows.forEach(row -> {
+                if (row == null || row.length < 2 || row[0] == null || row[1] == null) {
+                    return;
+                }
+                Instant slotStart = InfluxTime.toInstant(row[0]);
+                double avgCount = ((Number) row[1]).doubleValue();
+                double avgConfidence = row.length > 2 && row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
+                buckets.put(slotStart, new double[]{avgCount, avgConfidence});
+            });
         }
-        return points;
-    }
-
-    /**
-     * Aggregates readings into fixed {@code slotMinutes}-wide slots (count and
-     * confidence averaged), so a busy window doesn't ship thousands of points.
-     */
-    private List<HistoryPoint> toDownsampledPoints(List<Object[]> rows, int slotMinutes) {
-        long slotSeconds = slotMinutes * 60L;
-        // slot start (epoch seconds) → [sumCount, sumConfidence, sampleCount]
-        Map<Long, double[]> slots = new LinkedHashMap<>();
-
-        for (Object[] row : rows) {
-            if (row[0] == null || row[2] == null) {
-                continue;
-            }
-            double count = ((Number) row[0]).doubleValue();
-            double confidence = row[1] == null ? 0.0 : ((Number) row[1]).doubleValue();
-            long epochSecond = InfluxTime.toInstant(row[2]).getEpochSecond();
-            long slotStart = Math.floorDiv(epochSecond, slotSeconds) * slotSeconds;
-
-            double[] acc = slots.computeIfAbsent(slotStart, k -> new double[]{0.0, 0.0, 0.0});
-            acc[0] += count;
-            acc[1] += confidence;
-            acc[2] += 1;
-        }
-
-        return slots.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .map(e -> {
-                    double[] acc = e.getValue();
-                    int avgCount = (int) Math.round(acc[0] / acc[2]);
-                    double avgConfidence = acc[1] / acc[2];
-                    return new HistoryPoint(Instant.ofEpochSecond(e.getKey()), avgCount, avgConfidence);
-                })
-                .toList();
-    }
-
-    /**
-     * Picks the slot width (minutes) for downsampling from the window length, so the
-     * returned series stays at or below {@link #maxPoints} regardless of the sensor's
-     * write rate. Targets {@code maxPoints - 1} full slots; because the window edges
-     * are not aligned to the slot grid, at most one extra partial slot can appear,
-     * keeping the total within the cap.
-     */
-    private int slotMinutesFor(int hours) {
-        long windowMinutes = (long) hours * 60L;
-        long targetSlots = Math.max(1L, maxPoints - 1L);
-        return (int) Math.max(1L, (long) Math.ceil((double) windowMinutes / targetSlots));
+        return buckets;
     }
 
     private WeekPatternExtreme toExtreme(WeekPatternSlot slot) {

--- a/backend/src/main/java/com/occupi/feature/chart/TimeSlots.java
+++ b/backend/src/main/java/com/occupi/feature/chart/TimeSlots.java
@@ -1,0 +1,97 @@
+package com.occupi.feature.chart;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Shared time-slot math for the occupancy read side (#278).
+ *
+ * <p>History and forecast both present their series as regular, fixed-width slots
+ * aligned to a clean grid, with explicit empty slots where no data exists. For the
+ * two series to line up, they derive the slot width from the requested window with
+ * the <em>same</em> mapping and floor timestamps to the <em>same</em> epoch-anchored
+ * grid that InfluxDB's {@code date_bin(INTERVAL, time, TIMESTAMP '1970-01-01Z')} bins
+ * to — so SQL buckets and the in-memory gap-fill land on identical boundaries.
+ */
+public final class TimeSlots {
+
+    private TimeSlots() {
+    }
+
+    /**
+     * Window length (hours, inclusive upper bound) → slot width (minutes), smallest
+     * first. Beyond the last breakpoint the widest width is used, then widened
+     * further if needed to honour the point cap (see {@link #slotMinutes}).
+     */
+    private static final int[][] BREAKPOINTS = {
+            {1, 10},    // ≤ 1h  → 10 min
+            {3, 30},    // ≤ 3h  → 30 min
+            {12, 60},   // ≤ 12h → 1 h
+            {24, 120},  // ≤ 24h → 2 h
+            {168, 360}, // ≤ 1W  → 6 h
+    };
+
+    /**
+     * Picks the slot width (minutes) for a window — the single mapping shared by
+     * history and forecast, so equal windows produce an equal grid.
+     *
+     * <p>The width comes from a fixed breakpoint table (1h→10m, 3h→30m, 12h→1h,
+     * 24h→2h, 1W→6h). For windows longer than a week — or any window whose table
+     * width would still yield more than {@code maxPoints} slots — the width is
+     * widened just enough to keep the series at or below {@code maxPoints},
+     * preserving the point cap from #264.
+     *
+     * @param windowHours the requested window length in hours (must be &gt; 0)
+     * @param maxPoints   the hard cap on the number of slots the series may hold
+     * @return the slot width in minutes (always &ge; 1)
+     */
+    public static int slotMinutes(int windowHours, int maxPoints) {
+        if (windowHours <= 0) {
+            throw new IllegalArgumentException("windowHours must be positive, got: " + windowHours);
+        }
+        int fromTable = BREAKPOINTS[BREAKPOINTS.length - 1][1];
+        for (int[] breakpoint : BREAKPOINTS) {
+            if (windowHours <= breakpoint[0]) {
+                fromTable = breakpoint[1];
+                break;
+            }
+        }
+        long windowMinutes = (long) windowHours * 60L;
+        // Divide by maxPoints-1, not maxPoints: floor-aligning the window start to the grid
+        // can add one extra partial slot, so this keeps the emitted series at or below
+        // maxPoints (the #264 cap) rather than maxPoints+1.
+        long targetSlots = Math.max(1L, (long) maxPoints - 1L);
+        long capFloor = (long) Math.ceil((double) windowMinutes / targetSlots);
+        return (int) Math.max(1L, Math.max(fromTable, capFloor));
+    }
+
+    /**
+     * Floors an instant down to the start of its slot on the epoch-anchored grid —
+     * the same grid {@code date_bin} uses — so a SQL bucket's start and this Java
+     * grid share identical instants (and therefore compare equal as map keys).
+     */
+    public static Instant floorToSlot(Instant instant, Duration slot) {
+        long slotSeconds = slot.getSeconds();
+        long flooredSecond = Math.floorDiv(instant.getEpochSecond(), slotSeconds) * slotSeconds;
+        return Instant.ofEpochSecond(flooredSecond);
+    }
+
+    /**
+     * Builds every slot-start on the grid covering {@code [gridStart, end)}, stepping
+     * by {@code slot}. {@code gridStart} must already be slot-aligned (see
+     * {@link #floorToSlot}). The final entry is the slot containing {@code end}; the
+     * caller emits an empty marker for any slot that holds no data.
+     *
+     * @return the ordered slot-start instants, oldest first (empty if {@code end}
+     *         is not after {@code gridStart})
+     */
+    public static List<Instant> grid(Instant gridStart, Instant end, Duration slot) {
+        List<Instant> slots = new ArrayList<>();
+        for (Instant slotStart = gridStart; slotStart.isBefore(end); slotStart = slotStart.plus(slot)) {
+            slots.add(slotStart);
+        }
+        return slots;
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/chart/dto/HistoryPoint.java
+++ b/backend/src/main/java/com/occupi/feature/chart/dto/HistoryPoint.java
@@ -3,16 +3,22 @@ package com.occupi.feature.chart.dto;
 import java.time.Instant;
 
 /**
- * A single point in an occupancy history series.
+ * A single point in a room's occupancy history series.
  *
- * @param time       the instant the measurement applies to (slot start for
- *                   downsampled series)
- * @param count      the anonymized headcount; the rounded average when the
- *                   series is downsampled into slots
- * @param confidence confidence score of the measurement in [0.0, 1.0]
+ * <p>Points are emitted on a regular, window-scaled slot grid (#278). A slot with no
+ * readings is still emitted, with a {@code null} {@code count} marking the gap — so an
+ * empty slot is distinguishable from a real {@code count = 0}, letting the frontend
+ * draw a continuous time axis instead of collapsing missing periods into time jumps.
+ *
+ * @param time       the slot-start instant on the grid
+ * @param count      the average anonymized headcount over the slot, rounded to the
+ *                   nearest whole person, or {@code null} if the slot had no readings
+ *                   (an explicit gap, not zero occupancy)
+ * @param confidence the average measurement confidence over the slot in [0.0, 1.0];
+ *                   {@code 0.0} for an empty slot
  */
 public record HistoryPoint(
         Instant time,
-        int count,
+        Integer count,
         double confidence
 ) {}

--- a/backend/src/main/java/com/occupi/feature/database/InfluxTime.java
+++ b/backend/src/main/java/com/occupi/feature/database/InfluxTime.java
@@ -2,13 +2,18 @@ package com.occupi.feature.database;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 /**
- * Converts the {@code time} column returned by InfluxDB 3 queries into {@link Instant}.
+ * Converts a timestamp column returned by InfluxDB 3 queries into {@link Instant}.
  *
- * The influxdb3-java client returns the timestamp as nanoseconds-since-epoch
- * (typically a {@link BigInteger}) rather than an {@link Instant}, so a plain
- * cast fails at runtime. This helper accepts the value defensively.
+ * The influxdb3-java client returns the raw {@code time} column as nanoseconds-since-epoch
+ * (typically a {@link BigInteger}), but SQL time functions such as {@code date_bin} return
+ * their timestamp column as a timezone-less {@link LocalDateTime} (the UTC wall-clock). A
+ * plain cast therefore fails at runtime, so this helper accepts every shape defensively.
  */
 public final class InfluxTime {
 
@@ -25,6 +30,17 @@ public final class InfluxTime {
         }
         if (value instanceof Instant instant) {
             return instant;
+        }
+        if (value instanceof OffsetDateTime odt) {
+            return odt.toInstant();
+        }
+        if (value instanceof ZonedDateTime zdt) {
+            return zdt.toInstant();
+        }
+        if (value instanceof LocalDateTime ldt) {
+            // date_bin (and other SQL time functions) return a timezone-less timestamp;
+            // InfluxDB stores and bins in UTC, so read the wall-clock as UTC.
+            return ldt.toInstant(ZoneOffset.UTC);
         }
         if (value instanceof BigInteger nanos) {
             return ofEpochNanos(nanos.longValueExact());

--- a/backend/src/main/java/com/occupi/feature/forecast/ForecastService.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/ForecastService.java
@@ -5,11 +5,13 @@ import com.occupi.feature.forecast.dto.ForecastResponse;
 public interface ForecastService {
 
     /**
-     * Produces a short-term occupancy forecast for the given room.
+     * Produces a short-term occupancy forecast for the given room as a regular,
+     * window-scaled slot series (#278) — the same slot grid the history series uses,
+     * with empty slots (a {@code null} predicted count) where no lookback week has data.
      *
-     * @param roomId  the room to forecast
-     * @param minutes the lookahead horizon in minutes (e.g., 30)
-     * @return a {@link ForecastResponse} containing the predicted count and metadata
+     * @param roomId        the room to forecast
+     * @param forecastHours the lookahead horizon in hours (must be &gt; 0)
+     * @return a {@link ForecastResponse} containing the predicted slot points and metadata
      */
-    ForecastResponse forecast(String roomId, int hours);
+    ForecastResponse forecast(String roomId, int forecastHours);
 }

--- a/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
@@ -2,6 +2,7 @@ package com.occupi.feature.forecast;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.chart.TimeSlots;
 import com.occupi.feature.database.InfluxTime;
 import com.occupi.feature.forecast.dto.ForecastPoint;
 import com.occupi.feature.forecast.dto.ForecastResponse;
@@ -9,16 +10,33 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Stream;
 
+/**
+ * Default {@link ForecastService} implementation.
+ *
+ * <p>Projects the coming window from the same weekday-and-time in previous weeks,
+ * weighting more recent weeks more heavily (exponential decay). Forecast points are
+ * emitted on the <em>same</em> regular, window-scaled slot grid as the history series
+ * (#278) via {@link TimeSlots}, including empty slots — marked with a {@code null}
+ * {@code predictedCount} — for slots that no lookback week provides data for.
+ *
+ * <p>The week-over-week fold is a fixed UTC shift of whole weeks, matching history's
+ * epoch/UTC grid. A consequence is that across a local daylight-saving transition the
+ * source hour is off by one for the affected week; making the fold DST-aware (calendar
+ * weeks in a business zone) is a deliberate follow-up, kept out of #278 to preserve the
+ * "same grid as history" guarantee.
+ */
 @Slf4j
 @Service
 public class ForecastServiceImpl implements ForecastService {
+
+    private static final long DAYS_PER_WEEK = 7L;
 
     private final InfluxDBClient influxDBClient;
 
@@ -28,11 +46,20 @@ public class ForecastServiceImpl implements ForecastService {
     @Value("${forecast.lookback-weeks:4}")
     private int lookbackWeeks;
 
-    @Value("${forecast.slot-minutes:30}")
-    private int slotMinutes;
-
     @Value("${forecast.decay:0.5}")
     private double decay;
+
+    /**
+     * Point cap feeding the shared slot-width mapping. Deliberately reads the SAME key as
+     * history ({@code chart.history.max-points}) so that, for equal windows, forecast and
+     * history derive an identical slot width and grid — the contract the frontend #279
+     * relies on. Sourcing it from one key keeps the two grids in lock-step by construction.
+     */
+    @Value("${chart.history.max-points:500}")
+    private int maxPoints;
+
+    /** The wall clock the forecast window is measured against; overridable in tests. */
+    private Clock clock = Clock.systemUTC();
 
     public ForecastServiceImpl(InfluxDBClient influxDBClient) {
         this.influxDBClient = influxDBClient;
@@ -50,96 +77,92 @@ public class ForecastServiceImpl implements ForecastService {
             throw new IllegalArgumentException("forecastHours must be positive, got: " + forecastHours);
         }
 
-        Instant now = Instant.now();
+        int slotMinutes = TimeSlots.slotMinutes(forecastHours, maxPoints);
+        Duration slot = Duration.ofMinutes(slotMinutes);
+
+        Instant now = clock.instant();
+        Instant gridStart = TimeSlots.floorToSlot(now, slot);
         Instant forecastEnd = now.plus(forecastHours, ChronoUnit.HOURS);
+        List<Instant> futureSlots = TimeSlots.grid(gridStart, forecastEnd, slot);
 
-        // slot key → weighted sum and total weight
-        Map<Long, double[]> slotBuckets = new LinkedHashMap<>(); // [weightedSum, totalWeight]
-
+        // future slot-start → [weightedSum, totalWeight], folded from the lookback weeks.
+        Map<Instant, double[]> folded = new HashMap<>();
         for (int week = 1; week <= lookbackWeeks; week++) {
-            Instant windowStart = now.minus(week * 7L, ChronoUnit.DAYS);
-            Instant windowEnd   = forecastEnd.minus(week * 7L, ChronoUnit.DAYS);
-            double weight       = Math.pow(decay, week - 1); // 1.0, 0.5, 0.25, 0.125, …
+            double weight = Math.pow(decay, week - 1); // 1.0, 0.5, 0.25, 0.125, …
+            Duration shift = Duration.ofDays(DAYS_PER_WEEK * week);
+            Instant histStart = gridStart.minus(shift);
+            Instant histEnd = forecastEnd.minus(shift);
 
-            queryReadings(roomId, windowStart, windowEnd).forEach(row -> {
-                double count    = ((Number) row[0]).doubleValue();
-                Instant ts      = InfluxTime.toInstant(row[1]);
-                long slotKey    = toSlotKey(ts);
-
-                double[] bucket = slotBuckets.computeIfAbsent(slotKey, k -> new double[]{0.0, 0.0});
-                bucket[0] += count * weight;  // weighted sum
-                bucket[1] += weight;          // total weight
+            // Anchor the historical bins to histStart (itself gridStart shifted a whole
+            // number of weeks back), NOT to the epoch: then every bin start + shift lands
+            // exactly on a future grid slot for ANY slot width — including the wide widths
+            // the point cap can produce that do not evenly divide a week.
+            queryBuckets(roomId, histStart, histEnd, slotMinutes, histStart).forEach((binStart, agg) -> {
+                Instant futureSlot = binStart.plus(shift); // fold the historical bin onto the future grid
+                double avgCount = agg[0];
+                double sampleCount = agg[1];
+                double[] cell = folded.computeIfAbsent(futureSlot, k -> new double[]{0.0, 0.0});
+                // avgCount * sampleCount == sum(count); weighting per reading preserves the previous semantics.
+                cell[0] += avgCount * sampleCount * weight;
+                cell[1] += sampleCount * weight;
             });
         }
 
-        List<ForecastPoint> points = slotBuckets.entrySet().stream()
-                .sorted(Map.Entry.comparingByKey())
-                .filter(e -> e.getValue()[1] > 0)  // skip slots with no data
-                .map(e -> {
-                    double weightedAvg = e.getValue()[0] / e.getValue()[1];
-                    Instant slotInstant = toInstant(now, forecastHours, e.getKey());
-                    return new ForecastPoint(slotInstant, weightedAvg);
+        List<ForecastPoint> points = futureSlots.stream()
+                .map(slotStart -> {
+                    double[] cell = folded.get(slotStart);
+                    if (cell == null || cell[1] <= 0) {
+                        return new ForecastPoint(slotStart, null); // explicit gap
+                    }
+                    return new ForecastPoint(slotStart, cell[0] / cell[1]);
                 })
                 .toList();
 
-        double confidence = computeConfidence(slotBuckets, forecastHours);
+        long filled = points.stream().filter(p -> p.predictedCount() != null).count();
+        double confidence = futureSlots.isEmpty() ? 0.0 : (double) filled / futureSlots.size();
 
-        log.debug("Forecast for room={} horizon={}h: points={} confidence={}",
-                roomId, forecastHours, points.size(), confidence);
+        log.debug("Forecast for room={} horizon={}h: slotMinutes={} slots={} filled={} confidence={}",
+                roomId, forecastHours, slotMinutes, points.size(), filled, confidence);
 
         return new ForecastResponse(roomId, forecastHours, points, confidence, now);
     }
 
-    private List<Object[]> queryReadings(String roomId, Instant windowStart, Instant windowEnd) {
+    /**
+     * Buckets a lookback window's readings into fixed {@code slotMinutes}-wide slots in
+     * InfluxDB via {@code date_bin} + {@code GROUP BY}. Returns the per-slot average and
+     * the sample count, so the caller can reconstruct the per-reading weighted mean while
+     * still folding whole weeks with a single decay weight. Bins are anchored to
+     * {@code origin} (the caller passes the window start) so each bin lines up with the
+     * future grid once shifted forward by the same whole number of weeks.
+     *
+     * @return slot-start instant → {@code [avgCount, sampleCount]} for each non-empty slot
+     */
+    private Map<Instant, double[]> queryBuckets(String roomId, Instant start, Instant end,
+                                                int slotMinutes, Instant origin) {
         String sql = """
-            SELECT "count", time
-            FROM "%s"
-            WHERE "roomId" = '%s'
-              AND time >= '%s'
-              AND time < '%s'
-            ORDER BY time ASC
-            """.formatted(measurement, roomId, windowStart, windowEnd);
+                SELECT date_bin(INTERVAL '%d minutes', time, TIMESTAMP '%s') AS slot,
+                       avg("count") AS avg_count,
+                       count("count") AS n
+                FROM "%s"
+                WHERE "roomId" = '%s'
+                  AND time >= '%s'
+                  AND time < '%s'
+                GROUP BY slot
+                ORDER BY slot ASC
+                """.formatted(slotMinutes, origin, measurement, roomId, start, end);
 
-        List<Object[]> result = new ArrayList<>();
+        Map<Instant, double[]> buckets = new LinkedHashMap<>();
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
             rows.forEach(row -> {
-                if (row.length >= 2 && row[0] != null && row[1] != null) {
-                    result.add(row);
+                if (row == null || row.length < 3 || row[0] == null || row[1] == null || row[2] == null) {
+                    return;
                 }
+                Instant slotStart = InfluxTime.toInstant(row[0]);
+                double avgCount = ((Number) row[1]).doubleValue();
+                double sampleCount = ((Number) row[2]).doubleValue();
+                buckets.put(slotStart, new double[]{avgCount, sampleCount});
             });
         }
-        return result;
-    }
-
-    private long toSlotKey(Instant timestamp) {
-        ZonedDateTime zdt = timestamp.atZone(ZoneId.systemDefault());
-        long minuteOfDay = zdt.getHour() * 60L + zdt.getMinute();
-        return (minuteOfDay / slotMinutes) * slotMinutes;
-    }
-
-    /**
-     * Reconstructs the correct forecast-window date for a slot key.
-     * Slots before the current time-of-day belong to tomorrow if the
-     * forecast window spans midnight.
-     */
-    private Instant toInstant(Instant base, int forecastHours, long slotKeyMinutes) {
-        ZonedDateTime today = base.atZone(ZoneId.systemDefault()).truncatedTo(ChronoUnit.DAYS);
-        ZonedDateTime candidate = today.plusMinutes(slotKeyMinutes);
-
-        // If the slot is in the past relative to now, it must belong to tomorrow
-        if (candidate.toInstant().isBefore(base)) {
-            candidate = candidate.plusDays(1);
-        }
-        return candidate.toInstant();
-    }
-
-    private double computeConfidence(Map<Long, double[]> buckets, int forecastHours) {
-        int expectedSlots = (forecastHours * 60) / slotMinutes;
-        int expectedTotal = expectedSlots * lookbackWeeks;
-        if (expectedTotal == 0) return 1.0;
-        // Each slot's total weight reflects how many weeks contributed data
-        double actualWeight = buckets.values().stream().mapToDouble(b -> b[1]).sum();
-        double maxWeight = expectedTotal * 1.0; // max if all weeks had data, weight=1 each
-        return Math.min(1.0, actualWeight / maxWeight);
+        return buckets;
     }
 }

--- a/backend/src/main/java/com/occupi/feature/forecast/dto/ForecastPoint.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/dto/ForecastPoint.java
@@ -5,10 +5,16 @@ import java.time.Instant;
 /**
  * A single point in a forecast series.
  *
- * @param time           the instant this prediction applies to
- * @param predictedCount the expected number of occupants at that instant
+ * <p>Points are emitted on the same regular, window-scaled slot grid as the history
+ * series (#278). A slot that none of the lookback weeks provide data for is still
+ * emitted, with a {@code null} {@code predictedCount} marking the gap — so the frontend
+ * can render forecast and history against one continuous time axis.
+ *
+ * @param time           the slot-start instant this prediction applies to
+ * @param predictedCount the expected number of occupants in the slot, or {@code null}
+ *                       if no historical data backs this slot
  */
 public record ForecastPoint(
         Instant time,
-        double predictedCount
+        Double predictedCount
 ) {}

--- a/backend/src/test/java/com/occupi/feature/chart/ChartHistoryInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/chart/ChartHistoryInfluxIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.occupi.feature.chart;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.occupi.feature.chart.dto.HistoryPoint;
+import com.occupi.feature.chart.dto.HistoryResponse;
+import com.occupi.feature.database.model.OccupancyData;
+import com.occupi.feature.database.repository.OccupancyRepository;
+import com.occupi.feature.room.RoomService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Integration test for the bucketed history read path against a real InfluxDB 3
+ * instance (#278). A mocked client cannot reproduce {@code date_bin} + {@code GROUP BY}
+ * or the {@code BigInteger}-nanosecond slot column it returns, so the SQL is only truly
+ * exercised here. Skipped automatically when Docker is unavailable.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("ChartServiceImpl.getHistory — real InfluxDB 3 date_bin (integration)")
+class ChartHistoryInfluxIntegrationTest {
+
+    private static final Duration SLOT = Duration.ofMinutes(10); // 1h window → 10-min slots
+
+    @Container
+    static final GenericContainer<?> influxdb =
+            new GenericContainer<>(DockerImageName.parse("influxdb:3-core"))
+                    .withExposedPorts(8181)
+                    .withCommand("serve",
+                            "--host-id", "occupi-test",
+                            "--http-bind", "0.0.0.0:8181",
+                            "--object-store", "memory",
+                            "--without-auth")
+                    .waitingFor(Wait.forHttp("/health").forStatusCode(200)
+                            .withStartupTimeout(Duration.ofSeconds(90)));
+
+    private static InfluxDBClient client;
+    private OccupancyRepository repository;
+    private ChartServiceImpl service;
+
+    @BeforeAll
+    static void initClient() {
+        String url = "http://" + influxdb.getHost() + ":" + influxdb.getMappedPort(8181);
+        client = InfluxDBClient.getInstance(url, null, "occupi");
+    }
+
+    @AfterAll
+    static void closeClient() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        repository = new OccupancyRepository(client);
+        service = new ChartServiceImpl(client, Mockito.mock(RoomService.class));
+        ReflectionTestUtils.setField(service, "measurement", "occupancy");
+        ReflectionTestUtils.setField(service, "maxPoints", 500);
+    }
+
+    @Test
+    @DisplayName("date_bin averages readings per slot, aligns to the grid, and leaves gaps null")
+    void getHistory_bucketsAveragesAndFillsGaps() {
+        String roomId = "it-hist-room";
+        Instant now = Instant.now();
+
+        // Two readings in one 10-min slot (~25 min ago) → averaged to 10.
+        Instant slotA = TimeSlots.floorToSlot(now.minus(25, ChronoUnit.MINUTES), SLOT);
+        save(roomId, slotA.plus(2, ChronoUnit.MINUTES), 8, 0.9);
+        save(roomId, slotA.plus(4, ChronoUnit.MINUTES), 12, 0.9);
+        // One reading in an earlier slot (~45 min ago).
+        Instant slotB = TimeSlots.floorToSlot(now.minus(45, ChronoUnit.MINUTES), SLOT);
+        save(roomId, slotB.plus(3, ChronoUnit.MINUTES), 4, 0.7);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    HistoryResponse response = service.getHistory(roomId, 1);
+                    List<HistoryPoint> points = response.points();
+                    assertThat(points).isNotEmpty();
+
+                    // Every emitted slot sits on a clean 10-min grid.
+                    for (int i = 1; i < points.size(); i++) {
+                        assertThat(Duration.between(points.get(i - 1).time(), points.get(i).time()))
+                                .isEqualTo(SLOT);
+                    }
+
+                    // Slot A holds the average of its two readings.
+                    HistoryPoint pointA = pointAt(points, slotA);
+                    assertThat(pointA.count()).isEqualTo(10);
+                    assertThat(pointA.confidence()).isCloseTo(0.9, within(1e-6));
+
+                    // Slot B holds its single reading.
+                    assertThat(pointAt(points, slotB).count()).isEqualTo(4);
+
+                    // At least one slot between/around the data is an explicit gap.
+                    assertThat(points).anySatisfy(p -> assertThat(p.count()).isNull());
+                });
+    }
+
+    private void save(String roomId, Instant ts, int count, double confidence) {
+        repository.save(OccupancyData.builder()
+                .roomId(roomId).sensorId("it-sensor")
+                .count(count).confidence(confidence).timestamp(ts)
+                .build());
+    }
+
+    private static HistoryPoint pointAt(List<HistoryPoint> points, Instant slotStart) {
+        return points.stream()
+                .filter(p -> p.time().equals(slotStart))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no point at slot " + slotStart + " in " + points));
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
@@ -2,6 +2,7 @@ package com.occupi.feature.chart;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.chart.dto.HistoryPoint;
 import com.occupi.feature.chart.dto.HistoryResponse;
 import com.occupi.feature.chart.dto.WeekPatternResponse;
 import com.occupi.feature.chart.dto.WeekPatternSlot;
@@ -16,12 +17,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigInteger;
+import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,11 +46,16 @@ class ChartServiceImplTest {
 
     private ChartServiceImpl service;
 
-    /** Mirrors how InfluxDB 3 returns the time column: nanoseconds since epoch. */
+    /** Mirrors how InfluxDB 3 returns timestamp columns: nanoseconds since epoch. */
     private static BigInteger nanos(Instant t) {
         return BigInteger.valueOf(t.getEpochSecond())
                 .multiply(BigInteger.valueOf(1_000_000_000L))
                 .add(BigInteger.valueOf(t.getNano()));
+    }
+
+    /** One bucketed history row as {@code date_bin} + GROUP BY returns it: [slot, avgCount, avgConfidence]. */
+    private static Object[] bucket(Instant slotStart, double avgCount, double avgConfidence) {
+        return new Object[]{nanos(slotStart), avgCount, avgConfidence};
     }
 
     /** Builds an instant at a fixed local wall-clock time, so weekday/hour are zone-independent. */
@@ -55,6 +63,10 @@ class ChartServiceImplTest {
         return LocalDateTime.of(year, month, day, hour, minute)
                 .atZone(ZoneId.systemDefault())
                 .toInstant();
+    }
+
+    private void fixClockAt(Instant now) {
+        ReflectionTestUtils.setField(service, "clock", Clock.fixed(now, ZoneOffset.UTC));
     }
 
     @BeforeEach
@@ -69,87 +81,86 @@ class ChartServiceImplTest {
     // ---------- history ----------
 
     @Test
-    @DisplayName("history returns raw points unchanged when the readings fit within the cap")
-    void getHistory_readingsWithinCap_returnsRawPoints() {
-        Instant t1 = Instant.parse("2025-01-13T10:00:00Z");
-        Instant t2 = Instant.parse("2025-01-13T10:05:00Z");
+    @DisplayName("history emits one point per grid slot, filling empty slots with a null count")
+    void getHistory_bucketsOntoGrid_fillsGapsWithNull() {
+        // now 10:07:33, 1h window → 10-min slots aligned to a clean grid, gridStart 09:00.
+        fixClockAt(Instant.parse("2025-01-13T10:07:33Z"));
+        Instant s0900 = Instant.parse("2025-01-13T09:00:00Z");
+        Instant s0920 = Instant.parse("2025-01-13T09:20:00Z");
+        Instant s0930 = Instant.parse("2025-01-13T09:30:00Z");
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                 .thenAnswer(inv -> Stream.<Object[]>of(
-                        new Object[]{15, 0.92, nanos(t1)},
-                        new Object[]{18, 0.88, nanos(t2)}));
-
-        HistoryResponse response = service.getHistory("room-1", 2);
-
-        assertThat(response.roomId()).isEqualTo("room-1");
-        assertThat(response.points()).hasSize(2);
-        assertThat(response.points().get(0).time()).isEqualTo(t1);
-        assertThat(response.points().get(0).count()).isEqualTo(15);
-        assertThat(response.points().get(0).confidence()).isEqualTo(0.92);
-        assertThat(response.points().get(1).count()).isEqualTo(18);
-        assertThat(response.start()).isBefore(response.end());
-    }
-
-    @Test
-    @DisplayName("history downsamples into averaged slots once the readings exceed the cap")
-    void getHistory_moreReadingsThanCap_downsamplesIntoSlots() {
-        // A cap of 3 with 4 readings forces the downsample branch. For a 1h window
-        // the adaptive slot width is slotMinutesFor(1) = ceil(60 / (3 - 1)) = 30 min,
-        // so the readings fall into the same epoch-aligned 30-min slots as before:
-        //   three readings in [10:00,10:30) → avg count 20, one in [11:00,11:30) → 8.
-        ReflectionTestUtils.setField(service, "maxPoints", 3);
-        Instant a = Instant.parse("2025-01-13T10:00:00Z");
-        Instant b = Instant.parse("2025-01-13T10:10:00Z");
-        Instant c = Instant.parse("2025-01-13T10:20:00Z");
-        Instant d = Instant.parse("2025-01-13T11:00:00Z");
-        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenAnswer(inv -> Stream.<Object[]>of(
-                        new Object[]{10, 0.9, nanos(a)},
-                        new Object[]{20, 0.9, nanos(b)},
-                        new Object[]{30, 0.9, nanos(c)},
-                        new Object[]{8, 0.9, nanos(d)}));
+                        bucket(s0900, 12.6, 0.9),  // rounds up to 13
+                        bucket(s0920, 0.0, 0.5),   // a real zero, not a gap
+                        bucket(s0930, 8.4, 0.8))); // rounds down to 8
 
         HistoryResponse response = service.getHistory("room-1", 1);
 
-        assertThat(response.points()).hasSizeLessThanOrEqualTo(3);
-        assertThat(response.points()).hasSize(2);
-        assertThat(response.points().get(0).time()).isEqualTo(Instant.parse("2025-01-13T10:00:00Z"));
-        assertThat(response.points().get(0).count()).isEqualTo(20);
-        assertThat(response.points().get(0).confidence()).isCloseTo(0.9, within(1e-9));
-        assertThat(response.points().get(1).time()).isEqualTo(Instant.parse("2025-01-13T11:00:00Z"));
-        assertThat(response.points().get(1).count()).isEqualTo(8);
+        assertThat(response.roomId()).isEqualTo("room-1");
+        assertThat(response.start()).isEqualTo(s0900);
+        assertThat(response.end()).isEqualTo(Instant.parse("2025-01-13T10:07:33Z"));
+
+        // 09:00, 09:10, … 10:00 → seven evenly spaced slots.
+        assertThat(response.points()).hasSize(7);
+        assertThat(response.points()).extracting(HistoryPoint::time).containsExactly(
+                s0900,
+                Instant.parse("2025-01-13T09:10:00Z"),
+                s0920,
+                s0930,
+                Instant.parse("2025-01-13T09:40:00Z"),
+                Instant.parse("2025-01-13T09:50:00Z"),
+                Instant.parse("2025-01-13T10:00:00Z"));
+
+        assertThat(response.points().get(0).count()).isEqualTo(13);
+        assertThat(response.points().get(0).confidence()).isEqualTo(0.9);
+        assertThat(response.points().get(3).count()).isEqualTo(8);
+
+        // A real count = 0 stays 0; an empty slot is null — the two are distinguishable.
+        assertThat(response.points().get(2).count()).isEqualTo(0);
+        assertThat(response.points().get(1).count()).isNull();
+        assertThat(response.points().get(1).confidence()).isEqualTo(0.0);
+        assertThat(response.points().get(6).count()).isNull();
     }
 
     @Test
-    @DisplayName("history never returns more than max-points, however dense the window")
-    void getHistory_denseWindow_neverExceedsMaxPoints() {
-        int cap = 10;
-        ReflectionTestUtils.setField(service, "maxPoints", cap);
-        // One reading every 5 minutes across a full week → 2016 readings, far above
-        // the cap and all within the 168h window.
-        Instant base = Instant.parse("2025-01-13T00:00:00Z");
-        List<Object[]> readings = IntStream.range(0, 2016)
-                .mapToObj(i -> new Object[]{i % 50, 0.9, nanos(base.plusSeconds(i * 300L))})
-                .toList();
+    @DisplayName("history slot width scales with the window, and a no-data room yields a full grid of empty slots")
+    void getHistory_widerSlotForLongerWindow_emptyGridWhenNoData() {
+        // now 10:07:33, 24h window → 2-hour slots.
+        fixClockAt(Instant.parse("2025-01-13T10:07:33Z"));
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenAnswer(inv -> readings.stream());
-
-        HistoryResponse response = service.getHistory("room-1", 168);
-
-        assertThat(response.points()).isNotEmpty();
-        assertThat(response.points()).hasSizeLessThanOrEqualTo(cap);
-        assertThat(response.points().size()).isLessThan(readings.size());
-    }
-
-    @Test
-    @DisplayName("history returns an empty series when the room has no data")
-    void getHistory_noData_returnsEmptyPoints() {
-        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenAnswer(inv -> Stream.empty());
+                .thenAnswer(inv -> Stream.<Object[]>empty());
 
         HistoryResponse response = service.getHistory("room-1", 24);
 
-        assertThat(response.points()).isEmpty();
-        assertThat(response.start()).isBefore(response.end());
+        assertThat(response.points()).isNotEmpty();
+        // Every slot is emitted even with no data, and every one is an explicit gap.
+        assertThat(response.points()).allSatisfy(p -> {
+            assertThat(p.count()).isNull();
+            assertThat(p.confidence()).isEqualTo(0.0);
+        });
+        // Consecutive slots are exactly one 2-hour step apart (a clean, evenly spaced grid).
+        List<HistoryPoint> points = response.points();
+        for (int i = 1; i < points.size(); i++) {
+            assertThat(Duration.between(points.get(i - 1).time(), points.get(i).time()))
+                    .isEqualTo(Duration.ofHours(2));
+        }
+        assertThat(response.start()).isEqualTo(Instant.parse("2025-01-12T10:00:00Z"));
+    }
+
+    @Test
+    @DisplayName("history never returns more than max-points, however long the window")
+    void getHistory_longWindow_neverExceedsMaxPoints() {
+        int cap = 10;
+        ReflectionTestUtils.setField(service, "maxPoints", cap);
+        fixClockAt(Instant.parse("2025-01-13T10:00:00Z"));
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>empty());
+
+        // 1000h window with a cap of 10 forces the slot width past the breakpoint table.
+        HistoryResponse response = service.getHistory("room-1", 1000);
+
+        assertThat(response.points()).isNotEmpty();
+        assertThat(response.points()).hasSizeLessThanOrEqualTo(cap); // grid start alignment must not overshoot the cap
     }
 
     @Test

--- a/backend/src/test/java/com/occupi/feature/database/InfluxTimeTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/InfluxTimeTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,6 +36,15 @@ class InfluxTimeTest {
     @DisplayName("converts a numeric nanosecond value to Instant")
     void convertsLongNanos() {
         assertThat(InfluxTime.toInstant(1_000_000_000L)).isEqualTo(Instant.ofEpochSecond(1));
+    }
+
+    @Test
+    @DisplayName("reads a timezone-less LocalDateTime (as date_bin returns) as UTC")
+    void convertsLocalDateTimeAsUtc() {
+        LocalDateTime slot = LocalDateTime.of(2026, 6, 14, 10, 0, 0);
+        assertThat(InfluxTime.toInstant(slot))
+                .isEqualTo(slot.toInstant(ZoneOffset.UTC))
+                .isEqualTo(Instant.parse("2026-06-14T10:00:00Z"));
     }
 
     @Test

--- a/backend/src/test/java/com/occupi/feature/forecast/ForecastInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/forecast/ForecastInfluxIntegrationTest.java
@@ -1,0 +1,130 @@
+package com.occupi.feature.forecast;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.occupi.feature.chart.TimeSlots;
+import com.occupi.feature.database.model.OccupancyData;
+import com.occupi.feature.database.repository.OccupancyRepository;
+import com.occupi.feature.forecast.dto.ForecastPoint;
+import com.occupi.feature.forecast.dto.ForecastResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Integration test for the forecast fold against a real InfluxDB 3 instance (#278).
+ *
+ * <p>The forecast is strictly harder than history: it runs one {@code date_bin} query per
+ * lookback week and folds each historical bin forward by a whole number of weeks onto the
+ * future grid. A mocked client fabricates already-aligned bins, so the round-trip through
+ * real {@code date_bin} output — and the whole-week fold landing on the correct future
+ * slot — is only truly exercised here. Skipped automatically when Docker is unavailable.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@DisplayName("ForecastServiceImpl.forecast — real InfluxDB 3 date_bin fold (integration)")
+class ForecastInfluxIntegrationTest {
+
+    private static final Duration SLOT = Duration.ofMinutes(30); // 2h horizon → 30-min slots
+
+    @Container
+    static final GenericContainer<?> influxdb =
+            new GenericContainer<>(DockerImageName.parse("influxdb:3-core"))
+                    .withExposedPorts(8181)
+                    .withCommand("serve",
+                            "--host-id", "occupi-test",
+                            "--http-bind", "0.0.0.0:8181",
+                            "--object-store", "memory",
+                            "--without-auth")
+                    .waitingFor(Wait.forHttp("/health").forStatusCode(200)
+                            .withStartupTimeout(Duration.ofSeconds(90)));
+
+    private static InfluxDBClient client;
+    private OccupancyRepository repository;
+    private ForecastServiceImpl service;
+
+    @BeforeAll
+    static void initClient() {
+        String url = "http://" + influxdb.getHost() + ":" + influxdb.getMappedPort(8181);
+        client = InfluxDBClient.getInstance(url, null, "occupi");
+    }
+
+    @AfterAll
+    static void closeClient() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        repository = new OccupancyRepository(client);
+        service = new ForecastServiceImpl(client);
+        ReflectionTestUtils.setField(service, "measurement", "occupancy");
+        ReflectionTestUtils.setField(service, "lookbackWeeks", 4);
+        ReflectionTestUtils.setField(service, "decay", 0.5);
+        ReflectionTestUtils.setField(service, "maxPoints", 500);
+    }
+
+    @Test
+    @DisplayName("folds weekday-and-time readings from prior weeks onto the future grid, decay-weighted")
+    void forecast_foldsPriorWeeksOntoGrid() {
+        String roomId = "it-fc-room";
+        // Fix "now" so the future grid and the historical instants we seed are deterministic.
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        ReflectionTestUtils.setField(service, "clock", Clock.fixed(now, ZoneOffset.UTC));
+
+        Instant firstSlot = TimeSlots.floorToSlot(now, SLOT); // gridStart == first future slot
+
+        // Same weekday-and-time one and three weeks ago feed the first future slot:
+        // weighted avg = (4×1.0 + 8×0.25) / (1.0 + 0.25) = 6.0 / 1.25 = 4.8
+        save(roomId, firstSlot.minus(7, ChronoUnit.DAYS).plus(5, ChronoUnit.MINUTES), 4, 0.9);
+        save(roomId, firstSlot.minus(21, ChronoUnit.DAYS).plus(5, ChronoUnit.MINUTES), 8, 0.9);
+
+        await().atMost(Duration.ofSeconds(20)).pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    ForecastResponse response = service.forecast(roomId, 2);
+                    List<ForecastPoint> points = response.forecast();
+                    assertThat(points).isNotEmpty();
+
+                    // Regular 30-min grid over the 2h horizon.
+                    for (int i = 1; i < points.size(); i++) {
+                        assertThat(Duration.between(points.get(i - 1).time(), points.get(i).time()))
+                                .isEqualTo(SLOT);
+                    }
+
+                    // The seeded weekday-and-time folds onto the first slot, decay-weighted.
+                    ForecastPoint first = points.get(0);
+                    assertThat(first.time()).isEqualTo(firstSlot);
+                    assertThat(first.predictedCount()).isNotNull();
+                    assertThat(first.predictedCount()).isCloseTo(4.8, within(0.001));
+
+                    // Slots no lookback week backs stay explicit gaps.
+                    assertThat(points).anySatisfy(p -> assertThat(p.predictedCount()).isNull());
+                });
+    }
+
+    private void save(String roomId, Instant ts, int count, double confidence) {
+        repository.save(OccupancyData.builder()
+                .roomId(roomId).sensorId("it-sensor")
+                .count(count).confidence(confidence).timestamp(ts)
+                .build());
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
@@ -2,6 +2,7 @@ package com.occupi.feature.forecast;
 
 import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.forecast.dto.ForecastPoint;
 import com.occupi.feature.forecast.dto.ForecastResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -12,7 +13,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigInteger;
+import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
@@ -27,73 +30,105 @@ class ForecastServiceImplTest {
 
     private ForecastServiceImpl service;
 
-    // Fixed timestamp well away from slot boundaries and midnight
-    private static final Instant FIXED_TS = Instant.parse("2025-01-13T10:15:00Z");
+    // Fixed "now": 10:15 folds to a 30-min grid starting at 10:00 for a 2h horizon.
+    private static final Instant NOW = Instant.parse("2025-01-13T10:15:00Z");
+    private static final Instant SLOT_1000 = Instant.parse("2025-01-13T10:00:00Z");
 
-    /** Mirrors how InfluxDB 3 returns the time column: nanoseconds since epoch. */
+    /** Mirrors how InfluxDB 3 returns timestamp columns: nanoseconds since epoch. */
     private static BigInteger nanos(Instant t) {
         return BigInteger.valueOf(t.getEpochSecond())
                 .multiply(BigInteger.valueOf(1_000_000_000L))
                 .add(BigInteger.valueOf(t.getNano()));
     }
 
+    /**
+     * One bucketed forecast row for the given future slot, as it would look
+     * {@code weekOffset} weeks back: [binSlot, avgCount, sampleCount]. The service
+     * shifts the historical bin forward by the same offset to fold it onto the grid.
+     */
+    private static Object[] weekBucket(Instant futureSlot, int weekOffset, double avgCount, long sampleCount) {
+        Instant binSlot = futureSlot.minus(java.time.Duration.ofDays(7L * weekOffset));
+        return new Object[]{nanos(binSlot), avgCount, sampleCount};
+    }
+
     @BeforeEach
     void setUp() {
         service = new ForecastServiceImpl(influxDBClient);
-        ReflectionTestUtils.setField(service, "measurement",  "occupancy");
+        ReflectionTestUtils.setField(service, "measurement", "occupancy");
         ReflectionTestUtils.setField(service, "lookbackWeeks", 4);
-        ReflectionTestUtils.setField(service, "slotMinutes",  30);
-        ReflectionTestUtils.setField(service, "decay",        0.5);
+        ReflectionTestUtils.setField(service, "decay", 0.5);
+        ReflectionTestUtils.setField(service, "maxPoints", 500);
+        ReflectionTestUtils.setField(service, "clock", Clock.fixed(NOW, ZoneOffset.UTC));
     }
 
     @Test
     @DisplayName("applies exponential weighting across weeks — most recent week counts most")
     void forecast_appliesExponentialWeighting() {
-        // week 1 (weight 1.0): count=2, week 2 (0.5): count=4,
-        // week 3 (0.25): count=4, week 4 (0.125): count=6
+        // Same slot (10:00) fed from each of the four weeks:
         // weighted avg = (2×1.0 + 4×0.5 + 4×0.25 + 6×0.125) / (1.0+0.5+0.25+0.125)
-        //              = (2 + 2 + 1 + 0.75) / 1.875 = 5.75 / 1.875 ≈ 3.067
+        //              = 5.75 / 1.875 ≈ 3.067
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{2.0, nanos(FIXED_TS)}))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, nanos(FIXED_TS)}))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, nanos(FIXED_TS)}))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{6.0, nanos(FIXED_TS)}));
+                .thenAnswer(inv -> Stream.<Object[]>of(weekBucket(SLOT_1000, 1, 2.0, 1)))
+                .thenAnswer(inv -> Stream.<Object[]>of(weekBucket(SLOT_1000, 2, 4.0, 1)))
+                .thenAnswer(inv -> Stream.<Object[]>of(weekBucket(SLOT_1000, 3, 4.0, 1)))
+                .thenAnswer(inv -> Stream.<Object[]>of(weekBucket(SLOT_1000, 4, 6.0, 1)));
 
         ForecastResponse response = service.forecast("room-1", 2);
 
-        assertThat(response.forecast()).hasSize(1);
-        assertThat(response.forecast().get(0).predictedCount())
-                .isCloseTo(3.067, within(0.001));
+        // 10:00, 10:30, 11:00, 11:30, 12:00 — a regular 30-min grid over the 2h horizon.
+        assertThat(response.forecast()).hasSize(5);
+        assertThat(response.forecast().get(0).time()).isEqualTo(SLOT_1000);
+        assertThat(response.forecast().get(0).predictedCount()).isCloseTo(3.067, within(0.001));
+        // Only 10:00 had data; the remaining slots are explicit gaps.
+        assertThat(response.forecast().subList(1, 5))
+                .allSatisfy(p -> assertThat(p.predictedCount()).isNull());
+        assertThat(response.confidence()).isCloseTo(0.2, within(1e-9)); // 1 of 5 slots filled
     }
 
     @Test
-    @DisplayName("returns empty forecast when no historical data exists")
-    void forecast_noData_returnsEmptyPoints() {
+    @DisplayName("returns a full grid of empty slots when no historical data exists")
+    void forecast_noData_returnsEmptySlots() {
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                 .thenAnswer(inv -> Stream.empty());
 
         ForecastResponse response = service.forecast("room-1", 2);
 
-        assertThat(response.forecast()).isEmpty();
+        assertThat(response.forecast()).hasSize(5);
+        assertThat(response.forecast()).allSatisfy(p -> assertThat(p.predictedCount()).isNull());
+        assertThat(response.confidence()).isEqualTo(0.0);
     }
 
     @Test
     @DisplayName("skips weeks with missing data without skewing the average")
     void forecast_skipsWeeksWithNoData() {
-        // Only weeks 1 and 3 return data — week 2 and 4 are empty
-        // week 1 (weight 1.0): count=4, week 3 (weight 0.25): count=8
+        // Only weeks 1 and 3 return data for the 10:00 slot — weeks 2 and 4 are empty.
         // weighted avg = (4×1.0 + 8×0.25) / (1.0+0.25) = 6.0 / 1.25 = 4.8
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{4.0, nanos(FIXED_TS)}))
+                .thenAnswer(inv -> Stream.<Object[]>of(weekBucket(SLOT_1000, 1, 4.0, 1)))
                 .thenAnswer(inv -> Stream.empty())
-                .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{8.0, nanos(FIXED_TS)}))
+                .thenAnswer(inv -> Stream.<Object[]>of(weekBucket(SLOT_1000, 3, 8.0, 1)))
                 .thenAnswer(inv -> Stream.empty());
 
         ForecastResponse response = service.forecast("room-1", 2);
 
-        assertThat(response.forecast()).hasSize(1);
-        assertThat(response.forecast().get(0).predictedCount())
-                .isCloseTo(4.8, within(0.001));
+        assertThat(response.forecast().get(0).time()).isEqualTo(SLOT_1000);
+        assertThat(response.forecast().get(0).predictedCount()).isCloseTo(4.8, within(0.001));
+    }
+
+    @Test
+    @DisplayName("weights a slot by its sample count, preserving per-reading weighting")
+    void forecast_weightsBySampleCount() {
+        // Week 1: 3 readings averaging 4 (sum 12). Week 2: 1 reading of 10.
+        // weighted avg = (4×3×1.0 + 10×1×0.5) / (3×1.0 + 1×0.5) = (12 + 5) / 3.5 ≈ 4.857
+        when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                .thenAnswer(inv -> Stream.<Object[]>of(weekBucket(SLOT_1000, 1, 4.0, 3)))
+                .thenAnswer(inv -> Stream.<Object[]>of(weekBucket(SLOT_1000, 2, 10.0, 1)))
+                .thenAnswer(inv -> Stream.empty())
+                .thenAnswer(inv -> Stream.empty());
+
+        ForecastResponse response = service.forecast("room-1", 2);
+
+        assertThat(response.forecast().get(0).predictedCount()).isCloseTo(4.857, within(0.001));
     }
 
     @Test


### PR DESCRIPTION
Implements #278: history (`GET /api/occupancy/history`) and forecast (`GET /api/forecast`) now return an evenly-spaced, window-scaled slot series aligned to a clean grid, with empty periods kept explicit so the frontend (#279) can draw a continuous time axis instead of collapsing gaps into time jumps.

## What changed
- Shared `TimeSlots` helper derives the slot width from the window (1h->10m ... 1W->6h, capped at `chart.history.max-points`) and floors to the same epoch grid `date_bin` uses.
- History buckets in InfluxDB via `date_bin` + `GROUP BY`; slots with no readings are emitted as null-count points, distinct from a real `count = 0`.
- Forecast emits the same grid and width, folding each lookback week onto the future grid (bins anchored to the window start so any slot width stays aligned); empty slots carry a null `predictedCount`.
- `HistoryPoint.count` and `ForecastPoint.predictedCount` are now nullable to mark gaps.

## Tests
- Service unit tests reworked around the bucketed rows with a fixed clock.
- Added Docker-gated InfluxDB 3 integration tests exercising the real `date_bin` path on both history and forecast.

## Notes
- The forecast week-fold is UTC-based (matching history's grid); a DST-aware fold is a deliberate follow-up.

Closes #278