### PR TITLE
add: pin rooms to dashboard with persistent dashboard store #194

### DIFF
--- a/frontend/src/components/PinButton.tsx
+++ b/frontend/src/components/PinButton.tsx
@@ -1,0 +1,19 @@
+import { Pin } from 'lucide-react';
+import { useDashboardStore } from "../hooks/useDashboardStore";
+
+export function PinButton ({ roomId }: { roomId: string}) {
+    const { pinnedRoomIds, togglePin } = useDashboardStore();
+    const pinned = pinnedRoomIds.includes(roomId);
+
+    return (
+        <button
+            onClick={(e) => {e.stopPropagation(); togglePin(roomId); }}
+            className={`p-1.5 rounded-full transition-colors ${
+                pinned ? 'text-blue-600 hover:bg-blue-50' : 'text-gray-400 hover:text-blue-600 hover:bg-blue-50'
+            }`}
+            title={pinned ? 'Vom Dashboard entfernen' : 'Ans Dashboard pinnen'}
+        >
+            <Pin size={16} fill={pinned ? 'currentColor' : 'none'} />
+        </button>
+    )
+}

--- a/frontend/src/hooks/useDashboardStore.ts
+++ b/frontend/src/hooks/useDashboardStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'pinnedRoomIds';
+
+interface DashboardState {
+    pinnedRoomIds: string[];
+    togglePin: (roomId: string) => void;
+}
+
+function loadPinned(): string[] {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        return raw ? JSON.parse(raw) : [];
+    } catch {
+        return [];
+    }
+}
+
+export const useDashboardStore = create<DashboardState>((set) => ({
+    pinnedRoomIds: loadPinned(),
+
+    togglePin: (roomId) => set((state) => {
+        const next = state.pinnedRoomIds.includes(roomId)
+            ? state.pinnedRoomIds.filter((id) => id !== roomId)
+            : [...state.pinnedRoomIds, roomId];
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        return { pinnedRoomIds: next };
+    }),
+}));

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -3,6 +3,7 @@ import { StatusBadge} from '../components/RoomStatus';
 import {useState} from "react";
 import { useFetchRooms } from '../hooks/useFetchRooms';
 import { RoomDetailModal} from "../components/RoomDetailModal";
