### PR TITLE
fix: fetch rooms once in main layout instead of per page #288

### DIFF
--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -2,9 +2,11 @@ import { Outlet } from 'react-router-dom';
 import { Sidebar } from '../components/Sidebar';
 import { Navbar } from '../components/Navbar';
 import { useWebSocket } from '../hooks/useWebSocket';
+import { useFetchRooms } from "../hooks/useFetchRooms";
 
 export const MainLayout = () => {
     useWebSocket();
+    useFetchRooms()
     return (
         <div className="h-screen flex bg-[#F3F4F6] text-[#1F2937] font-sans overflow-hidden">
 

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,7 +1,6 @@
 import { useRoomStore } from '../hooks/useRoomStore';
 import { StatusBadge} from '../components/RoomStatus';
 import {useState} from "react";
-import { useFetchRooms } from '../hooks/useFetchRooms';
 import { RoomDetailModal} from "../components/RoomDetailModal";
 import {PinButton} from "../components/PinButton";
 import type { Room } from '../types/room'
@@ -18,7 +17,6 @@ function SummaryCard({ label, value }: {label: string; value: string | number })
 
 export default function Analytics() {
     const { rooms } = useRoomStore();
-    useFetchRooms();
     // Filter & sort state
     const [search, setSearch] = useState('');
     const [buildingFilter, setBuildingFilter] = useState('');

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,7 +1,6 @@
 import { useState} from 'react';
 import { useRoomStore } from '../hooks/useRoomStore';
 import { Users, Activity } from 'lucide-react';
-import { useFetchRooms } from '../hooks/useFetchRooms';
 import type { Room} from "../types/room";
 import { RoomDetailModal} from "../components/RoomDetailModal";
 import { useDashboardStore } from "../hooks/useDashboardStore";
@@ -9,8 +8,6 @@ import { useDashboardStore } from "../hooks/useDashboardStore";
 export default function Dashboard() {
     // we retrieve spaces and function for setting them from the sore
     const { rooms, isConnected, isMockData } = useRoomStore();
-
-    useFetchRooms();
 
     const [selectedRoom, setSelectedRoom] = useState<Room | null>(null);
     const occupancyUnavailable = rooms.some((r) => r.occupancyRate === 'unknown');
@@ -45,7 +42,7 @@ export default function Dashboard() {
                 </div>
             )}
 
-            {pinnedRooms.length === 0 ? (
+            {pinnedRooms.length === 0 ? null : pinnedRooms.length === 0 ? (
                 <div className="py-16 text-center text-gray-400">
                     <p className="mb-1 font-medium">Noch keine Räume gepinnt</p>
                     <p className="text-sm">Pinne Räume über die Raumübersicht an dein Dashboard.</p>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -42,7 +42,7 @@ export default function Dashboard() {
                 </div>
             )}
 
-            {pinnedRooms.length === 0 ? null : pinnedRooms.length === 0 ? (
+            {rooms.length === 0 ? null : pinnedRooms.length === 0 ? (
                 <div className="py-16 text-center text-gray-400">
                     <p className="mb-1 font-medium">Noch keine Räume gepinnt</p>
                     <p className="text-sm">Pinne Räume über die Raumübersicht an dein Dashboard.</p>

--- a/frontend/src/pages/Rooms.tsx
+++ b/frontend/src/pages/Rooms.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { useRoomStore } from '../hooks/useRoomStore';
 import { StatusBadge, OccupancyBar } from '../components/RoomStatus';
 import { RoomDetailModal} from "../components/RoomDetailModal";
-import { useFetchRooms } from '../hooks/useFetchRooms';
 import { PinButton } from "../components/PinButton";
 import type { Room } from '../types/room';
 import React from 'react';
@@ -37,7 +36,6 @@ function formatTime(timestamp: string) {
 export default function Rooms(){
     const { rooms } = useRoomStore();
     const [, setTick] = useState(0);
-    useFetchRooms();
     const [selectedRoom, setSelectedRoom] = useState<Room | null>(null);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
`useFetchRooms()` was called individually on the Dashboard, Rooms and
Analytics pages. Every navigation remounted the target page and fired a
fresh `/rooms` + `/occupancy/all` fetch, replacing the store array — pinned
room cards visibly "reloaded" on every page switch, redundant requests were
issued, and on first load the dashboard briefly flashed the
"Noch keine Räume gepinnt" empty state while the store was still empty.

## Changes
- `MainLayout.tsx` — `useFetchRooms()` is now called once next to
  `useWebSocket()`; the layout stays mounted across navigations, so the
  initial fetch and the 30s fallback polling run centrally
- `Dashboard.tsx`, `Rooms.tsx`, `Analytics.tsx` — removed the per-page
  `useFetchRooms()` calls; pages only read the store
- `Dashboard.tsx` — the pinned empty state only renders once rooms have
  actually loaded (`rooms.length === 0` → render nothing)

## Verification
- Navigating between pages triggers no additional `/rooms` /
  `/occupancy/all` requests (network tab)
- Pinned cards no longer visibly reload on navigation
- Empty state appears only when rooms are loaded and none are pinned
- Initial fetch + 30s fallback polling still work
- `npm run build` and `npm run lint` green

Closes #288