### PR TITLE
fix: serve latest reads from InfluxDB's last value cache, cap analytic windows #294

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,14 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   live occupancy for room 137 (#201).
 
 ### Changed
-- InfluxDB now runs with `--query-file-limit 8192` (default 432) in the base compose
-  command. InfluxDB 3 Core never compacts its 10-minute gen1 parquet files, so at
-  ~100 files per table and day the default limit rejected every read wider than
-  ~4 days — the 8-week week-pattern chart alone needs ~5,600 files at steady state.
+- InfluxDB now runs with `--query-file-limit 10000` (default 432) in the base compose
+  command. InfluxDB 3 Core never compacts its 10-minute gen1 parquet files (up to 144
+  per table and day), so the default limit rejected every read wider than ~3–4 days —
+  the 8-week week-pattern chart alone needs up to ~8,064 files at full write cadence.
   The raise is safe on this host: the files are ~7 KB each and the #273 CPU/memory
   caps stay on as backstop. Auto-deploy leaves infra containers alone, so applying
   it needs a manual `docker compose ... up -d influxdb` (#294).
+- The InfluxDB container now runs under a hard resource ceiling in the production
   compose (0.5 CPU, 2 GiB memory) so one heavy query can never starve the single-core
   host again. InfluxDB 3 Core does not cancel a running query when the client
   disconnects, so this cap is the backstop that keeps the box reachable. Auto-deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   live occupancy for room 137 (#201).
 
 ### Changed
-- The InfluxDB container now runs under a hard resource ceiling in the production
+- InfluxDB now runs with `--query-file-limit 8192` (default 432) in the base compose
+  command. InfluxDB 3 Core never compacts its 10-minute gen1 parquet files, so at
+  ~100 files per table and day the default limit rejected every read wider than
+  ~4 days — the 8-week week-pattern chart alone needs ~5,600 files at steady state.
+  The raise is safe on this host: the files are ~7 KB each and the #273 CPU/memory
+  caps stay on as backstop. Auto-deploy leaves infra containers alone, so applying
+  it needs a manual `docker compose ... up -d influxdb` (#294).
   compose (0.5 CPU, 2 GiB memory) so one heavy query can never starve the single-core
   host again. InfluxDB 3 Core does not cancel a running query when the client
   disconnects, so this cap is the backstop that keeps the box reachable. Auto-deploy
@@ -34,6 +40,19 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   computation, with short per-endpoint TTLs and a bounded cache size (#280).
 
 ### Fixed
+- The dashboard's "latest per room / per sensor" reads work again and no longer
+  depend on parquet files at all: they are served from InfluxDB's in-memory last
+  value cache, which the backend creates idempotently at startup (key `roomId` /
+  `sensorId`, TTL = `*.latest-lookback-days`). The former 7-day window-function
+  scan started failing InfluxDB 3 Core's 432-parquet-file query limit once ~4 days
+  of gen1 files had accumulated — `GET /api/occupancy/all` returned 500 and every
+  room except the live-streaming 137 showed as unavailable. While the cache is
+  cold right after an InfluxDB restart, a scan bounded to
+  `*.latest-fallback-days` (default 2) fills the gap; the previously unbounded
+  single-room reads now use the same bounded fallback. Client-controlled windows
+  are capped server-side (history/forecast ≤ 168 h, week-pattern ≤ 8 weeks,
+  metrics history ≤ `metrics.history-max-days`) so a single request can never
+  exceed the file limit (#294).
 - `POST /api/rooms` now rejects a create whose `roomId` already exists with
   `409 Conflict` instead of silently overwriting the stored room. Rooms use an
   assigned ID, so `save()` on a duplicate acted as an update and corrupted the

--- a/README.md
+++ b/README.md
@@ -338,7 +338,10 @@ Only the values you'll actually touch. Internal service-to-service URLs
 | `SPRING_PROFILES_ACTIVE`       | `dev`                       | `dev` = open, no auth; `prod` = Keycloak JWT      |
 | `INFLUXDB_URL`                 | `http://localhost:8181`     | InfluxDB endpoint (compose sets `http://influxdb:8181`) |
 | `POSTGRES_URL`                 | `jdbc:postgresql://localhost:5432/occupi` | room-metadata DB                   |
-| `occupancy.latest-lookback-days` | `7`                       | how far back the "latest per room" query scans   |
+| `occupancy.latest-lookback-days` | `7`                       | TTL of the InfluxDB last value cache serving "latest per room" |
+| `occupancy.latest-fallback-days` | `2`                       | bounded-scan window that tops up the cache after an InfluxDB restart |
+| `chart.history.max-hours` / `forecast.max-hours` | `168`     | hard cap on the history/forecast request window  |
+| `chart.weekpattern.max-weeks`  | `8`                         | hard cap on the week-pattern request window       |
 
 **Sensor sender** (`raspberry/.env`, copy from `raspberry/.env.example`):
 

--- a/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/chart/ChartServiceImpl.java
@@ -53,6 +53,21 @@ public class ChartServiceImpl implements ChartService {
     @Value("${chart.history.max-points:500}")
     private int maxPoints;
 
+    /**
+     * Hard cap on the history look-back window. Bounds how many parquet files a
+     * single request can make InfluxDB open — the query file limit rejects wider
+     * scans outright (#294).
+     */
+    @Value("${chart.history.max-hours:168}")
+    private int maxHours = 168;
+
+    /**
+     * Hard cap on the week-pattern look-back, for the same reason as
+     * {@link #maxHours}. Eight weeks is also all the frontend ever requests.
+     */
+    @Value("${chart.weekpattern.max-weeks:8}")
+    private int maxWeeks = 8;
+
     /** Earliest hour (inclusive) considered when picking the quiet time. */
     @Value("${chart.weekpattern.quiet-start-hour:8}")
     private int quietStartHour;
@@ -76,6 +91,10 @@ public class ChartServiceImpl implements ChartService {
         validateRoomId(roomId);
         if (hours <= 0) {
             throw new IllegalArgumentException("hours must be positive, got: " + hours);
+        }
+        if (hours > maxHours) {
+            throw new IllegalArgumentException(
+                    "hours must be at most " + maxHours + ", got: " + hours);
         }
 
         int slotMinutes = TimeSlots.slotMinutes(hours, maxPoints);
@@ -109,6 +128,10 @@ public class ChartServiceImpl implements ChartService {
         validateRoomId(roomId);
         if (weeks <= 0) {
             throw new IllegalArgumentException("weeks must be positive, got: " + weeks);
+        }
+        if (weeks > maxWeeks) {
+            throw new IllegalArgumentException(
+                    "weeks must be at most " + maxWeeks + ", got: " + weeks);
         }
 
         Instant end = clock.instant();

--- a/backend/src/main/java/com/occupi/feature/database/config/InfluxDBConfig.java
+++ b/backend/src/main/java/com/occupi/feature/database/config/InfluxDBConfig.java
@@ -5,6 +5,9 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.net.http.HttpClient;
+import java.time.Duration;
+
 /**
  * Spring configuration for InfluxDB 3.x client bean.
  * Creates a singleton InfluxDBClient connected to the configured instance.
@@ -22,5 +25,16 @@ public class InfluxDBConfig {
                         : null,
                 properties.getDatabase()
         );
+    }
+
+    /**
+     * Plain HTTP client for InfluxDB's management API (e.g. creating last value
+     * caches, #294) — the influxdb3-java client only covers write and query.
+     */
+    @Bean
+    public HttpClient influxHttpClient() {
+        return HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
     }
 }

--- a/backend/src/main/java/com/occupi/feature/database/config/InfluxLastCacheInitializer.java
+++ b/backend/src/main/java/com/occupi/feature/database/config/InfluxLastCacheInitializer.java
@@ -1,0 +1,101 @@
+package com.occupi.feature.database.config;
+
+import com.occupi.feature.database.repository.MetricsRepository;
+import com.occupi.feature.database.repository.OccupancyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+/**
+ * Creates the InfluxDB last value caches the latest-per-room/-per-sensor reads are
+ * served from (#294). A last value cache answers "newest row per tag value" from
+ * memory without opening any parquet file — the scan-based query broke once the
+ * accumulated gen1 files exceeded InfluxDB 3 Core's query file limit, because Core
+ * never compacts them.
+ *
+ * Creation is idempotent: InfluxDB answers 409 when the cache already exists, which
+ * is the normal case on every restart after the first. Any failure is logged and
+ * swallowed — the repositories fall back to a bounded scan when the cache is
+ * missing, so the backend must start (degraded) even if InfluxDB is unreachable.
+ *
+ * Note: InfluxDB 3 Core persists the cache <em>definition</em> only. After an
+ * InfluxDB restart the cache content starts cold and refills as sensors write.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InfluxLastCacheInitializer {
+
+    private final InfluxDBProperties properties;
+    private final HttpClient influxHttpClient;
+
+    /** Cache TTL: mirrors how far back the latest-reads looked before the cache (#273). */
+    @Value("${occupancy.latest-lookback-days:7}")
+    private int occupancyTtlDays = 7;
+
+    @Value("${metrics.latest-lookback-days:7}")
+    private int metricsTtlDays = 7;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void createLastCaches() {
+        createLastCache(OccupancyRepository.MEASUREMENT_NAME,
+                OccupancyRepository.LAST_CACHE_NAME,
+                OccupancyRepository.LAST_CACHE_KEY_COLUMN,
+                Duration.ofDays(occupancyTtlDays));
+        createLastCache(MetricsRepository.MEASUREMENT_NAME,
+                MetricsRepository.LAST_CACHE_NAME,
+                MetricsRepository.LAST_CACHE_KEY_COLUMN,
+                Duration.ofDays(metricsTtlDays));
+    }
+
+    private void createLastCache(String table, String cacheName, String keyColumn, Duration ttl) {
+        HttpRequest.Builder request = HttpRequest.newBuilder()
+                .uri(URI.create(properties.getUrl() + "/api/v3/configure/last_cache"))
+                .timeout(Duration.ofSeconds(10))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(
+                        cacheDefinition(properties.getDatabase(), table, cacheName, keyColumn, ttl)));
+        if (properties.getToken() != null && !properties.getToken().isEmpty()) {
+            request.header("Authorization", "Bearer " + properties.getToken());
+        }
+
+        try {
+            HttpResponse<String> response =
+                    influxHttpClient.send(request.build(), HttpResponse.BodyHandlers.ofString());
+            switch (response.statusCode()) {
+                case 201 -> log.info("Created InfluxDB last value cache '{}' on table '{}'", cacheName, table);
+                case 409 -> log.debug("InfluxDB last value cache '{}' already exists", cacheName);
+                default -> log.warn("Creating InfluxDB last value cache '{}' failed (HTTP {}): {} — "
+                                + "latest reads fall back to bounded scans",
+                        cacheName, response.statusCode(), response.body());
+            }
+        } catch (IOException e) {
+            log.warn("Creating InfluxDB last value cache '{}' failed: {} — "
+                    + "latest reads fall back to bounded scans", cacheName, e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Interrupted while creating InfluxDB last value cache '{}'", cacheName);
+        }
+    }
+
+    /**
+     * Request body for POST /api/v3/configure/last_cache. The API expects the TTL in
+     * seconds (unlike the CLI's humantime format); count 1 keeps exactly the newest
+     * row per key value.
+     */
+    static String cacheDefinition(String db, String table, String cacheName, String keyColumn, Duration ttl) {
+        return """
+                {"db": "%s", "table": "%s", "name": "%s", "key_columns": ["%s"], "count": 1, "ttl": %d}"""
+                .formatted(db, table, cacheName, keyColumn, ttl.toSeconds());
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/database/config/InfluxLastCacheInitializer.java
+++ b/backend/src/main/java/com/occupi/feature/database/config/InfluxLastCacheInitializer.java
@@ -5,8 +5,10 @@ import com.occupi.feature.database.repository.OccupancyRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -15,6 +17,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Creates the InfluxDB last value caches the latest-per-room/-per-sensor reads are
@@ -23,21 +27,30 @@ import java.time.Duration;
  * accumulated gen1 files exceeded InfluxDB 3 Core's query file limit, because Core
  * never compacts them.
  *
- * Creation is idempotent: InfluxDB answers 409 when the cache already exists, which
- * is the normal case on every restart after the first. Any failure is logged and
- * swallowed — the repositories fall back to a bounded scan when the cache is
- * missing, so the backend must start (degraded) even if InfluxDB is unreachable.
+ * Creation is attempted at startup and retried on a schedule until both caches
+ * exist: InfluxDB creates tables lazily on first write, and creating a cache for
+ * a table that does not exist yet fails (404) — on a fresh database the caches
+ * can only be created once the first sensor has reported. InfluxDB answers 409
+ * when the cache already exists, which is the normal case on every restart after
+ * the first and counts as success. Any failure is logged and swallowed — the
+ * repositories keep a bounded scan besides the cache read, so the backend must
+ * start (degraded) even if InfluxDB is unreachable.
  *
- * Note: InfluxDB 3 Core persists the cache <em>definition</em> only. After an
- * InfluxDB restart the cache content starts cold and refills as sensors write.
+ * Two InfluxDB 3 Core caveats: the cache <em>definition</em> survives an InfluxDB
+ * restart but the content starts cold and refills as sensors write; and an
+ * existing cache is never updated — changing the TTL requires deleting the cache
+ * ({@code DELETE /api/v3/configure/last_cache}) so it gets recreated.
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
+@ConditionalOnProperty(name = "influxdb.last-cache.enabled", havingValue = "true", matchIfMissing = true)
 public class InfluxLastCacheInitializer {
 
     private final InfluxDBProperties properties;
     private final HttpClient influxHttpClient;
+
+    private final Set<String> created = ConcurrentHashMap.newKeySet();
 
     /** Cache TTL: mirrors how far back the latest-reads looked before the cache (#273). */
     @Value("${occupancy.latest-lookback-days:7}")
@@ -48,17 +61,38 @@ public class InfluxLastCacheInitializer {
 
     @EventListener(ApplicationReadyEvent.class)
     public void createLastCaches() {
-        createLastCache(OccupancyRepository.MEASUREMENT_NAME,
+        createIfMissing(OccupancyRepository.MEASUREMENT_NAME,
                 OccupancyRepository.LAST_CACHE_NAME,
                 OccupancyRepository.LAST_CACHE_KEY_COLUMN,
                 Duration.ofDays(occupancyTtlDays));
-        createLastCache(MetricsRepository.MEASUREMENT_NAME,
+        createIfMissing(MetricsRepository.MEASUREMENT_NAME,
                 MetricsRepository.LAST_CACHE_NAME,
                 MetricsRepository.LAST_CACHE_KEY_COLUMN,
                 Duration.ofDays(metricsTtlDays));
     }
 
-    private void createLastCache(String table, String cacheName, String keyColumn, Duration ttl) {
+    /**
+     * Retries any cache whose creation has not succeeded yet — most importantly on
+     * a fresh database, where the tables appear only after the first sensor write.
+     */
+    @Scheduled(fixedDelayString = "${influxdb.last-cache.retry-ms:300000}",
+            initialDelayString = "${influxdb.last-cache.retry-ms:300000}")
+    public void retryMissingLastCaches() {
+        if (created.size() < 2) {
+            createLastCaches();
+        }
+    }
+
+    private void createIfMissing(String table, String cacheName, String keyColumn, Duration ttl) {
+        if (created.contains(cacheName)) {
+            return;
+        }
+        if (createLastCache(table, cacheName, keyColumn, ttl)) {
+            created.add(cacheName);
+        }
+    }
+
+    private boolean createLastCache(String table, String cacheName, String keyColumn, Duration ttl) {
         HttpRequest.Builder request = HttpRequest.newBuilder()
                 .uri(URI.create(properties.getUrl() + "/api/v3/configure/last_cache"))
                 .timeout(Duration.ofSeconds(10))
@@ -72,19 +106,31 @@ public class InfluxLastCacheInitializer {
         try {
             HttpResponse<String> response =
                     influxHttpClient.send(request.build(), HttpResponse.BodyHandlers.ofString());
-            switch (response.statusCode()) {
-                case 201 -> log.info("Created InfluxDB last value cache '{}' on table '{}'", cacheName, table);
-                case 409 -> log.debug("InfluxDB last value cache '{}' already exists", cacheName);
-                default -> log.warn("Creating InfluxDB last value cache '{}' failed (HTTP {}): {} — "
-                                + "latest reads fall back to bounded scans",
-                        cacheName, response.statusCode(), response.body());
+            int status = response.statusCode();
+            switch (status) {
+                case 201 -> {
+                    log.info("Created InfluxDB last value cache '{}' on table '{}'", cacheName, table);
+                    return true;
+                }
+                case 409 -> {
+                    log.debug("InfluxDB last value cache '{}' already exists", cacheName);
+                    return true;
+                }
+                default -> {
+                    log.warn("Creating InfluxDB last value cache '{}' failed (HTTP {}): {} — "
+                                    + "latest reads rely on the bounded scan until the next retry",
+                            cacheName, status, response.body());
+                    return false;
+                }
             }
         } catch (IOException e) {
             log.warn("Creating InfluxDB last value cache '{}' failed: {} — "
-                    + "latest reads fall back to bounded scans", cacheName, e.getMessage());
+                    + "latest reads rely on the bounded scan until the next retry", cacheName, e.getMessage());
+            return false;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.warn("Interrupted while creating InfluxDB last value cache '{}'", cacheName);
+            return false;
         }
     }
 

--- a/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
@@ -22,7 +22,13 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class MetricsRepository {
 
-    static final String MEASUREMENT_NAME = "metrics";
+    public static final String MEASUREMENT_NAME = "metrics";
+
+    /** Name of the InfluxDB last value cache serving the latest-per-sensor reads (#294). */
+    public static final String LAST_CACHE_NAME = "metrics_latest_by_sensor";
+
+    /** Tag column the last value cache is keyed by: one cached row per sensor. */
+    public static final String LAST_CACHE_KEY_COLUMN = "sensorId";
 
     /** Column list shared by every read query; order must match {@link #toMetricsData}. */
     private static final String SELECT_COLUMNS =

--- a/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -226,10 +227,13 @@ public class MetricsRepository {
     /**
      * Maps a query result row to a MetricsData object.
      * Expected column order: see {@link #SELECT_COLUMNS}.
+     * String columns arrive as {@link String} from table scans but as Arrow
+     * {@code Text} from {@code last_cache()} reads, so they must be converted,
+     * not cast.
      */
     private MetricsData toMetricsData(Object[] row) {
         return MetricsData.builder()
-                .sensorId((String) row[0])
+                .sensorId(Objects.toString(row[0], null))
                 .cpuPercentage(((Number) row[1]).doubleValue())
                 .memoryPercentage(((Number) row[2]).doubleValue())
                 .queueSize(((Number) row[3]).intValue())

--- a/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
@@ -38,13 +38,23 @@ public class MetricsRepository {
     private final InfluxDBClient influxDBClient;
 
     /**
-     * How many days back {@link #findAllLatest()} scans for the newest row per sensor.
-     * The scan MUST be bounded: without a time predicate InfluxDB reads the whole
-     * measurement history and sorts it on every call, which pegged the single-core
-     * server CPU once a large amount of data had accumulated (#273).
+     * How many days back the SQL fallback scans when the last value cache has no
+     * rows — right after an InfluxDB restart, before the sensors have reported
+     * again (InfluxDB 3 Core persists the cache definition, not its contents, #294).
+     * The scan MUST be bounded and stay short: a wider window both pegged the
+     * single-core server CPU (#273) and now exceeds InfluxDB's parquet file limit
+     * at roughly four days' worth of gen1 files.
      */
-    @Value("${metrics.latest-lookback-days:7}")
-    private int latestLookbackDays = 7;
+    @Value("${metrics.latest-fallback-days:2}")
+    private int latestFallbackDays = 2;
+
+    /**
+     * Oldest allowed start of a {@link #findBySensorSince} window; an unlimited
+     * {@code since} would let a single request exceed InfluxDB's parquet file
+     * limit (#294). Older values are clamped, not rejected.
+     */
+    @Value("${metrics.history-max-days:7}")
+    private int historyMaxDays = 7;
 
     public void save(MetricsData metrics) {
         validate(metrics);
@@ -84,7 +94,9 @@ public class MetricsRepository {
     }
 
     /**
-     * Returns the most recent metrics row for a single sensor.
+     * Returns the most recent metrics row for a single sensor, served from the last
+     * value cache; falls back to a bounded scan while the cache is cold after an
+     * InfluxDB restart (#294).
      *
      * @param sensorId the sensor to look up (alphanumeric and dashes only)
      * @return the latest metrics, or empty if the sensor has no data
@@ -93,13 +105,19 @@ public class MetricsRepository {
     public Optional<MetricsData> findLatestBySensor(String sensorId) {
         validateSensorId(sensorId);
 
+        List<MetricsData> cached = queryLastCache(" WHERE \"sensorId\" = '%s'".formatted(sensorId));
+        if (!cached.isEmpty()) {
+            return Optional.of(cached.get(0));
+        }
+
         String sql = """
                 SELECT %s
                 FROM "%s"
                 WHERE "sensorId" = '%s'
+                  AND time >= '%s'
                 ORDER BY time DESC
                 LIMIT 1
-                """.formatted(SELECT_COLUMNS, MEASUREMENT_NAME, sensorId);
+                """.formatted(SELECT_COLUMNS, MEASUREMENT_NAME, sensorId, fallbackSince());
 
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
             return rows.map(this::toMetricsData).findFirst();
@@ -107,16 +125,21 @@ public class MetricsRepository {
     }
 
     /**
-     * Returns the most recent metrics row for every known sensor.
-     * Uses a window function to pick the latest row per sensorId in a single query,
-     * scanning only the last {@link #latestLookbackDays} days so the query stays
-     * cheap regardless of how much history has accumulated (see #273).
+     * Returns the most recent metrics row for every known sensor, served from the
+     * last value cache — an in-memory lookup that opens no parquet file, so it
+     * stays cheap no matter how much history has accumulated (#294). While the
+     * cache is cold after an InfluxDB restart, a window-function scan over the
+     * last {@link #latestFallbackDays} days fills the gap.
      *
-     * @return one latest row per sensor within the lookback window
-     *         (empty list if no sensor has reported in that window)
+     * @return one latest row per sensor (empty list if no sensor has reported
+     *         within the cache TTL, or within the fallback window on a cold cache)
      */
     public List<MetricsData> findAllLatest() {
-        Instant since = Instant.now().minus(latestLookbackDays, ChronoUnit.DAYS);
+        List<MetricsData> cached = queryLastCache("");
+        if (!cached.isEmpty()) {
+            return cached;
+        }
+
         String sql = """
                 SELECT %s
                 FROM (
@@ -126,7 +149,7 @@ public class MetricsRepository {
                     WHERE time >= '%s'
                 )
                 WHERE rn = 1
-                """.formatted(SELECT_COLUMNS, SELECT_COLUMNS, MEASUREMENT_NAME, since);
+                """.formatted(SELECT_COLUMNS, SELECT_COLUMNS, MEASUREMENT_NAME, fallbackSince());
 
         List<MetricsData> result = new ArrayList<>();
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
@@ -136,11 +159,41 @@ public class MetricsRepository {
     }
 
     /**
+     * Reads from the last value cache. Returns an empty list when the cache has no
+     * matching rows or cannot be read (missing cache, InfluxDB error) so that
+     * callers can fall back to a bounded scan.
+     *
+     * @param whereClause optional {@code WHERE} clause (values must be validated
+     *                    by the caller), or an empty string for all rows
+     */
+    private List<MetricsData> queryLastCache(String whereClause) {
+        String sql = """
+                SELECT %s
+                FROM last_cache('%s', '%s')%s
+                """.formatted(SELECT_COLUMNS, MEASUREMENT_NAME, LAST_CACHE_NAME, whereClause);
+
+        List<MetricsData> result = new ArrayList<>();
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            rows.forEach(row -> result.add(toMetricsData(row)));
+        } catch (RuntimeException e) {
+            log.warn("Last value cache '{}' not readable, falling back to bounded scan: {}",
+                    LAST_CACHE_NAME, e.getMessage());
+        }
+        return result;
+    }
+
+    private Instant fallbackSince() {
+        return Instant.now().minus(latestFallbackDays, ChronoUnit.DAYS);
+    }
+
+    /**
      * Returns all metrics rows for a sensor from {@code since} (inclusive) onward,
-     * ordered oldest first — for charts and history views.
+     * ordered oldest first — for charts and history views. {@code since} reaches at
+     * most {@link #historyMaxDays} days back; older values are clamped so a single
+     * request can never exceed InfluxDB's parquet file limit (#294).
      *
      * @param sensorId the sensor to look up (alphanumeric and dashes only)
-     * @param since    the start of the time window (inclusive)
+     * @param since    the start of the time window (inclusive, clamped)
      * @return the matching rows in ascending time order (empty list if none)
      * @throws IllegalArgumentException if sensorId is malformed or since is null
      */
@@ -148,6 +201,11 @@ public class MetricsRepository {
         validateSensorId(sensorId);
         if (since == null) {
             throw new IllegalArgumentException("since must not be null");
+        }
+
+        Instant oldestAllowed = Instant.now().minus(historyMaxDays, ChronoUnit.DAYS);
+        if (since.isBefore(oldestAllowed)) {
+            since = oldestAllowed;
         }
 
         String sql = """

--- a/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/MetricsRepository.java
@@ -13,7 +13,9 @@ import org.springframework.stereotype.Repository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -126,21 +128,18 @@ public class MetricsRepository {
     }
 
     /**
-     * Returns the most recent metrics row for every known sensor, served from the
-     * last value cache — an in-memory lookup that opens no parquet file, so it
-     * stays cheap no matter how much history has accumulated (#294). While the
-     * cache is cold after an InfluxDB restart, a window-function scan over the
-     * last {@link #latestFallbackDays} days fills the gap.
+     * Returns the most recent metrics row for every known sensor: the union of
+     * the last value cache — an in-memory lookup that opens no parquet file and
+     * reaches back its full TTL (#294) — and a window-function scan over the last
+     * {@link #latestFallbackDays} days, taking the newer row per sensor. The
+     * union matters because InfluxDB persists the cache definition but not its
+     * contents: after an InfluxDB restart the cache only knows sensors that have
+     * written since, and the bounded scan restores the rest.
      *
      * @return one latest row per sensor (empty list if no sensor has reported
-     *         within the cache TTL, or within the fallback window on a cold cache)
+     *         within the cache TTL or the fallback window)
      */
     public List<MetricsData> findAllLatest() {
-        List<MetricsData> cached = queryLastCache("");
-        if (!cached.isEmpty()) {
-            return cached;
-        }
-
         String sql = """
                 SELECT %s
                 FROM (
@@ -152,17 +151,37 @@ public class MetricsRepository {
                 WHERE rn = 1
                 """.formatted(SELECT_COLUMNS, SELECT_COLUMNS, MEASUREMENT_NAME, fallbackSince());
 
-        List<MetricsData> result = new ArrayList<>();
+        Map<String, MetricsData> latest = new LinkedHashMap<>();
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
-            rows.forEach(row -> result.add(toMetricsData(row)));
+            rows.forEach(row -> {
+                MetricsData data = toMetricsData(row);
+                latest.put(data.getSensorId(), data);
+            });
         }
-        return result;
+        for (MetricsData data : queryLastCache("")) {
+            latest.merge(data.getSensorId(), data, MetricsRepository::newer);
+        }
+        return List.copyOf(latest.values());
+    }
+
+    private static MetricsData newer(MetricsData a, MetricsData b) {
+        if (a.getTimestamp() == null) {
+            return b;
+        }
+        if (b.getTimestamp() == null) {
+            return a;
+        }
+        return b.getTimestamp().isAfter(a.getTimestamp()) ? b : a;
     }
 
     /**
      * Reads from the last value cache. Returns an empty list when the cache has no
-     * matching rows or cannot be read (missing cache, InfluxDB error) so that
-     * callers can fall back to a bounded scan.
+     * matching rows or cannot be read (missing cache, InfluxDB error, stream broken
+     * mid-read) so that callers degrade to the bounded scan alone. A partial read
+     * is discarded rather than returned — it must never pass for a complete cache
+     * view. Failures are logged at debug: the bounded scan covers the reads while
+     * {@link com.occupi.feature.database.config.InfluxLastCacheInitializer} keeps
+     * retrying the cache creation.
      *
      * @param whereClause optional {@code WHERE} clause (values must be validated
      *                    by the caller), or an empty string for all rows
@@ -177,8 +196,9 @@ public class MetricsRepository {
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
             rows.forEach(row -> result.add(toMetricsData(row)));
         } catch (RuntimeException e) {
-            log.warn("Last value cache '{}' not readable, falling back to bounded scan: {}",
+            log.debug("Last value cache '{}' not readable, relying on the bounded scan: {}",
                     LAST_CACHE_NAME, e.getMessage());
+            return List.of();
         }
         return result;
     }

--- a/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
@@ -37,14 +37,15 @@ public class OccupancyRepository {
     private final InfluxDBClient influxDBClient;
 
     /**
-     * How many days back {@link #findAllLatest()} scans for the newest row per room.
-     * The scan MUST be bounded: without a time predicate InfluxDB reads the whole
-     * measurement history and sorts it on every call, which pegged the single-core
-     * server CPU once a large amount of data had accumulated (#273). A room that has
-     * been silent longer than this window simply won't appear until it reports again.
+     * How many days back the SQL fallback scans when the last value cache has no
+     * rows — right after an InfluxDB restart, before the sensors have reported
+     * again (InfluxDB 3 Core persists the cache definition, not its contents, #294).
+     * The scan MUST be bounded and stay short: a wider window both pegged the
+     * single-core server CPU (#273) and now exceeds InfluxDB's parquet file limit
+     * at roughly four days' worth of gen1 files.
      */
-    @Value("${occupancy.latest-lookback-days:7}")
-    private int latestLookbackDays = 7;
+    @Value("${occupancy.latest-fallback-days:2}")
+    private int latestFallbackDays = 2;
 
     /**
      * Saves a single occupancy measurement to InfluxDB.
@@ -88,7 +89,9 @@ public class OccupancyRepository {
     }
 
     /**
-     * Returns the most recent occupancy measurement for a single room.
+     * Returns the most recent occupancy measurement for a single room, served from
+     * the last value cache; falls back to a bounded scan while the cache is cold
+     * after an InfluxDB restart (#294).
      *
      * @param roomId the room to look up (alphanumeric and dashes only)
      * @return the latest measurement, or empty if the room has no data
@@ -97,13 +100,19 @@ public class OccupancyRepository {
     public Optional<OccupancyData> findLatestByRoom(String roomId) {
         validateRoomId(roomId);
 
+        List<OccupancyData> cached = queryLastCache(" WHERE \"roomId\" = '%s'".formatted(roomId));
+        if (!cached.isEmpty()) {
+            return Optional.of(cached.get(0));
+        }
+
         String sql = """
                 SELECT "roomId", "sensorId", "count", "confidence", time
                 FROM "%s"
                 WHERE "roomId" = '%s'
+                  AND time >= '%s'
                 ORDER BY time DESC
                 LIMIT 1
-                """.formatted(MEASUREMENT_NAME, roomId);
+                """.formatted(MEASUREMENT_NAME, roomId, fallbackSince());
 
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
             return rows.map(this::toOccupancyData).findFirst();
@@ -111,16 +120,21 @@ public class OccupancyRepository {
     }
 
     /**
-     * Returns the most recent occupancy measurement for every known room.
-     * Uses a window function to pick the latest row per roomId in a single query,
-     * scanning only the last {@link #latestLookbackDays} days so the query stays
-     * cheap regardless of how much history has accumulated (see #273).
+     * Returns the most recent occupancy measurement for every known room, served
+     * from the last value cache — an in-memory lookup that opens no parquet file,
+     * so it stays cheap no matter how much history has accumulated (#294). While
+     * the cache is cold after an InfluxDB restart, a window-function scan over the
+     * last {@link #latestFallbackDays} days fills the gap.
      *
-     * @return one latest measurement per room within the lookback window
-     *         (empty list if no room has reported in that window)
+     * @return one latest measurement per room (empty list if no room has reported
+     *         within the cache TTL, or within the fallback window on a cold cache)
      */
     public List<OccupancyData> findAllLatest() {
-        Instant since = Instant.now().minus(latestLookbackDays, ChronoUnit.DAYS);
+        List<OccupancyData> cached = queryLastCache("");
+        if (!cached.isEmpty()) {
+            return cached;
+        }
+
         String sql = """
                 SELECT "roomId", "sensorId", "count", "confidence", time
                 FROM (
@@ -130,13 +144,41 @@ public class OccupancyRepository {
                     WHERE time >= '%s'
                 )
                 WHERE rn = 1
-                """.formatted(MEASUREMENT_NAME, since);
+                """.formatted(MEASUREMENT_NAME, fallbackSince());
 
         List<OccupancyData> result = new ArrayList<>();
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
             rows.forEach(row -> result.add(toOccupancyData(row)));
         }
         return result;
+    }
+
+    /**
+     * Reads from the last value cache. Returns an empty list when the cache has no
+     * matching rows or cannot be read (missing cache, InfluxDB error) so that
+     * callers can fall back to a bounded scan.
+     *
+     * @param whereClause optional {@code WHERE} clause (values must be validated
+     *                    by the caller), or an empty string for all rows
+     */
+    private List<OccupancyData> queryLastCache(String whereClause) {
+        String sql = """
+                SELECT "roomId", "sensorId", "count", "confidence", time
+                FROM last_cache('%s', '%s')%s
+                """.formatted(MEASUREMENT_NAME, LAST_CACHE_NAME, whereClause);
+
+        List<OccupancyData> result = new ArrayList<>();
+        try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
+            rows.forEach(row -> result.add(toOccupancyData(row)));
+        } catch (RuntimeException e) {
+            log.warn("Last value cache '{}' not readable, falling back to bounded scan: {}",
+                    LAST_CACHE_NAME, e.getMessage());
+        }
+        return result;
+    }
+
+    private Instant fallbackSince() {
+        return Instant.now().minus(latestFallbackDays, ChronoUnit.DAYS);
     }
 
     /**

--- a/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
@@ -26,7 +26,13 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class OccupancyRepository {
 
-    static final String MEASUREMENT_NAME = "occupancy";
+    public static final String MEASUREMENT_NAME = "occupancy";
+
+    /** Name of the InfluxDB last value cache serving the latest-per-room reads (#294). */
+    public static final String LAST_CACHE_NAME = "occupancy_latest_by_room";
+
+    /** Tag column the last value cache is keyed by: one cached row per room. */
+    public static final String LAST_CACHE_KEY_COLUMN = "roomId";
 
     private final InfluxDBClient influxDBClient;
 

--- a/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -184,11 +185,14 @@ public class OccupancyRepository {
     /**
      * Maps a query result row to an OccupancyData object.
      * Expected column order: roomId, sensorId, count, confidence, time.
+     * String columns arrive as {@link String} from table scans but as Arrow
+     * {@code Text} from {@code last_cache()} reads, so they must be converted,
+     * not cast.
      */
     private OccupancyData toOccupancyData(Object[] row) {
         return OccupancyData.builder()
-                .roomId((String) row[0])
-                .sensorId((String) row[1])
+                .roomId(Objects.toString(row[0], null))
+                .sensorId(Objects.toString(row[1], null))
                 .count(((Number) row[2]).intValue())
                 .confidence(((Number) row[3]).doubleValue())
                 .timestamp(InfluxTime.toInstant(row[4]))

--- a/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
+++ b/backend/src/main/java/com/occupi/feature/database/repository/OccupancyRepository.java
@@ -13,7 +13,9 @@ import org.springframework.stereotype.Repository;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -121,21 +123,18 @@ public class OccupancyRepository {
     }
 
     /**
-     * Returns the most recent occupancy measurement for every known room, served
-     * from the last value cache — an in-memory lookup that opens no parquet file,
-     * so it stays cheap no matter how much history has accumulated (#294). While
-     * the cache is cold after an InfluxDB restart, a window-function scan over the
-     * last {@link #latestFallbackDays} days fills the gap.
+     * Returns the most recent occupancy measurement for every known room: the
+     * union of the last value cache — an in-memory lookup that opens no parquet
+     * file and reaches back its full TTL (#294) — and a window-function scan over
+     * the last {@link #latestFallbackDays} days, taking the newer row per room.
+     * The union matters because InfluxDB persists the cache definition but not
+     * its contents: after an InfluxDB restart the cache only knows rooms that
+     * have written since, and the bounded scan restores the rest.
      *
      * @return one latest measurement per room (empty list if no room has reported
-     *         within the cache TTL, or within the fallback window on a cold cache)
+     *         within the cache TTL or the fallback window)
      */
     public List<OccupancyData> findAllLatest() {
-        List<OccupancyData> cached = queryLastCache("");
-        if (!cached.isEmpty()) {
-            return cached;
-        }
-
         String sql = """
                 SELECT "roomId", "sensorId", "count", "confidence", time
                 FROM (
@@ -147,17 +146,37 @@ public class OccupancyRepository {
                 WHERE rn = 1
                 """.formatted(MEASUREMENT_NAME, fallbackSince());
 
-        List<OccupancyData> result = new ArrayList<>();
+        Map<String, OccupancyData> latest = new LinkedHashMap<>();
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
-            rows.forEach(row -> result.add(toOccupancyData(row)));
+            rows.forEach(row -> {
+                OccupancyData data = toOccupancyData(row);
+                latest.put(data.getRoomId(), data);
+            });
         }
-        return result;
+        for (OccupancyData data : queryLastCache("")) {
+            latest.merge(data.getRoomId(), data, OccupancyRepository::newer);
+        }
+        return List.copyOf(latest.values());
+    }
+
+    private static OccupancyData newer(OccupancyData a, OccupancyData b) {
+        if (a.getTimestamp() == null) {
+            return b;
+        }
+        if (b.getTimestamp() == null) {
+            return a;
+        }
+        return b.getTimestamp().isAfter(a.getTimestamp()) ? b : a;
     }
 
     /**
      * Reads from the last value cache. Returns an empty list when the cache has no
-     * matching rows or cannot be read (missing cache, InfluxDB error) so that
-     * callers can fall back to a bounded scan.
+     * matching rows or cannot be read (missing cache, InfluxDB error, stream broken
+     * mid-read) so that callers degrade to the bounded scan alone. A partial read
+     * is discarded rather than returned — it must never pass for a complete cache
+     * view. Failures are logged at debug: the bounded scan covers the reads while
+     * {@link com.occupi.feature.database.config.InfluxLastCacheInitializer} keeps
+     * retrying the cache creation.
      *
      * @param whereClause optional {@code WHERE} clause (values must be validated
      *                    by the caller), or an empty string for all rows
@@ -172,8 +191,9 @@ public class OccupancyRepository {
         try (Stream<Object[]> rows = influxDBClient.query(sql, QueryOptions.defaultQueryOptions())) {
             rows.forEach(row -> result.add(toOccupancyData(row)));
         } catch (RuntimeException e) {
-            log.warn("Last value cache '{}' not readable, falling back to bounded scan: {}",
+            log.debug("Last value cache '{}' not readable, relying on the bounded scan: {}",
                     LAST_CACHE_NAME, e.getMessage());
+            return List.of();
         }
         return result;
     }

--- a/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/forecast/ForecastServiceImpl.java
@@ -55,6 +55,14 @@ public class ForecastServiceImpl implements ForecastService {
     private double decay;
 
     /**
+     * Hard cap on the forecast horizon. Every lookback week runs its own query over
+     * a window this wide, so the cap bounds how many parquet files one request can
+     * make InfluxDB open — the query file limit rejects wider scans outright (#294).
+     */
+    @Value("${forecast.max-hours:168}")
+    private int maxForecastHours = 168;
+
+    /**
      * Point cap feeding the shared slot-width mapping. Deliberately reads the SAME key as
      * history ({@code chart.history.max-points}) so that, for equal windows, forecast and
      * history derive an identical slot width and grid — the contract the frontend #279
@@ -82,6 +90,10 @@ public class ForecastServiceImpl implements ForecastService {
         }
         if (forecastHours <= 0) {
             throw new IllegalArgumentException("forecastHours must be positive, got: " + forecastHours);
+        }
+        if (forecastHours > maxForecastHours) {
+            throw new IllegalArgumentException(
+                    "forecastHours must be at most " + maxForecastHours + ", got: " + forecastHours);
         }
 
         int slotMinutes = TimeSlots.slotMinutes(forecastHours, maxPoints);

--- a/backend/src/main/java/com/occupi/feature/provider/MetricsProviderController.java
+++ b/backend/src/main/java/com/occupi/feature/provider/MetricsProviderController.java
@@ -69,7 +69,9 @@ public class MetricsProviderController {
      *
      * @param sensorId the sensor identifier
      * @param since    the start of the window as an ISO-8601 UTC instant
-     *                 (e.g. {@code 2026-06-14T10:00:00Z})
+     *                 (e.g. {@code 2026-06-14T10:00:00Z}); reaches at most
+     *                 {@code metrics.history-max-days} (default 7) back — older
+     *                 values are clamped, not rejected (#294)
      * @return 200 OK with a list of {@link MetricsResponse}, or 400 if sensorId is
      *         blank or {@code since} is not a parseable instant
      */

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -26,14 +26,20 @@ influxdb:
   database: occupi
   token: ""
 
-# "Latest per room / per sensor" reads only scan this many days back, so the
-# InfluxDB window-function query never walks the full measurement history. An
-# unbounded scan pinned the single-core server CPU and crashed it once a large
-# amount of data had accumulated (#273).
+# "Latest per room / per sensor" reads are served from InfluxDB's in-memory last
+# value cache (#294); latest-lookback-days doubles as that cache's TTL. While the
+# cache is cold right after an InfluxDB restart, a scan bounded to
+# latest-fallback-days fills the gap — kept short because a wider scan pinned the
+# single-core server CPU (#273) and now exceeds InfluxDB's parquet file limit at
+# roughly four days' worth of files. history-max-days clamps how far back the
+# metrics history endpoint may reach, for the same reason.
 occupancy:
   latest-lookback-days: 7
+  latest-fallback-days: 2
 metrics:
   latest-lookback-days: 7
+  latest-fallback-days: 2
+  history-max-days: 7
 
 # Caches for the room-detail reads (history / forecast / week-pattern). These results
 # are identical for every viewer of a room and change slowly, so a short-lived cache

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -26,13 +26,13 @@ influxdb:
   database: occupi
   token: ""
 
-# "Latest per room / per sensor" reads are served from InfluxDB's in-memory last
-# value cache (#294); latest-lookback-days doubles as that cache's TTL. While the
-# cache is cold right after an InfluxDB restart, a scan bounded to
-# latest-fallback-days fills the gap — kept short because a wider scan pinned the
+# "Latest per room / per sensor" reads are the union of InfluxDB's in-memory last
+# value cache (#294) — latest-lookback-days is that cache's TTL — and a scan
+# bounded to latest-fallback-days, which restores rooms the cache lost across an
+# InfluxDB restart. The scan window is kept short because a wider scan pinned the
 # single-core server CPU (#273) and now exceeds InfluxDB's parquet file limit at
-# roughly four days' worth of files. history-max-days clamps how far back the
-# metrics history endpoint may reach, for the same reason.
+# roughly three to four days' worth of files. history-max-days clamps how far back
+# the metrics history endpoint may reach, for the same reason.
 occupancy:
   latest-lookback-days: 7
   latest-fallback-days: 2

--- a/backend/src/test/java/com/occupi/feature/chart/ChartHistoryInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/chart/ChartHistoryInfluxIntegrationTest.java
@@ -42,7 +42,7 @@ class ChartHistoryInfluxIntegrationTest {
 
     @Container
     static final GenericContainer<?> influxdb =
-            new GenericContainer<>(DockerImageName.parse("influxdb:3-core"))
+            new GenericContainer<>(DockerImageName.parse("influxdb:3.9.3-core"))
                     .withExposedPorts(8181)
                     .withCommand("serve",
                             "--host-id", "occupi-test",

--- a/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
@@ -182,6 +182,12 @@ class ChartServiceImplTest {
         assertThatIllegalArgumentException().isThrownBy(() -> service.getHistory("room-1", 0));
     }
 
+    @Test
+    @DisplayName("history throws on hours beyond the cap (guards the parquet file limit, #294)")
+    void getHistory_hoursBeyondCap_throws() {
+        assertThatIllegalArgumentException().isThrownBy(() -> service.getHistory("room-1", 169));
+    }
+
     // ---------- weekpattern ----------
 
     @Test
@@ -276,5 +282,11 @@ class ChartServiceImplTest {
     @DisplayName("weekpattern throws on non-positive weeks")
     void getWeekPattern_zeroWeeks_throws() {
         assertThatIllegalArgumentException().isThrownBy(() -> service.getWeekPattern("room-1", 0));
+    }
+
+    @Test
+    @DisplayName("weekpattern throws on weeks beyond the cap (guards the parquet file limit, #294)")
+    void getWeekPattern_weeksBeyondCap_throws() {
+        assertThatIllegalArgumentException().isThrownBy(() -> service.getWeekPattern("room-1", 9));
     }
 }

--- a/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/chart/ChartServiceImplTest.java
@@ -152,6 +152,9 @@ class ChartServiceImplTest {
     void getHistory_longWindow_neverExceedsMaxPoints() {
         int cap = 10;
         ReflectionTestUtils.setField(service, "maxPoints", cap);
+        // Lift the request cap (#294): this test needs a window far beyond it to
+        // push the slot width past the breakpoint table.
+        ReflectionTestUtils.setField(service, "maxHours", 1000);
         fixClockAt(Instant.parse("2025-01-13T10:00:00Z"));
         when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                 .thenAnswer(inv -> Stream.<Object[]>empty());

--- a/backend/src/test/java/com/occupi/feature/database/config/InfluxLastCacheInitializerTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/config/InfluxLastCacheInitializerTest.java
@@ -114,6 +114,32 @@ class InfluxLastCacheInitializerTest {
     }
 
     @Test
+    @DisplayName("does not retry caches that were created successfully")
+    void retryStopsAfterSuccess() throws Exception {
+        stubResponse(201);
+
+        initializer.createLastCaches();
+        initializer.retryMissingLastCaches();
+
+        verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
+    @DisplayName("retries failed creations until they succeed, then stops")
+    void retryRetriesFailures() throws Exception {
+        when(response.statusCode()).thenReturn(500, 500, 201, 201);
+        lenient().when(response.body()).thenReturn("");
+        when(httpClient.send(any(HttpRequest.class), any()))
+                .thenReturn(response);
+
+        initializer.createLastCaches();       // both fail (500)
+        initializer.retryMissingLastCaches(); // both succeed (201)
+        initializer.retryMissingLastCaches(); // nothing left to create
+
+        verify(httpClient, times(4)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
     @DisplayName("cache definition carries key column, count 1 and the TTL in seconds")
     void cacheDefinitionJson() {
         String json = InfluxLastCacheInitializer.cacheDefinition(

--- a/backend/src/test/java/com/occupi/feature/database/config/InfluxLastCacheInitializerTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/config/InfluxLastCacheInitializerTest.java
@@ -130,7 +130,7 @@ class InfluxLastCacheInitializerTest {
         when(response.statusCode()).thenReturn(500, 500, 201, 201);
         lenient().when(response.body()).thenReturn("");
         when(httpClient.send(any(HttpRequest.class), any()))
-                .thenReturn(response);
+                .thenAnswer(inv -> response);
 
         initializer.createLastCaches();       // both fail (500)
         initializer.retryMissingLastCaches(); // both succeed (201)

--- a/backend/src/test/java/com/occupi/feature/database/config/InfluxLastCacheInitializerTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/config/InfluxLastCacheInitializerTest.java
@@ -1,0 +1,126 @@
+package com.occupi.feature.database.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InfluxLastCacheInitializer")
+class InfluxLastCacheInitializerTest {
+
+    @Mock
+    private HttpClient httpClient;
+
+    @Mock
+    private HttpResponse<String> response;
+
+    private InfluxDBProperties properties;
+    private InfluxLastCacheInitializer initializer;
+
+    @BeforeEach
+    void setUp() {
+        properties = new InfluxDBProperties();
+        properties.setUrl("http://influx.test:8181");
+        properties.setDatabase("occupi");
+        properties.setToken("");
+        initializer = new InfluxLastCacheInitializer(properties, httpClient);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubResponse(int statusCode) throws Exception {
+        when(response.statusCode()).thenReturn(statusCode);
+        lenient().when(response.body()).thenReturn("");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+    }
+
+    @Test
+    @DisplayName("creates one cache per measurement against the configure endpoint")
+    void createsBothCaches() throws Exception {
+        stubResponse(201);
+
+        initializer.createLastCaches();
+
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient, times(2)).send(captor.capture(), any());
+        List<HttpRequest> requests = captor.getAllValues();
+        for (HttpRequest request : requests) {
+            assertEquals("http://influx.test:8181/api/v3/configure/last_cache",
+                    request.uri().toString());
+            assertEquals("POST", request.method());
+            assertTrue(request.headers().firstValue("Authorization").isEmpty(),
+                    "empty token must not produce an Authorization header");
+        }
+    }
+
+    @Test
+    @DisplayName("sends a bearer header when a token is configured")
+    void sendsBearerWhenTokenSet() throws Exception {
+        properties.setToken("secret");
+        stubResponse(201);
+
+        initializer.createLastCaches();
+
+        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(httpClient, times(2)).send(captor.capture(), any());
+        assertEquals("Bearer secret",
+                captor.getValue().headers().firstValue("Authorization").orElseThrow());
+    }
+
+    @Test
+    @DisplayName("treats 409 (cache already exists) as success and still creates the second cache")
+    void treats409AsSuccess() throws Exception {
+        stubResponse(409);
+
+        assertDoesNotThrow(() -> initializer.createLastCaches());
+
+        verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
+    @DisplayName("swallows unexpected HTTP errors so startup continues on the fallback path")
+    void swallowsHttpErrors() throws Exception {
+        stubResponse(500);
+
+        assertDoesNotThrow(() -> initializer.createLastCaches());
+
+        verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
+    @DisplayName("swallows connection failures so startup continues on the fallback path")
+    void swallowsConnectionFailure() throws Exception {
+        when(httpClient.send(any(HttpRequest.class), any()))
+                .thenThrow(new IOException("connection refused"));
+
+        assertDoesNotThrow(() -> initializer.createLastCaches());
+
+        verify(httpClient, times(2)).send(any(HttpRequest.class), any());
+    }
+
+    @Test
+    @DisplayName("cache definition carries key column, count 1 and the TTL in seconds")
+    void cacheDefinitionJson() {
+        String json = InfluxLastCacheInitializer.cacheDefinition(
+                "occupi", "occupancy", "occupancy_latest_by_room", "roomId", Duration.ofDays(7));
+
+        assertEquals("{\"db\": \"occupi\", \"table\": \"occupancy\", "
+                + "\"name\": \"occupancy_latest_by_room\", \"key_columns\": [\"roomId\"], "
+                + "\"count\": 1, \"ttl\": 604800}", json);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/database/repository/LastCacheInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/LastCacheInfluxIntegrationTest.java
@@ -4,6 +4,7 @@ import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.query.QueryOptions;
 import com.occupi.feature.database.config.InfluxDBProperties;
 import com.occupi.feature.database.config.InfluxLastCacheInitializer;
+import com.occupi.feature.database.model.MetricsData;
 import com.occupi.feature.database.model.OccupancyData;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -103,15 +104,23 @@ class LastCacheInfluxIntegrationTest {
 
     @Test
     @Order(2)
-    @DisplayName("creates the caches via the management API; a second run is idempotent (409)")
+    @DisplayName("creates both caches via the management API; re-running is safe")
     void cacheCreationIsIdempotent() {
-        assertDoesNotThrow(initializer::createLastCaches);
+        // InfluxDB creates tables lazily on first write — without this row the
+        // metrics cache creation would 404 (no metrics test writes otherwise).
+        new MetricsRepository(client).save(MetricsData.builder()
+                .sensorId("it-sensor").cpuPercentage(10.0).memoryPercentage(20.0)
+                .queueSize(0).sent(1).dropped(0).avgProcessTime(1.0f)
+                .timestamp(Instant.now()).build());
+
+        initializer.createLastCaches();
         assertDoesNotThrow(initializer::createLastCaches);
 
         try (Stream<Object[]> rows =
                      client.query("SELECT * FROM system.last_caches", QueryOptions.defaultQueryOptions())) {
             List<String> cells = rows.flatMap(Arrays::stream).map(String::valueOf).toList();
-            assertThat(cells).contains(OccupancyRepository.LAST_CACHE_NAME);
+            assertThat(cells).contains(OccupancyRepository.LAST_CACHE_NAME,
+                    MetricsRepository.LAST_CACHE_NAME);
         }
     }
 

--- a/backend/src/test/java/com/occupi/feature/database/repository/LastCacheInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/LastCacheInfluxIntegrationTest.java
@@ -1,0 +1,138 @@
+package com.occupi.feature.database.repository;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.influxdb.v3.client.query.QueryOptions;
+import com.occupi.feature.database.config.InfluxDBProperties;
+import com.occupi.feature.database.config.InfluxLastCacheInitializer;
+import com.occupi.feature.database.model.OccupancyData;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Integration test for the last value cache read path (#294) against a real
+ * InfluxDB 3 instance: cache creation via the management API, cache-served
+ * latest reads, and the bounded-scan fallback while no cache exists. Skipped
+ * automatically when Docker is unavailable.
+ *
+ * The tests are ordered: the fallback behavior is only observable before the
+ * caches have been created on the shared container.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("OccupancyRepository last value cache — real InfluxDB 3 (integration)")
+class LastCacheInfluxIntegrationTest {
+
+    @Container
+    static final GenericContainer<?> influxdb =
+            new GenericContainer<>(DockerImageName.parse("influxdb:3-core"))
+                    .withExposedPorts(8181)
+                    .withCommand("serve",
+                            "--host-id", "occupi-test",
+                            "--http-bind", "0.0.0.0:8181",
+                            "--object-store", "memory",
+                            "--without-auth")
+                    .waitingFor(Wait.forHttp("/health").forStatusCode(200)
+                            .withStartupTimeout(Duration.ofSeconds(90)));
+
+    private static InfluxDBClient client;
+    private static InfluxLastCacheInitializer initializer;
+    private OccupancyRepository repository;
+
+    @BeforeAll
+    static void initClient() {
+        String url = "http://" + influxdb.getHost() + ":" + influxdb.getMappedPort(8181);
+        client = InfluxDBClient.getInstance(url, null, "occupi");
+
+        InfluxDBProperties properties = new InfluxDBProperties();
+        properties.setUrl(url);
+        properties.setDatabase("occupi");
+        properties.setToken("");
+        initializer = new InfluxLastCacheInitializer(properties, HttpClient.newHttpClient());
+    }
+
+    @AfterAll
+    static void closeClient() throws Exception {
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        repository = new OccupancyRepository(client);
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("falls back to the bounded scan while no cache exists")
+    void fallbackServesReadsWithoutCache() {
+        Instant ts = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        repository.save(OccupancyData.builder()
+                .roomId("fallback-room").sensorId("s").count(6).confidence(0.9).timestamp(ts).build());
+
+        await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    List<OccupancyData> all = repository.findAllLatest();
+                    assertThat(all).extracting(OccupancyData::getRoomId).contains("fallback-room");
+                    assertThat(repository.findLatestByRoom("fallback-room")).isPresent();
+                });
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("creates the caches via the management API; a second run is idempotent (409)")
+    void cacheCreationIsIdempotent() {
+        assertDoesNotThrow(initializer::createLastCaches);
+        assertDoesNotThrow(initializer::createLastCaches);
+
+        try (Stream<Object[]> rows =
+                     client.query("SELECT * FROM system.last_caches", QueryOptions.defaultQueryOptions())) {
+            List<String> cells = rows.flatMap(Arrays::stream).map(String::valueOf).toList();
+            assertThat(cells).contains(OccupancyRepository.LAST_CACHE_NAME);
+        }
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("serves a room outside the fallback window from the warm cache")
+    void warmCacheServesLatestReads() {
+        // Three days old: outside the 2-day fallback scan, so only the cache —
+        // fed by this write, which happens after the caches exist — can serve it.
+        Instant ts = Instant.now().minus(3, ChronoUnit.DAYS).truncatedTo(ChronoUnit.MILLIS);
+        repository.save(OccupancyData.builder()
+                .roomId("warm-room").sensorId("s").count(11).confidence(0.85).timestamp(ts).build());
+
+        await().atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(500))
+                .untilAsserted(() -> {
+                    List<OccupancyData> all = repository.findAllLatest();
+                    assertThat(all).extracting(OccupancyData::getRoomId).contains("warm-room");
+
+                    OccupancyData warm = repository.findLatestByRoom("warm-room").orElseThrow();
+                    assertThat(warm.getCount()).isEqualTo(11);
+                    assertThat(warm.getTimestamp()).isEqualTo(ts);
+                });
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/database/repository/LastCacheInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/LastCacheInfluxIntegrationTest.java
@@ -47,7 +47,7 @@ class LastCacheInfluxIntegrationTest {
 
     @Container
     static final GenericContainer<?> influxdb =
-            new GenericContainer<>(DockerImageName.parse("influxdb:3-core"))
+            new GenericContainer<>(DockerImageName.parse("influxdb:3.9.3-core"))
                     .withExposedPorts(8181)
                     .withCommand("serve",
                             "--host-id", "occupi-test",

--- a/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
@@ -229,7 +229,7 @@ class MetricsRepositoryTest {
     class FindAllLatest {
 
         @Test
-        @DisplayName("should serve all rows from the last value cache without scanning")
+        @DisplayName("should union the bounded scan with the last value cache")
         void shouldMapAllRows() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
@@ -246,9 +246,12 @@ class MetricsRepositoryTest {
             assertEquals(50, result.get(1).getSent());
 
             ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
-            assertTrue(sqlCaptor.getValue().contains("last_cache('metrics'"),
-                    "a warm cache must satisfy the read without a second query");
+            verify(influxDBClient, times(2)).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getAllValues().get(0).contains("time >="),
+                    "the scan must constrain the window with a time predicate, "
+                            + "otherwise it reads the entire measurement history");
+            assertTrue(sqlCaptor.getAllValues().get(1).contains("last_cache('metrics'"),
+                    "the cache read must complement the scan");
         }
 
         @Test
@@ -261,18 +264,23 @@ class MetricsRepositoryTest {
         }
 
         @Test
-        @DisplayName("should fall back to a time-bounded scan when the cache is empty (guards #273)")
-        void shouldBoundScanByTime() {
+        @DisplayName("should keep cache-only sensors and prefer the newer row per sensor")
+        void shouldMergeCacheAndScanRows() {
+            Instant older = Instant.parse("2026-06-14T10:00:00Z");
+            Instant newer = Instant.parse("2026-06-14T12:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                    .thenAnswer(inv -> Stream.empty());
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            row("sensor-A", 42.0, 60.0, 3L, 100L, 1L, 12.5, older)))
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            row("sensor-A", 45.0, 61.0, 4L, 110L, 1L, 13.0, newer),
+                            row("sensor-B", 10.0, 30.0, 0L, 50L, 0L, 8.0, older)));
 
-            repository.findAllLatest();
+            List<MetricsData> result = repository.findAllLatest();
 
-            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(influxDBClient, times(2)).query(sqlCaptor.capture(), any(QueryOptions.class));
-            assertTrue(sqlCaptor.getAllValues().get(1).contains("time >="),
-                    "the fallback scan must constrain the window with a time predicate, "
-                            + "otherwise it reads the entire measurement history");
+            assertEquals(2, result.size());
+            assertEquals(110, result.get(0).getSent());
+            assertEquals(newer, result.get(0).getTimestamp());
+            assertEquals("sensor-B", result.get(1).getSensorId());
         }
 
         @Test
@@ -290,13 +298,13 @@ class MetricsRepositoryTest {
         }
 
         @Test
-        @DisplayName("should fall back to the bounded scan when the cache is not readable")
+        @DisplayName("should tolerate an unreadable cache and return the scan rows")
         void shouldFallBackWhenCacheReadFails() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                    .thenThrow(new RuntimeException("could not find cache"))
                     .thenAnswer(inv -> Stream.<Object[]>of(
-                            row("sensor-A", 42.0, 60.0, 3L, 100L, 1L, 12.5, ts)));
+                            row("sensor-A", 42.0, 60.0, 3L, 100L, 1L, 12.5, ts)))
+                    .thenThrow(new RuntimeException("could not find cache"));
 
             List<MetricsData> result = repository.findAllLatest();
 

--- a/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
@@ -4,6 +4,7 @@ import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.Point;
 import com.influxdb.v3.client.query.QueryOptions;
 import com.occupi.feature.database.model.MetricsData;
+import org.apache.arrow.vector.util.Text;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -272,6 +273,20 @@ class MetricsRepositoryTest {
             assertTrue(sqlCaptor.getAllValues().get(1).contains("time >="),
                     "the fallback scan must constrain the window with a time predicate, "
                             + "otherwise it reads the entire measurement history");
+        }
+
+        @Test
+        @DisplayName("should map Arrow Text string columns as last_cache() rows deliver them")
+        void shouldMapArrowTextColumns() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{
+                            new Text("sensor-A"), 42.0, 60.0, 3L, 100L, 1L, 12.5, nanos(ts)}));
+
+            List<MetricsData> result = repository.findAllLatest();
+
+            assertEquals(1, result.size());
+            assertEquals("sensor-A", result.get(0).getSensorId());
         }
 
         @Test

--- a/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/MetricsRepositoryTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -154,7 +155,7 @@ class MetricsRepositoryTest {
     class FindLatestBySensor {
 
         @Test
-        @DisplayName("should map the latest row to MetricsData")
+        @DisplayName("should serve the latest row from the last value cache")
         void shouldMapLatestRow() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
@@ -173,10 +174,33 @@ class MetricsRepositoryTest {
             assertEquals(1, data.getDropped());
             assertEquals(12.5f, data.getAvgProcessTime());
             assertEquals(ts, data.getTimestamp());
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getValue().contains("last_cache('metrics'"),
+                    "the first read must hit the last value cache, not a scan");
         }
 
         @Test
-        @DisplayName("should return empty when no rows are found")
+        @DisplayName("should fall back to a time-bounded scan when the cache is empty")
+        void shouldFallBackWhenCacheEmpty() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty())
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            row("sensor-A", 42.0, 60.0, 3L, 100L, 1L, 12.5, ts)));
+
+            Optional<MetricsData> result = repository.findLatestBySensor("sensor-A");
+
+            assertTrue(result.isPresent());
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient, times(2)).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getAllValues().get(1).contains("time >="),
+                    "the fallback scan must be bounded by a time predicate");
+        }
+
+        @Test
+        @DisplayName("should return empty when neither cache nor fallback have rows")
         void shouldReturnEmptyWhenNoRows() {
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                     .thenAnswer(inv -> Stream.empty());
@@ -204,7 +228,7 @@ class MetricsRepositoryTest {
     class FindAllLatest {
 
         @Test
-        @DisplayName("should map every returned row to MetricsData")
+        @DisplayName("should serve all rows from the last value cache without scanning")
         void shouldMapAllRows() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
@@ -219,6 +243,11 @@ class MetricsRepositoryTest {
             assertEquals(3, result.get(0).getQueueSize());
             assertEquals("sensor-B", result.get(1).getSensorId());
             assertEquals(50, result.get(1).getSent());
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getValue().contains("last_cache('metrics'"),
+                    "a warm cache must satisfy the read without a second query");
         }
 
         @Test
@@ -231,7 +260,7 @@ class MetricsRepositoryTest {
         }
 
         @Test
-        @DisplayName("should bound the scan with a time predicate (guards #273)")
+        @DisplayName("should fall back to a time-bounded scan when the cache is empty (guards #273)")
         void shouldBoundScanByTime() {
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                     .thenAnswer(inv -> Stream.empty());
@@ -239,10 +268,25 @@ class MetricsRepositoryTest {
             repository.findAllLatest();
 
             ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
-            assertTrue(sqlCaptor.getValue().contains("time >="),
-                    "findAllLatest must constrain the scan with a time predicate, "
+            verify(influxDBClient, times(2)).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getAllValues().get(1).contains("time >="),
+                    "the fallback scan must constrain the window with a time predicate, "
                             + "otherwise it reads the entire measurement history");
+        }
+
+        @Test
+        @DisplayName("should fall back to the bounded scan when the cache is not readable")
+        void shouldFallBackWhenCacheReadFails() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenThrow(new RuntimeException("could not find cache"))
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            row("sensor-A", 42.0, 60.0, 3L, 100L, 1L, 12.5, ts)));
+
+            List<MetricsData> result = repository.findAllLatest();
+
+            assertEquals(1, result.size());
+            assertEquals("sensor-A", result.get(0).getSensorId());
         }
     }
 
@@ -291,6 +335,20 @@ class MetricsRepositoryTest {
         void shouldRejectNullSince() {
             assertThrows(IllegalArgumentException.class,
                     () -> repository.findBySensorSince("sensor-A", null));
+        }
+
+        @Test
+        @DisplayName("should clamp a since older than the history window (guards #294)")
+        void shouldClampAncientSince() {
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty());
+
+            repository.findBySensorSince("sensor-A", Instant.parse("1970-01-01T00:00:00Z"));
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertFalse(sqlCaptor.getValue().contains("1970-01-01"),
+                    "an epoch since must be clamped, otherwise one request scans the whole history");
         }
     }
 }

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyInfluxIntegrationTest.java
@@ -37,7 +37,7 @@ class OccupancyInfluxIntegrationTest {
 
     @Container
     static final GenericContainer<?> influxdb =
-            new GenericContainer<>(DockerImageName.parse("influxdb:3-core"))
+            new GenericContainer<>(DockerImageName.parse("influxdb:3.9.3-core"))
                     .withExposedPorts(8181)
                     .withCommand("serve",
                             "--host-id", "occupi-test",

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
@@ -181,7 +181,7 @@ class OccupancyRepositoryTest {
     class FindLatestByRoom {
 
         @Test
-        @DisplayName("should map the latest row to OccupancyData")
+        @DisplayName("should serve the latest row from the last value cache")
         void shouldMapLatestRow() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             // InfluxDB 3 returns the time column as nanoseconds (BigInteger), not Instant.
@@ -198,10 +198,33 @@ class OccupancyRepositoryTest {
             assertEquals(12, data.getCount());
             assertEquals(0.9, data.getConfidence());
             assertEquals(ts, data.getTimestamp());
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getValue().contains("last_cache('occupancy'"),
+                    "the first read must hit the last value cache, not a scan");
         }
 
         @Test
-        @DisplayName("should return empty when no rows are found")
+        @DisplayName("should fall back to a time-bounded scan when the cache is empty")
+        void shouldFallBackWhenCacheEmpty() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.empty())
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            new Object[]{"room-101", "sensor-A", 12L, 0.9, nanos(ts)}));
+
+            Optional<OccupancyData> result = repository.findLatestByRoom("room-101");
+
+            assertTrue(result.isPresent());
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient, times(2)).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getAllValues().get(1).contains("time >="),
+                    "the fallback scan must be bounded by a time predicate");
+        }
+
+        @Test
+        @DisplayName("should return empty when neither cache nor fallback have rows")
         void shouldReturnEmptyWhenNoRows() {
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                     .thenAnswer(inv -> Stream.empty());
@@ -228,7 +251,7 @@ class OccupancyRepositoryTest {
     class FindAllLatest {
 
         @Test
-        @DisplayName("should map every returned row to OccupancyData")
+        @DisplayName("should serve all rows from the last value cache without scanning")
         void shouldMapAllRows() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
@@ -243,6 +266,11 @@ class OccupancyRepositoryTest {
             assertEquals(5, result.get(0).getCount());
             assertEquals("room-202", result.get(1).getRoomId());
             assertEquals(20, result.get(1).getCount());
+
+            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getValue().contains("last_cache('occupancy'"),
+                    "a warm cache must satisfy the read without a second query");
         }
 
         @Test
@@ -255,7 +283,7 @@ class OccupancyRepositoryTest {
         }
 
         @Test
-        @DisplayName("should bound the scan with a time predicate (guards #273)")
+        @DisplayName("should fall back to a time-bounded scan when the cache is empty (guards #273)")
         void shouldBoundScanByTime() {
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
                     .thenAnswer(inv -> Stream.empty());
@@ -263,10 +291,25 @@ class OccupancyRepositoryTest {
             repository.findAllLatest();
 
             ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
-            assertTrue(sqlCaptor.getValue().contains("time >="),
-                    "findAllLatest must constrain the scan with a time predicate, "
+            verify(influxDBClient, times(2)).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getAllValues().get(1).contains("time >="),
+                    "the fallback scan must constrain the window with a time predicate, "
                             + "otherwise it reads the entire measurement history");
+        }
+
+        @Test
+        @DisplayName("should fall back to the bounded scan when the cache is not readable")
+        void shouldFallBackWhenCacheReadFails() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenThrow(new RuntimeException("could not find cache"))
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            new Object[]{"room-101", "sensor-A", 5L, 0.8, nanos(ts)}));
+
+            List<OccupancyData> result = repository.findAllLatest();
+
+            assertEquals(1, result.size());
+            assertEquals("room-101", result.get(0).getRoomId());
         }
     }
 }

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
@@ -252,7 +252,7 @@ class OccupancyRepositoryTest {
     class FindAllLatest {
 
         @Test
-        @DisplayName("should serve all rows from the last value cache without scanning")
+        @DisplayName("should union the bounded scan with the last value cache")
         void shouldMapAllRows() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
@@ -269,9 +269,12 @@ class OccupancyRepositoryTest {
             assertEquals(20, result.get(1).getCount());
 
             ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(influxDBClient).query(sqlCaptor.capture(), any(QueryOptions.class));
-            assertTrue(sqlCaptor.getValue().contains("last_cache('occupancy'"),
-                    "a warm cache must satisfy the read without a second query");
+            verify(influxDBClient, times(2)).query(sqlCaptor.capture(), any(QueryOptions.class));
+            assertTrue(sqlCaptor.getAllValues().get(0).contains("time >="),
+                    "the scan must constrain the window with a time predicate, "
+                            + "otherwise it reads the entire measurement history");
+            assertTrue(sqlCaptor.getAllValues().get(1).contains("last_cache('occupancy'"),
+                    "the cache read must complement the scan");
         }
 
         @Test
@@ -284,18 +287,25 @@ class OccupancyRepositoryTest {
         }
 
         @Test
-        @DisplayName("should fall back to a time-bounded scan when the cache is empty (guards #273)")
-        void shouldBoundScanByTime() {
+        @DisplayName("should keep cache-only rooms and prefer the newer row per room")
+        void shouldMergeCacheAndScanRows() {
+            Instant older = Instant.parse("2026-06-14T10:00:00Z");
+            Instant newer = Instant.parse("2026-06-14T12:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                    .thenAnswer(inv -> Stream.empty());
+                    // scan: room-101 only, with the older row
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            new Object[]{"room-101", "sensor-A", 5L, 0.8, nanos(older)}))
+                    // cache: newer row for room-101, plus a room the scan window missed
+                    .thenAnswer(inv -> Stream.<Object[]>of(
+                            new Object[]{"room-101", "sensor-A", 9L, 0.9, nanos(newer)},
+                            new Object[]{"room-303", "sensor-C", 2L, 0.7, nanos(older)}));
 
-            repository.findAllLatest();
+            List<OccupancyData> result = repository.findAllLatest();
 
-            ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
-            verify(influxDBClient, times(2)).query(sqlCaptor.capture(), any(QueryOptions.class));
-            assertTrue(sqlCaptor.getAllValues().get(1).contains("time >="),
-                    "the fallback scan must constrain the window with a time predicate, "
-                            + "otherwise it reads the entire measurement history");
+            assertEquals(2, result.size());
+            assertEquals(9, result.get(0).getCount());
+            assertEquals(newer, result.get(0).getTimestamp());
+            assertEquals("room-303", result.get(1).getRoomId());
         }
 
         @Test
@@ -314,13 +324,13 @@ class OccupancyRepositoryTest {
         }
 
         @Test
-        @DisplayName("should fall back to the bounded scan when the cache is not readable")
+        @DisplayName("should tolerate an unreadable cache and return the scan rows")
         void shouldFallBackWhenCacheReadFails() {
             Instant ts = Instant.parse("2026-06-14T10:00:00Z");
             when(influxDBClient.query(anyString(), any(QueryOptions.class)))
-                    .thenThrow(new RuntimeException("could not find cache"))
                     .thenAnswer(inv -> Stream.<Object[]>of(
-                            new Object[]{"room-101", "sensor-A", 5L, 0.8, nanos(ts)}));
+                            new Object[]{"room-101", "sensor-A", 5L, 0.8, nanos(ts)}))
+                    .thenThrow(new RuntimeException("could not find cache"));
 
             List<OccupancyData> result = repository.findAllLatest();
 

--- a/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/database/repository/OccupancyRepositoryTest.java
@@ -4,6 +4,7 @@ import com.influxdb.v3.client.InfluxDBClient;
 import com.influxdb.v3.client.Point;
 import com.influxdb.v3.client.query.QueryOptions;
 import com.occupi.feature.database.model.OccupancyData;
+import org.apache.arrow.vector.util.Text;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -295,6 +296,21 @@ class OccupancyRepositoryTest {
             assertTrue(sqlCaptor.getAllValues().get(1).contains("time >="),
                     "the fallback scan must constrain the window with a time predicate, "
                             + "otherwise it reads the entire measurement history");
+        }
+
+        @Test
+        @DisplayName("should map Arrow Text string columns as last_cache() rows deliver them")
+        void shouldMapArrowTextColumns() {
+            Instant ts = Instant.parse("2026-06-14T10:00:00Z");
+            when(influxDBClient.query(anyString(), any(QueryOptions.class)))
+                    .thenAnswer(inv -> Stream.<Object[]>of(new Object[]{
+                            new Text("room-101"), new Text("sensor-A"), 5L, 0.8, nanos(ts)}));
+
+            List<OccupancyData> result = repository.findAllLatest();
+
+            assertEquals(1, result.size());
+            assertEquals("room-101", result.get(0).getRoomId());
+            assertEquals("sensor-A", result.get(0).getSensorId());
         }
 
         @Test

--- a/backend/src/test/java/com/occupi/feature/forecast/ForecastInfluxIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/forecast/ForecastInfluxIntegrationTest.java
@@ -46,7 +46,7 @@ class ForecastInfluxIntegrationTest {
 
     @Container
     static final GenericContainer<?> influxdb =
-            new GenericContainer<>(DockerImageName.parse("influxdb:3-core"))
+            new GenericContainer<>(DockerImageName.parse("influxdb:3.9.3-core"))
                     .withExposedPorts(8181)
                     .withCommand("serve",
                             "--host-id", "occupi-test",

--- a/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/forecast/ForecastServiceImplTest.java
@@ -151,4 +151,11 @@ class ForecastServiceImplTest {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> service.forecast("room-1", 0));
     }
+
+    @Test
+    @DisplayName("throws on forecastHours beyond the cap (guards the parquet file limit, #294)")
+    void forecast_hoursBeyondCap_throws() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> service.forecast("room-1", 169));
+    }
 }

--- a/backend/src/test/resources/application-test.yaml
+++ b/backend/src/test/resources/application-test.yaml
@@ -12,6 +12,12 @@ spring:
       ddl-auto: create-drop
     open-in-view: false
 
+# Full-context tests must not reach out to a real InfluxDB (or create caches on a
+# developer's running compose stack as a side effect).
+influxdb:
+  last-cache:
+    enabled: false
+
 logging:
   level:
     com.occupi: DEBUG

--- a/docker/README.md
+++ b/docker/README.md
@@ -76,6 +76,29 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d influxdb
 docker inspect occupi-influxdb3 -f 'nanocpus={{.HostConfig.NanoCpus}} mem={{.HostConfig.Memory}}'
 ```
 
+### InfluxDB query file limit
+InfluxDB 3 Core writes a new parquet file per table roughly every 10 minutes and — unlike
+Enterprise — never compacts them, so long-lived instances accumulate ~100 files per day
+and table. Core refuses any query that would open more than `--query-file-limit` files
+(default 432 ≈ 3 days): that broke the dashboard's latest-per-room read and the week-pattern
+chart once enough history existed (#294).
+
+Two-part mitigation: the *latest* reads now come from InfluxDB's in-memory **last value
+cache** (created by the backend at startup, no parquet involved), and the remaining
+analytic reads run under a raised `--query-file-limit 8192` in the base compose command —
+wide enough for the 8-week week-pattern, and safe here because our files are tiny (~7 KB)
+and the prod resource cap above bounds worst-case memory/CPU. The backend additionally
+caps every client-controlled window (history/forecast ≤ 168 h, week-pattern ≤ 8 weeks) so
+no request can exceed the limit.
+
+Like the resource cap, the flag needs a one-time manual `up -d influxdb` (auto-deploy
+leaves infra containers alone):
+```bash
+cd docker
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d influxdb
+docker inspect occupi-influxdb3 -f '{{.Config.Cmd}}' | grep -o 'query-file-limit [0-9]*'
+```
+
 ### Host Nginx (already present on the server)
 The reverse proxy lives on the host (not in Compose). The versioned config is
 [`../deploy/nginx/occupi.conf`](../deploy/nginx/occupi.conf):

--- a/docker/README.md
+++ b/docker/README.md
@@ -77,19 +77,21 @@ docker inspect occupi-influxdb3 -f 'nanocpus={{.HostConfig.NanoCpus}} mem={{.Hos
 ```
 
 ### InfluxDB query file limit
-InfluxDB 3 Core writes a new parquet file per table roughly every 10 minutes and — unlike
-Enterprise — never compacts them, so long-lived instances accumulate ~100 files per day
-and table. Core refuses any query that would open more than `--query-file-limit` files
-(default 432 ≈ 3 days): that broke the dashboard's latest-per-room read and the week-pattern
-chart once enough history existed (#294).
+InfluxDB 3 Core writes a new parquet file per table every 10 minutes of data — up to
+144 per table and day (we observe ~100–111) — and, unlike Enterprise, never compacts
+them. Core refuses any query that would open more than `--query-file-limit` files
+(default 432, about 3–4 days of files): that broke the dashboard's latest-per-room read
+and the week-pattern chart once enough history existed (#294).
 
 Two-part mitigation: the *latest* reads now come from InfluxDB's in-memory **last value
 cache** (created by the backend at startup, no parquet involved), and the remaining
-analytic reads run under a raised `--query-file-limit 8192` in the base compose command —
-wide enough for the 8-week week-pattern, and safe here because our files are tiny (~7 KB)
+analytic reads run under a raised `--query-file-limit 10000` in the base compose
+command. The widest capped read is the 8-week week-pattern at up to 56 × 144 ≈ 8,064
+files, so 10000 keeps real headroom; it is safe here because our files are tiny (~7 KB)
 and the prod resource cap above bounds worst-case memory/CPU. The backend additionally
-caps every client-controlled window (history/forecast ≤ 168 h, week-pattern ≤ 8 weeks) so
-no request can exceed the limit.
+caps every client-controlled window (history/forecast ≤ 168 h, week-pattern ≤ 8 weeks) —
+those caps and this limit are coupled: whoever raises a window cap must re-check the
+file arithmetic.
 
 Like the resource cap, the flag needs a one-time manual `up -d influxdb` (auto-deploy
 leaves infra containers alone):

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -45,7 +45,10 @@ services:
     restart: unless-stopped
 
   influxdb:
-    image: influxdb:3-core
+    # Pinned: the floating 3-core tag drifted from 3.9.x to 3.10.x and CI suddenly
+    # tested a different version than prod runs. The integration tests pin the same
+    # tag — bump both together, deliberately (#294).
+    image: influxdb:3.9.3-core
     container_name: occupi-influxdb3
     environment:
       - INFLUXDB3_HOST_ID=occupi-prod

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -52,11 +52,12 @@ services:
     container_name: occupi-influxdb3
     environment:
       - INFLUXDB3_HOST_ID=occupi-prod
-    # --query-file-limit: Core never compacts its 10-minute gen1 parquet files, so wide
-    # reads (the 8-week week-pattern needs ~5,600 files at ~100/day) exceed the default
-    # limit of 432 and fail outright (#294). Our files are tiny (~7 KB), and in prod the
-    # #273 CPU/memory caps bound the blast radius, so a higher limit is safe here.
-    command: serve --host-id occupi-prod --http-bind 0.0.0.0:8181 --object-store file --data-dir /var/lib/influxdb3 --without-auth --query-file-limit 8192
+    # --query-file-limit: Core never compacts its 10-minute gen1 parquet files (up to
+    # 144 per table and day), so wide reads exceed the default limit of 432 and fail
+    # outright — the 8-week week-pattern needs up to ~8,064 files at full write cadence
+    # (#294). 10000 leaves headroom above that worst case; our files are tiny (~7 KB),
+    # and in prod the #273 CPU/memory caps bound the blast radius.
+    command: serve --host-id occupi-prod --http-bind 0.0.0.0:8181 --object-store file --data-dir /var/lib/influxdb3 --without-auth --query-file-limit 10000
     volumes:
       - influxdb3-data:/var/lib/influxdb3
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -49,7 +49,11 @@ services:
     container_name: occupi-influxdb3
     environment:
       - INFLUXDB3_HOST_ID=occupi-prod
-    command: serve --host-id occupi-prod --http-bind 0.0.0.0:8181 --object-store file --data-dir /var/lib/influxdb3 --without-auth
+    # --query-file-limit: Core never compacts its 10-minute gen1 parquet files, so wide
+    # reads (the 8-week week-pattern needs ~5,600 files at ~100/day) exceed the default
+    # limit of 432 and fail outright (#294). Our files are tiny (~7 KB), and in prod the
+    # #273 CPU/memory caps bound the blast radius, so a higher limit is safe here.
+    command: serve --host-id occupi-prod --http-bind 0.0.0.0:8181 --object-store file --data-dir /var/lib/influxdb3 --without-auth --query-file-limit 8192
     volumes:
       - influxdb3-data:/var/lib/influxdb3
     healthcheck:


### PR DESCRIPTION
Implements #294: the dashboard died because InfluxDB 3 Core refuses any query touching more than 432 parquet files, and Core never compacts its 10-minute gen1 files (up to 144/day per table) — so the 7-day latest-per-room scan, the single-room reads (unbounded!) and the 8-week week-pattern all crossed the limit as history accumulated. Only room 137 survived, via the WebSocket broadcast path.

## What changed
- **Last value cache for all latest reads.** `InfluxLastCacheInitializer` creates two caches (occupancy keyed by `roomId`, metrics by `sensorId`, count 1, TTL = `*.latest-lookback-days`) via `POST /api/v3/configure/last_cache` — at startup and retried on a schedule, because InfluxDB creates tables lazily and a fresh database 404s until the first sensor write. 409 = already exists = fine; failures are logged and tolerated.
- **Union of cache and bounded scan.** `findAllLatest` merges the cache (full TTL reach, zero parquet files) with a scan bounded to `*.latest-fallback-days` (default 2), newest row per room — the cache alone would silently lose rooms across an InfluxDB restart (Core keeps cache *definitions*, not contents), the scan alone cannot reach past ~3–4 days of files. The single-room/single-sensor reads (previously unbounded!) go cache-first with the same bounded scan as fallback. String columns from `last_cache()` arrive as Arrow `Text` (scans deliver `String`) — caught by the integration test, mapped via conversion instead of casts.
- **Server-side window caps** so no request can exceed the file limit: history/forecast ≤ 168 h, week-pattern ≤ 8 weeks (400 beyond), metrics history `since` clamped to `metrics.history-max-days`.
- **`--query-file-limit 10000`** in the base compose command for the remaining analytic reads — the widest capped read (8-week week-pattern) needs up to 56 × 144 ≈ 8,064 files at full write cadence. Safe here: ~7 KB files, #273 CPU/memory caps as backstop. Documented in `docker/README.md`.
- **InfluxDB image pinned to `3.9.3-core`** in compose and the integration tests: the floating `3-core` tag drifted to 3.10.x and CI silently tested a different version than prod runs.

## Tests
- Unit: union/merge semantics (cache-only rooms kept, newer row wins, unreadable cache tolerated, partial cache reads discarded), Arrow-`Text` mapping, `since`-clamp, window caps, initializer (401/409/500/connect-failure handling, TTL-in-seconds body, scheduled retry stops after success).
- Docker-gated integration test against a real `influxdb:3.9.3-core`: bounded scan before the caches exist, idempotent creation of both caches via the management API, warm-cache read of a room outside the scan window.

## Notes
- Behavior: with a warm cache this matches the old 7-day window. Rooms silent for longer than the TTL show as unavailable (same UX as #275); after an InfluxDB restart a room additionally needs to be inside the 2-day scan window or write once to reappear.
- Changing `*.latest-lookback-days` later does not update an existing cache — delete it (`DELETE /api/v3/configure/last_cache`) so the initializer recreates it with the new TTL.
- Rollout needs one manual step (auto-deploy leaves infra alone): `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d influxdb` to apply the new flag and the pinned tag; the backend deploys itself and creates the caches on startup.
- `--gen1-duration` is no alternative lever: 10 m is already Core's maximum and the value is frozen in the catalog after first start (verified against the 3.9.3 source).
- Out of scope (see issue): retention period to bound file growth for good; restarting the demo senders that went quiet on Jul 1 — until then the other rooms show stale values.

Closes #294