### PR TITLE
add: Pi metrics section in admin panel #224

### DIFF
--- a/frontend/src/components/MetricsSection.tsx
+++ b/frontend/src/components/MetricsSection.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { fetchMetrics } from '../utils/api';
+import type { MetricsResponse } from '../types/metrics';
+
+function healthColor(pct: number): string {
+    if (pct > 90) return 'text-red-600 font-medium';
+    if (pct > 70) return 'text-yellow-600 font-medium';
+    return 'text-green-600';
+}
+
+export function MetricsSection() {
+    const [metrics, setMetrics] = useState<MetricsResponse[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        fetchMetrics()
+            .then((data) => {
+                setMetrics(data);
+                setError(null);
+            })
+            .catch((err: unknown) => {
+                const status = (err as { response?: { status?: number } })?.response?.status;
+                setError(status === 403 ? 'Keine Berechtigung.' : 'Fehler beim Laden der Metriken.');
+            })
+            .finally(() => setLoading(false));
+    }, []);
+
+    return (
+        <section className="bg-white rounded-xl shadow p-6">
+            <h2 className="text-xl font-semibold text-gray-900 mb-4">Pi Metrics</h2>
+
+            {error ? (
+                <p className="text-red-600">{error}</p>
+
+                ) : loading ? (
+                <div className="space-y-3">
+                    {[...Array(2)].map((_, i) => (
+                        <div key={i} className="h-4 bg-gray-100 rounded animate-pulse w-3/4" />
+                    ))}
+                </div>
+            ) : metrics.length === 0 ? (
+                <p className="text-gray-400">Keine Sensoren melden aktuell Metriken.</p>
+            ) : (
+                <table className="w-full text-left">
+                    <thead>
+                    <tr className="border-b border-gray-200 text-gray-500 text-sm">
+                        <th className="pb-3">Sensor</th>
+                        <th className="pb-3">CPU</th>
+                        <th className="pb-3">RAM</th>
+                        <th className="pb-3">Queue</th>
+                        <th className="pb-3">Gesendet</th>
+                        <th className="pb-3">Verworfen</th>
+                        <th className="pb-3">Ø Zeit</th>
+                        <th className="pb-3">Aktualisiert</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {metrics.map((m) => (
+                        <tr key={m.sensorId} className="border-b border-gray-100">
+                            <td className="py-3">{m.sensorId}</td>
+                            <td className={`py-3 ${healthColor(m.cpuPercentage)}`}>{Math.round(m.cpuPercentage)}%</td>
+                            <td className={`py-3 ${healthColor(m.memoryPercentage)}`}>{Math.round(m.memoryPercentage)}%</td>
+                            <td className="py-3">{m.queueSize}</td>
+                            <td className="py-3">{m.sent}</td>
+                            <td className="py-3">{m.dropped}</td>
+                            <td className="py-3">{m.avgProcessTime.toFixed(1)} ms</td>
+                            <td className="py-3">{new Date(m.timestamp).toLocaleString('de-DE', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })}</td>
+                        </tr>
+                    ))}
+                    </tbody>
+                </table>
+            )}
+        </section>
+    );
+}

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { Pencil, Trash2 } from 'lucide-react';
 import api from '../utils/api';
 import { createRoom, updateRoom, deleteRoom} from "../utils/api";
+import { MetricsSection} from "../components/MetricsSection";
 import type { RoomResponse } from '../types/room';
 
 const emptyForm = { roomId: '', name: '', building: '', floor: 0, capacity: 0};
@@ -234,10 +235,7 @@ const AdminPanel = () => {
             )}
 
             {/* Metrics Placeholder #224 */}
-            <section className="bg-white rounded-xl shadow p-6">
-                <h2 className="text-xl font-semibold text-gray-900 mb-2">Pi Metrics</h2>
-                <p className="text-gray-400">Coming soon with Issue #224</p>
-            </section>
+            <MetricsSection />
         </div>
     );
 };

--- a/frontend/src/types/metrics.ts
+++ b/frontend/src/types/metrics.ts
@@ -1,0 +1,10 @@
+export interface MetricsResponse {
+    sensorId: string;
+    cpuPercentage: number;
+    memoryPercentage: number;
+    queueSize: number;
+    sent: number;
+    dropped: number;
+    avgProcessTime: number;
+    timestamp: string;
+}

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { useAuthStore, TOKEN_ENDPOINT, CLIENT_ID } from "../hooks/useAuthStore";
 import type { ForecastResponse, HistoryResponse, WeekPatternResponse, RoomResponse } from "../types/room";
+import type { MetricsResponse } from "../types/metrics";
 
 const api = axios.create({
     baseURL: import.meta.env.VITE_API_URL,
@@ -99,6 +100,10 @@ export function updateRoom(id: string, data: {roomId: string; name: string; buil
 
 export function deleteRoom(id: string) {
     return api.delete(`/rooms/${id}`)
+}
+
+export function fetchMetrics(): Promise<MetricsResponse[]> {
+    return api.get<MetricsResponse[]>('/metrics').then(res => res.data);
 }
 
 export default api;


### PR DESCRIPTION
## Summary
Replaces the "Coming soon" placeholder in the Admin Panel with a working
Pi metrics section that displays the latest health sample per sensor from
the REST API built in #223.

## Changes
- New `types/metrics.ts` — `MetricsResponse` matching the #223 DTO
- `api.ts` — `fetchMetrics()` on the shared axios instance (JWT, timeout,
  token refresh included)
- New `MetricsSection.tsx` — table with sensor ID, CPU %, RAM %, queue size,
  sent/dropped, avg process time and last-updated timestamp; health colouring
  (red > 90 %, yellow > 70 %, green otherwise); distinct loading skeleton,
  empty state ("Keine Sensoren melden aktuell Metriken.") and error states
  (403 → "Keine Berechtigung.")
- `AdminPanel.tsx` — placeholder section replaced with `<MetricsSection />`

## Verification
- Loading skeleton shows while fetching
- Error state verified live (server currently returns 500 on `/api/metrics`
  due to the InfluxDB query-file-limit — separate backend issue)
- Happy path (rows with real sensor data) pending the backend fix + a
  reporting Pi
- `npm run build` and `npm run lint` green

Closes #224