### PR TITLE
Feature/chart continuous time axis #279

### DIFF
--- a/frontend/src/components/OccupancyChart.tsx
+++ b/frontend/src/components/OccupancyChart.tsx
@@ -1,4 +1,4 @@
-import { ComposedChart, Area, XAxis, YAxis, ReferenceLine, Tooltip, ResponsiveContainer } from "recharts";
+import {ComposedChart, Area, XAxis, YAxis, ReferenceLine, Tooltip, ResponsiveContainer, ReferenceArea} from "recharts";
 import type { HistoryPoint, ForecastPoint } from "../types/room";
 
 interface OccupancyChartProps {
@@ -7,17 +7,35 @@ interface OccupancyChartProps {
     capacity: number;
 }
 
+type ChartRow = { time: number; count: number | null; predictedCount: number | null };
 const toMs = (t: string) => new Date(t).getTime();
 
+function gapRanges(data: ChartRow[]): [number, number][] {
+    const ranges: [number, number][] = [];
+    let runStart = -1;
+    for (let i = 0; i <= data.length; i++) {
+        const isGap = i < data.length && data[i].count === null && data[i].predictedCount === null;
+        if (isGap && runStart === -1) {
+            runStart = i;
+        } else if (!isGap && runStart !== -1) {
+            const x1 = data[Math.max(0, runStart - 1)].time;
+            const x2 = data[Math.min(data.length - 1, i)].time;
+            ranges.push([x1, x2]);
+            runStart = -1;
+        }
+    }
+    return ranges;
+}
 
 export const OccupancyChart = ({ historyPoints, forecastPoints, capacity }: OccupancyChartProps) => {
     const lastHistory = historyPoints[historyPoints.length - 1];
-    const mergedData = [
+    const mergedData: ChartRow[] = [
         ...historyPoints.slice(0, -1).map(p => ({ time: toMs(p.time), count: p.count, predictedCount: null })),
         ...(lastHistory ? [{ time: toMs(lastHistory.time), count: lastHistory.count, predictedCount: lastHistory.count}] : []),
         ...forecastPoints.map(p => ({ time: toMs(p.time), count: null, predictedCount: p.predictedCount })),
     ];
     const nowLine = lastHistory ? toMs(lastHistory.time) : undefined;
+    const gaps = gapRanges(mergedData)
 
     return (
         <ResponsiveContainer width="100%" height={300}>
@@ -28,6 +46,12 @@ export const OccupancyChart = ({ historyPoints, forecastPoints, capacity }: Occu
                        domain={['dataMin', 'dataMax']}
                        tickFormatter={(t) => new Date(t).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })} />
                 <YAxis domain={[0, capacity]}/>
+                {gaps.map(([x1, x2], i) =>(
+                    <ReferenceArea key={i} x1={x1} x2={x2}
+                                   fill="#9ca3af" fillOpacity={0.12}
+                                   stroke="#9ca3af" strokeDasharray="4 4"
+                                   label={{ value: 'keine Daten', fontSize: 11, fill: '#9ca3af' }} />
+                ))}
                 <Area dataKey="count" stroke="#3b82f6" fill="#3b82f6" fillOpacity={0.2} connectNulls={false}/>
                 <Area dataKey="predictedCount" stroke="#8b5cf6" fill="#8b5cf6" fillOpacity={0.1} strokeDasharray="5 5" connectNulls={false} />
                 <ReferenceLine x={nowLine} />

--- a/frontend/src/components/OccupancyChart.tsx
+++ b/frontend/src/components/OccupancyChart.tsx
@@ -7,23 +7,29 @@ interface OccupancyChartProps {
     capacity: number;
 }
 
+const toMs = (t: string) => new Date(t).getTime();
+
 
 export const OccupancyChart = ({ historyPoints, forecastPoints, capacity }: OccupancyChartProps) => {
     const lastHistory = historyPoints[historyPoints.length - 1];
     const mergedData = [
-        ...historyPoints.slice(0, -1).map(p => ({ time: p.time, count: p.count, predictedCount: null })),
-        ...(lastHistory ? [{ time: lastHistory.time, count: lastHistory.count, predictedCount: lastHistory.count}] : []),
-        ...forecastPoints.map(p => ({ time: p.time, count: null, predictedCount: p.predictedCount })),
+        ...historyPoints.slice(0, -1).map(p => ({ time: toMs(p.time), count: p.count, predictedCount: null })),
+        ...(lastHistory ? [{ time: toMs(lastHistory.time), count: lastHistory.count, predictedCount: lastHistory.count}] : []),
+        ...forecastPoints.map(p => ({ time: toMs(p.time), count: null, predictedCount: p.predictedCount })),
     ];
-    const nowLine = historyPoints[historyPoints.length - 1]?.time;
+    const nowLine = lastHistory ? toMs(lastHistory.time) : undefined;
 
     return (
         <ResponsiveContainer width="100%" height={300}>
             <ComposedChart data={mergedData}>
-                <XAxis dataKey="time" tickFormatter={(t) => new Date(t).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })} />
+                <XAxis dataKey="time"
+                       type="number"
+                       scale="time"
+                       domain={['dataMin', 'dataMax']}
+                       tickFormatter={(t) => new Date(t).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })} />
                 <YAxis domain={[0, capacity]}/>
-                <Area dataKey="count" stroke="#3b82f6" fill="#3b82f6" fillOpacity={0.2}/>
-                <Area dataKey="predictedCount" stroke="#8b5cf6" fill="#8b5cf6" fillOpacity={0.1} strokeDasharray="5 5" />
+                <Area dataKey="count" stroke="#3b82f6" fill="#3b82f6" fillOpacity={0.2} connectNulls={false}/>
+                <Area dataKey="predictedCount" stroke="#8b5cf6" fill="#8b5cf6" fillOpacity={0.1} strokeDasharray="5 5" connectNulls={false} />
                 <ReferenceLine x={nowLine} />
                 <Tooltip labelFormatter={(t) => new Date(t).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' })}
                          // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/components/RoomDetailModal.tsx
+++ b/frontend/src/components/RoomDetailModal.tsx
@@ -146,7 +146,7 @@ export const RoomDetailModal = ({room, isOpen, onClose}: RoomDetailModalProps) =
                                         <h3 className="text-lg font-semibold"> Verlauf & Prognose</h3>
                                         <div className="flex gap-1">
                                             {[1, 3, 12, 24, 168].map(h => (
-                                                <button key={h} onClick={() => { setIsLoading(true); setTimeRange(h); }}
+                                                <button key={h} onClick={() =>  setTimeRange(h)}
                                                 className={`px-3 py-1 text-sm rounded-lg ${timeRange === h ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`}>
                                                     {h === 168 ? '1W' : `${h}h`}
                                                 </button>

--- a/frontend/src/types/room.ts
+++ b/frontend/src/types/room.ts
@@ -9,12 +9,12 @@ export interface Occupancy{
 
 export interface ForecastPoint {
     time: string;
-    predictedCount: number;
+    predictedCount: number | null;
 }
 
 export interface HistoryPoint {
     time: string;
-    count: number;
+    count: number | null;
     confidence: number;
 }
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -4,7 +4,7 @@ import type { ForecastResponse, HistoryResponse, WeekPatternResponse, RoomRespon
 
 const api = axios.create({
     baseURL: import.meta.env.VITE_API_URL,
-    timeout: 8000,
+    timeout: 10000,
     headers: {
         'Content-Type': 'application/json',
     },


### PR DESCRIPTION
## Summary
The occupancy chart used a category X-axis, so points were spaced evenly
regardless of their real timestamps — gaps in the data were collapsed and
the axis "jumped" in time. The chart now draws on a real, proportional time
axis and renders missing periods as explicitly marked gaps.

## Changes
- OccupancyChart.tsx — X-axis switched to a continuous time scale
  (type="number", scale="time", epoch-ms values via toMs)
- OccupancyChart.tsx — empty slots break the line/area instead of being
  drawn across (connectNulls={false}), and contiguous no-data ranges are
  marked with a grey dashed "keine Daten" band (ReferenceArea via
  gapRanges)
- types/room.ts — HistoryPoint.count and ForecastPoint.predictedCount
  are nullable to carry the empty-slot format from #278
- RoomDetailModal.tsx — small chart UX fix (follow-up to #237): switching
  the time range keeps the current chart visible and transitions smoothly
  instead of flashing the loading skeleton

## Verification
- Manufactured null-slots in mock data → line breaks at the gap and the grey
  dashed "keine Daten" band spans exactly the missing range
- Real empty slots from the backend slot format (#278) render as marked gaps
- Time-range buttons (1h/3h/12h/24h/1W) show a proportional, stable timeline
  with no time jumps; switching ranges transitions smoothly without skeleton
- npm run build and npm run lint green

Closes #279