### PR TITLE
fix: remove non-functional search bar from navbar #214

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,4 +1,3 @@
-import { Search } from 'lucide-react';
 import { User } from 'lucide-react';
 import { useAuthStore} from "../hooks/useAuthStore";
 
@@ -6,28 +5,10 @@ export const Navbar = () => {
     const { user } = useAuthStore();
 
     return (
-        <header className="h-20 bg-white border-b border-gray-200 flex items-center justify-between px-6 shadow-sm z-10 shrink-0">
-
-            {/* Search Bar */}
-            <div className="flex-1 max-w-md">
-                <div className="relative">
-                    {/* Magnifying Glass Icon */}
-                    <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                        <Search className="h-5 w-5 text-gray-400" />
-                    </div>
-
-                    {/* The actual search bar*/}
-                    <input
-                        type="text"
-                        placeholder="Search rooms or buildings..."
-                        className="block w-full pl-10 pr-3 py-2 border border-gray-200 rounded-lg bg-gray-50 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:bg-white focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-colors"
-                    />
-                </div>
-            </div>
-
+        <header className="h-20 bg-white border-b border-gray-200 flex items-center justify-end px-6 shadow-sm z-10 shrink-0">
 
             {/* User Status */}
-            <div className="ml-6 flex items-center space-x-3 bg-gray-50 py-2 px-4 rounded-lg border border-gray-100">
+            <div className="flex items-center space-x-3 bg-gray-50 py-2 px-4 rounded-lg border border-gray-100">
                 <div className="bg-white p-1.5 rounded-md border border-gray-200 shadow-sm">
                     <User className="h-5 w-5 text-gray-600" />
                 </div>


### PR DESCRIPTION
## Summary
The search bar in the navbar was a non-functional placeholder (no value,
no onChange handler). It is removed; the user panel keeps its position on
the right.

## Changes
- `Navbar.tsx` — removed the search bar block and the unused `Search`
  import; header switched from `justify-between` to `justify-end` and the
  obsolete `ml-6` spacing removed so the user panel stays right-aligned

## Verification
- User panel sits right-aligned, layout stable at narrow viewport widths
- `npm run build` and `npm run lint` green

Closes #214