### PR TITLE
fix: reject duplicate room ID on create with 409 Conflict #248

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   computation, with short per-endpoint TTLs and a bounded cache size (#280).
 
 ### Fixed
+- `POST /api/rooms` now rejects a create whose `roomId` already exists with
+  `409 Conflict` instead of silently overwriting the stored room. Rooms use an
+  assigned ID, so `save()` on a duplicate acted as an update and corrupted the
+  existing room's metadata; the admin panel already shows "Raum-ID existiert
+  bereits." for the 409 (#248).
 - The "latest per room / per sensor" reads no longer scan the entire InfluxDB history
   on every call. The window-function queries in `OccupancyRepository.findAllLatest`
   and `MetricsRepository.findAllLatest` are now bounded to a configurable recent

--- a/backend/src/main/java/com/occupi/feature/room/RoomAlreadyExistsException.java
+++ b/backend/src/main/java/com/occupi/feature/room/RoomAlreadyExistsException.java
@@ -1,0 +1,16 @@
+package com.occupi.feature.room;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Thrown when a room is created with a roomId that already exists.
+ * Mapped to HTTP 409 by Spring.
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class RoomAlreadyExistsException extends RuntimeException {
+
+    public RoomAlreadyExistsException(String roomId) {
+        super("Room already exists: " + roomId);
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/room/RoomService.java
+++ b/backend/src/main/java/com/occupi/feature/room/RoomService.java
@@ -17,7 +17,11 @@ public interface RoomService {
     /** Returns a single room, or empty if it does not exist. */
     Optional<RoomResponse> getRoom(String roomId);
 
-    /** Creates a new room and returns it. */
+    /**
+     * Creates a new room and returns it.
+     *
+     * @throws RoomAlreadyExistsException if a room with the given roomId already exists
+     */
     RoomResponse createRoom(RoomRequest request);
 
     /**

--- a/backend/src/main/java/com/occupi/feature/room/RoomServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/room/RoomServiceImpl.java
@@ -33,6 +33,9 @@ public class RoomServiceImpl implements RoomService {
 
     @Override
     public RoomResponse createRoom(RoomRequest request) {
+        if (roomRepository.existsById(request.roomId())) {
+            throw new RoomAlreadyExistsException(request.roomId());
+        }
         Room room = Room.builder()
                 .roomId(request.roomId())
                 .name(request.name())

--- a/backend/src/test/java/com/occupi/feature/room/RoomControllerValidationTest.java
+++ b/backend/src/test/java/com/occupi/feature/room/RoomControllerValidationTest.java
@@ -65,6 +65,17 @@ class RoomControllerValidationTest {
     }
 
     @Test
+    void createRoom_withExistingId_returns409() throws Exception {
+        RoomRequest request = new RoomRequest("room-1", "Room One", "BuildingA", 1, 10);
+        when(roomService.createRoom(any())).thenThrow(new RoomAlreadyExistsException("room-1"));
+
+        mockMvc.perform(post("/api/rooms")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
     void getRoom_withUnknownId_returns404() throws Exception {
         when(roomService.getRoom("unknown")).thenReturn(Optional.empty());
 

--- a/backend/src/test/java/com/occupi/feature/room/RoomServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/room/RoomServiceImplTest.java
@@ -78,6 +78,16 @@ class RoomServiceImplTest {
     }
 
     @Test
+    @DisplayName("createRoom throws RoomAlreadyExistsException for a duplicate roomId")
+    void createRoom_duplicate_throws() {
+        when(roomRepository.existsById("room-9")).thenReturn(true);
+
+        assertThatThrownBy(() -> service.createRoom(request("room-9")))
+                .isInstanceOf(RoomAlreadyExistsException.class);
+        verify(roomRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("updateRoom updates fields of an existing room")
     void updateRoom_existing() {
         when(roomRepository.findById("room-1")).thenReturn(Optional.of(room("room-1")));


### PR DESCRIPTION
Implements #248: `POST /api/rooms` now returns `409 Conflict` when the submitted `roomId` already exists, instead of silently overwriting the stored room.

## What changed
- New `RoomAlreadyExistsException` (same pattern as `RoomNotFoundException`), mapped to `409 Conflict` via `@ResponseStatus`.
- `RoomServiceImpl.createRoom` checks `existsById(request.roomId())` before saving. Rooms use an assigned String id, so `save()` on a duplicate acted as a JPA merge/upsert and corrupted the existing room's metadata (the `7/0` occupancy seen in manual testing) — the service-level guard is the fix point, since no DB constraint can catch this.

## Tests
- Service unit test: a duplicate create throws and never calls `save()`.
- MockMvc test: `POST /api/rooms` with an existing id returns 409.

## Notes
- No frontend change needed: the admin panel already maps 409 to "Raum-ID existiert bereits." (`AdminPanel.tsx`).
- The check-then-act keeps a small race window (two concurrent creates for the same id can still both pass the check). Acceptable for the admin-only write path; a `@Version` field or `Persistable.isNew()` backstop would close it for real if that ever matters.

Closes #248