+import {PinButton} from "../components/PinButton";
 import type { Room } from '../types/room'
 
 function SummaryCard({ label, value }: {label: string; value: string | number }) {
@@ -47,7 +48,7 @@ export default function Analytics() {
     const occupancyPct = totalCapacity > 0 ? Math.round((totalPeople / totalCapacity) * 100) : 0;
     const occupancyUnavailable = rooms.some((r) => r.occupancyRate === 'unknown');
 
-    const columns = ['Raum', 'Gebäude', 'Belegung', 'Auslastung'];
+    const columns = ['Raum', 'Gebäude', 'Belegung', 'Auslastung', 'Pin'];
 
     return (
         <div className="max-w-7xl mx-auto">
@@ -129,6 +130,9 @@ export default function Analytics() {
                             <td className="px-4 py-3 text-sm text-gray-600">{room.occupancyRate === 'unknown' ? '—' : `${room.count} / ${room.capacity}`}</td>
                             <td className="px-4 py-3 text-sm">
                                 <StatusBadge occupancyRate={room.occupancyRate} />
+                            </td>
+                            <td className="px-4 py-3">
+                                <PinButton roomId={room.roomId} />
                             </td>
                         </tr>
                     ))}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import { Users, Activity } from 'lucide-react';
 import { useFetchRooms } from '../hooks/useFetchRooms';
 import type { Room} from "../types/room";
 import { RoomDetailModal} from "../components/RoomDetailModal";
+import { useDashboardStore } from "../hooks/useDashboardStore";
 
 export default function Dashboard() {
     // we retrieve spaces and function for setting them from the sore
@@ -13,6 +14,9 @@ export default function Dashboard() {
 
     const [selectedRoom, setSelectedRoom] = useState<Room | null>(null);
     const occupancyUnavailable = rooms.some((r) => r.occupancyRate === 'unknown');
+
+    const { pinnedRoomIds } = useDashboardStore();
+    const pinnedRooms = rooms.filter((r) => pinnedRoomIds.includes(r.roomId));
 
     return (
         <div className="max-w-7xl mx-auto">
@@ -41,47 +45,54 @@ export default function Dashboard() {
                 </div>
             )}
 
-            {/* grid for rooms */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {rooms.map((room) => (
-                    <div key={room.roomId} className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow cursor-pointer"
-                    onClick={() => setSelectedRoom(room)}>
-                        <div className="flex justify-between items-start mb-4">
-                            <div>
-                                <h3 className="font-bold text-lg text-gray-800">{room.name}</h3>
-                                <p className="text-sm text-gray-400">{room.building} • Etage {room.floor}</p>
-                            </div>
-                            {/* traffic light system */}
-                            <div className={`w-3 h-3 rounded-full ${
-                                room.occupancyRate === 'unknown' ? 'bg-gray-300' :
-                                room.occupancyRate === 'low' ? 'bg-green-500' :
-                                room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
-                            }`} />
-                        </div>
-
-                        <div className="flex items-center justify-between">
-                            <div className="flex items-center space-x-2 text-gray-600">
-                                <Users size={20} />
-                                <span className="text-2xl font-semibold">{room.occupancyRate === 'unknown' ? '—' : room.count}</span>
-                                <span className="text-gray-400">/ {room.capacity}</span>
-                            </div>
-                            <Activity size={20} className="text-blue-500 opacity-20" />
-                        </div>
-
-                        {/* small progress bar */}
-                        <div className="mt-4 w-full bg-gray-100 rounded-full h-2">
-                            <div
-                                className={`h-2 rounded-full transition-all duration-500 ${
+            {pinnedRooms.length === 0 ? (
+                <div className="py-16 text-center text-gray-400">
+                    <p className="mb-1 font-medium">Noch keine Räume gepinnt</p>
+                    <p className="text-sm">Pinne Räume über die Raumübersicht an dein Dashboard.</p>
+                </div>
+            ) : (
+                // grid for rooms
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                    {pinnedRooms.map((room) => (
+                        <div key={room.roomId} className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow cursor-pointer"
+                        onClick={() => setSelectedRoom(room)}>
+                            <div className="flex justify-between items-start mb-4">
+                                <div>
+                                    <h3 className="font-bold text-lg text-gray-800">{room.name}</h3>
+                                    <p className="text-sm text-gray-400">{room.building} • Etage {room.floor}</p>
+                                </div>
+                                {/* traffic light system */}
+                                <div className={`w-3 h-3 rounded-full ${
                                     room.occupancyRate === 'unknown' ? 'bg-gray-300' :
                                     room.occupancyRate === 'low' ? 'bg-green-500' :
                                     room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
-                                }`}
-                                style={{ width: `${room.capacity > 0 ? (room.count / room.capacity) * 100 : 0}%` }}
-                            />
+                                }`} />
+                            </div>
+
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center space-x-2 text-gray-600">
+                                    <Users size={20} />
+                                    <span className="text-2xl font-semibold">{room.occupancyRate === 'unknown' ? '—' : room.count}</span>
+                                    <span className="text-gray-400">/ {room.capacity}</span>
+                                </div>
+                                <Activity size={20} className="text-blue-500 opacity-20" />
+                            </div>
+
+                            {/* small progress bar */}
+                            <div className="mt-4 w-full bg-gray-100 rounded-full h-2">
+                                <div
+                                    className={`h-2 rounded-full transition-all duration-500 ${
+                                        room.occupancyRate === 'unknown' ? 'bg-gray-300' :
+                                        room.occupancyRate === 'low' ? 'bg-green-500' :
+                                        room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
+                                    }`}
+                                    style={{ width: `${room.capacity > 0 ? (room.count / room.capacity) * 100 : 0}%` }}
+                                />
+                            </div>
                         </div>
-                    </div>
-                ))}
-            </div>
+                    ))}
+                </div>
+            )}
             {selectedRoom && (
             <RoomDetailModal room={selectedRoom} isOpen={true} onClose={() => setSelectedRoom(null)} />
             )}

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -3,6 +3,7 @@ import { useRoomStore } from '../hooks/useRoomStore';
 import { StatusBadge, OccupancyBar } from '../components/RoomStatus';
 import { RoomDetailModal} from "../components/RoomDetailModal";
 import { useFetchRooms } from '../hooks/useFetchRooms';
+import { PinButton } from "../components/PinButton";
 import type { Room } from '../types/room';
 import React from 'react';
 
@@ -64,6 +65,7 @@ export default function Rooms(){
                                 {col.label}
                             </th>
                         ))}
+                        <th className="text-left px-4 py-3 text-sm font-medium text-gray-600">Pin</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -76,6 +78,9 @@ export default function Rooms(){
 
                                         </td>
                                     ))}
+                                <td className="px-4 py-3">
+                                    <PinButton roomId={room.roomId} />
+                                </td>
                             </tr>
                         ))}
                     </tbody>


### PR DESCRIPTION
## Summary
Users can now pin individual rooms to their dashboard. The dashboard only
shows pinned rooms instead of all rooms, with an empty-state hint when
nothing is pinned yet. Pins persist across reloads via localStorage.

## Changes
- New `useDashboardStore` (Zustand) with `pinnedRoomIds` and localStorage
  persistence
- New `PinButton` component (shared) — pin/unpin toggle with filled/outline
  state, used on both the Rooms page and the Analytics page
- `Dashboard.tsx` — filters to pinned rooms, shows an empty-state hint when
  no rooms are pinned
- Pin column added to the Rooms and Analytics tables

## Verification
- Pin/unpin on both pages toggles the icon and does not open the detail modal
- Dashboard shows only pinned rooms; empty state when none are pinned
- Pins survive a page reload (localStorage)
- `npm run build` and `npm run lint` green

Closes #194