### PR TITLE
add: over-capacity indicator on dashboard room cards #244

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -51,7 +51,10 @@ export default function Dashboard() {
                 // grid for rooms
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                     {pinnedRooms.map((room) => (
-                        <div key={room.roomId} className="bg-white rounded-2xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow cursor-pointer"
+                        <div key={room.roomId}
+                             className={`bg-white rounded-2xl shadow-sm border border-gray-100 p-6 hover:shadow-md transition-shadow cursor-pointer ${
+                                 room.count > room.capacity ? 'ring-2 ring-red-300 animate-pulse' : ''
+                             }`}
                         onClick={() => setSelectedRoom(room)}>
                             <div className="flex justify-between items-start mb-4">
                                 <div>
@@ -76,14 +79,14 @@ export default function Dashboard() {
                             </div>
 
                             {/* small progress bar */}
-                            <div className="mt-4 w-full bg-gray-100 rounded-full h-2">
+                            <div className="mt-4 w-full bg-gray-100 rounded-full h-2 overflow-hidden">
                                 <div
                                     className={`h-2 rounded-full transition-all duration-500 ${
                                         room.occupancyRate === 'unknown' ? 'bg-gray-300' :
                                         room.occupancyRate === 'low' ? 'bg-green-500' :
                                         room.occupancyRate === 'medium' ? 'bg-yellow-500' : 'bg-red-500'
                                     }`}
-                                    style={{ width: `${room.capacity > 0 ? (room.count / room.capacity) * 100 : 0}%` }}
+                                    style={{ width: `${room.capacity > 0 ? Math.min(100,(room.count / room.capacity) * 100) : 0}%` }}
                                 />
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
An over-capacity room (e.g. 35/30 — or the 7/0 case from the issue) looked
identical to a nearly-full room on the dashboard. The card now gets a subtle
pulsing red ring when `count > capacity`. Also fixes the progress bar
overflowing the card in exactly that state.

## Changes
- `Dashboard.tsx` — room card gets `ring-2 ring-red-300 animate-pulse` when
  `room.count > room.capacity` (soft pulse, per the look agreed in the issue)
- `Dashboard.tsx` — progress bar width clamped with `Math.min(100, …)` and
  `overflow-hidden` added to the bar container, so the bar can no longer
  extend past the card at over 100 % occupancy (surfaced while implementing
  this, same root state)

## Verification
- Room with `count > capacity` → card pulses with a soft red ring, bar caps
  at 100 %
- `capacity = 0` with people present (the 7/0 case) → ring shows, bar stays
  empty
- Normal rooms → unchanged
- `npm run build` and `npm run lint` green

Closes #244