### PR TITLE
add: demo mode for the Pi sender — live bands, over-capacity and Pi health #297

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- The Pi sender has a demo mode (`SENSOR_MODE=demo`, compose profile `demo`) for the
+  live dashboard demo: one hardware-free container walks the configured rooms
+  (`DEMO_ROOMS`, `roomId:capacity` pairs) through the traffic-light bands in small
+  steps, occasionally overshoots capacity for a few minutes to trigger the
+  over-capacity pulse (#244), and emits synthetic Pi-health snapshots — one healthy,
+  one warning, one critical sensor — for the admin metrics section (#224). Everything
+  goes over the regular STOMP path at moderate rates (15 s occupancy / 45 s metrics
+  by default), so the frontend updates live without a reload and InfluxDB stays
+  inside the parquet-file-limit guidance from #294. Without a `.env` the demo
+  container defaults straight to the production endpoint (#297).
 - Occupancy history and weekly-pattern REST endpoints for the room detail view:
   `GET /api/occupancy/history` returns the recent time series (raw points within 24h,
   downsampled to 30-minute slots beyond that), and `GET /api/occupancy/weekpattern`

--- a/raspberry/.dockerignore
+++ b/raspberry/.dockerignore
@@ -17,3 +17,6 @@ Dockerfile
 compose.yml
 README.md
 run.sh
+tests/
+pytest.ini
+requirements-dev.txt

--- a/raspberry/.env.example
+++ b/raspberry/.env.example
@@ -6,6 +6,7 @@
 
 # ── Mode ──────────────────────────────────────────────────────────────────────
 # mock = generate realistic fake data (no hardware). real = read the mmWave sensor.
+# demo = scripted dashboard demo (the `demo` compose service sets this itself).
 SENSOR_MODE=mock
 
 # ── Backend (STOMP over WebSocket) ────────────────────────────────────────────
@@ -32,3 +33,12 @@ ROOM_ID_02=room-02
 MOCK_INTERVAL=2.0
 MOCK_ROOM_CAPACITY=30
 MOCK_MAX_STEP=2
+
+# ── Demo scenario (only used when SENSOR_MODE=demo) ───────────────────────────
+# Rooms as roomId:capacity pairs. Each capacity MUST match the room's capacity
+# in Postgres, otherwise the frontend's traffic light doesn't line up with the
+# scripted bands. The defaults below are also the code defaults.
+# DEMO_ROOMS=016E:50,136:20,011:250
+# DEMO_INTERVAL=15
+# DEMO_MAX_STEP=3
+# DEMO_METRICS_INTERVAL=45

--- a/raspberry/README.md
+++ b/raspberry/README.md
@@ -19,6 +19,7 @@ headcount, a confidence value, and a timestamp:
 
 - `mock` (default) generates a smooth, bounded occupancy curve. No hardware needed.
 - `real` reads frames from the mmWave sensor over two serial ports.
+- `demo` runs the scripted dashboard demo (see "Dashboard demo mode" below). No hardware needed.
 
 ## Requirements
 
@@ -50,7 +51,7 @@ Every setting comes from the environment. Edit `.env` (copied from `.env.example
 
 | Variable | Default | Meaning |
 |---|---|---|
-| `SENSOR_MODE` | `mock` | `mock` or `real` |
+| `SENSOR_MODE` | `mock` | `mock`, `real` or `demo` |
 | `BACKEND_HOST` | `localhost` | Backend host |
 | `BACKEND_PORT` | `8080` | Backend port |
 | `BACKEND_WS_PATH` | `/ws` | WebSocket path |
@@ -61,6 +62,10 @@ Every setting comes from the environment. Edit `.env` (copied from `.env.example
 | `MOCK_ROOM_CAPACITY` | `30` | Upper bound for the mock headcount |
 | `MOCK_MAX_STEP` | `2` | Largest change between two mock readings |
 | `MOCK_ROOM_IDS` | (empty) | Comma-separated room IDs to simulate from one container; empty = just `ROOM_ID_01` |
+| `DEMO_ROOMS` | `016E:50,136:20,011:250` | Demo rooms as `roomId:capacity` pairs; capacities must match Postgres |
+| `DEMO_INTERVAL` | `15` | Seconds between demo readings per room (keep within 10–30) |
+| `DEMO_MAX_STEP` | `3` | Largest headcount change between two demo readings |
+| `DEMO_METRICS_INTERVAL` | `45` | Seconds between demo health snapshots per sensor (keep within 30–60) |
 
 For the real sensor, set `SENSOR_MODE=real`; the serial devices are already mapped on
 `sensor-01` (next section).
@@ -93,6 +98,54 @@ network or VPN needed.
 
 The Pi talks to the backend, never to the database directly. InfluxDB and Postgres have no
 public ports on purpose; the backend is the only door, and `/ws` is already open for it.
+
+## Dashboard demo mode
+
+`SENSOR_MODE=demo` turns the sender into a scripted live demo for the dashboard
+(#297): a handful of prominent rooms whose occupancy visibly changes while someone
+watches the frontend. Everything goes over the normal STOMP path, so the readings
+run through the full Receiver → InfluxDB → WebSocket-broadcast chain and the
+dashboard tiles update live, without a reload — that is the whole point over
+seeding the database directly.
+
+Per room the scenario:
+
+- walks the count in small steps (±1–3 people) through the traffic-light bands
+  (~30 % → ~65 % → ~90 % of capacity), resting a few minutes at each level, so
+  green/yellow/red transitions happen while you watch;
+- occasionally overshoots the capacity by a few people for a couple of minutes
+  (e.g. 22/20), which triggers the dashboard's over-capacity pulse (#244);
+- reports as its own sensor (`sensor-<roomId>`) and sends a synthetic Pi-health
+  snapshot every `DEMO_METRICS_INTERVAL`. The profiles cycle healthy → warning →
+  critical across the configured rooms, so the admin panel's metrics section
+  (#224) shows all three states, with slowly drifting values and a stressed
+  sensor that accumulates drops.
+
+On the Pi (or any machine with Docker) one command is enough — without a `.env`
+the demo service defaults straight to the production backend over TLS:
+
+```bash
+cd raspberry
+docker compose --profile demo up -d --build demo
+docker compose logs -f demo      # expect: Tick N: 016E=34/50, 136=18/20, 011=75/250
+```
+
+An existing `.env` wins over those defaults, so a `BACKEND_HOST=localhost` from
+local testing would redirect the demo — check the file before starting.
+
+Two things must line up with the server, or the demo misleads:
+
+- **The rooms must exist in Postgres** (create them in the admin panel),
+  otherwise the frontend never shows them.
+- **Each capacity in `DEMO_ROOMS` must match the room's capacity in Postgres.**
+  The frontend computes the traffic light from `count / capacity(Postgres)`; a
+  mismatch shifts every band the scenario aims for.
+
+Leave rooms that should stay static or empty (and the real sensor's room) out of
+`DEMO_ROOMS`. The default rates — one reading per room every 15 s, one health
+snapshot per sensor every 45 s — are deliberately moderate: InfluxDB 3 Core
+rejects queries that scan too many parquet files (#294), so don't crank the
+intervals down for long-running demos.
 
 ## Real sensor mode
 
@@ -152,7 +205,8 @@ SENSOR_MODE=mock BACKEND_HOST=localhost ./run.sh
 
 ## Notes
 
-- The sender connects over plain WebSocket (`ws`). Reaching the production backend through
-  the Nginx TLS endpoint (`wss`) needs extra setup and is tracked separately.
-- Pi health metrics (CPU, memory, queue depth) are logged locally but not yet sent to the
-  backend (#110).
+- Pi health metrics (CPU, memory, queue depth, throughput) are logged locally and sent to
+  the backend at `/app/metrics` (#110). In demo mode the scripted per-sensor health is
+  sent instead; the local log line stays on.
+- Tests live in `tests/` and cover the demo scenario logic. Run them with
+  `pip install -r requirements-dev.txt && python -m pytest` inside `raspberry/`.

--- a/raspberry/compose.yml
+++ b/raspberry/compose.yml
@@ -7,6 +7,7 @@
 #
 #   Start (one sensor):  docker compose up -d --build
 #   Two sensors:         docker compose --profile second-sensor up -d --build
+#   Dashboard demo:      docker compose --profile demo up -d --build demo
 #   Logs:                docker compose logs -f
 #
 # Configure via .env (copy from .env.example). Flip mock/real with SENSOR_MODE,
@@ -44,6 +45,22 @@ services:
       - "/dev/serial/by-id/usb-Silicon_Labs_CP2105_Dual_USB_to_UART_Bridge_Controller_010BCEBF-if01-port0:/dev/ttyUSB1"
     group_add:
       - dialout
+
+  # Live dashboard demo (#297) — scripted occupancy bands, over-capacity pulses
+  # and Pi-health states for the demo rooms. No hardware, no device mappings;
+  # without a .env it defaults straight to the production backend, so on the Pi
+  # this one command is all it takes:
+  #   docker compose --profile demo up -d --build demo
+  # Rooms/capacities come from DEMO_ROOMS (must match the rooms in Postgres).
+  demo:
+    <<: *sensor-base
+    container_name: occupi-demo-sender
+    profiles: ["demo"]
+    environment:
+      SENSOR_MODE: demo
+      BACKEND_HOST: ${BACKEND_HOST:-occupi.mi.hdm-stuttgart.de}
+      BACKEND_PORT: ${BACKEND_PORT:-443}
+      BACKEND_TLS: ${BACKEND_TLS:-true}
 
   # Second sensor — opt-in. Start with:
   #   docker compose --profile second-sensor up -d --build

--- a/raspberry/config.py
+++ b/raspberry/config.py
@@ -7,6 +7,7 @@ SENSOR_ID = os.getenv("SENSOR_ID", "sensor-01")
 # --- Sensor Mode ---
 # "mock" generates realistic fake occupancy data (no hardware needed), used by the
 # container and for local testing. "real" reads from the mmWave sensor over serial.
+# "demo" runs the scripted dashboard demo (see demo_data.py).
 # Flip this in one place: the SENSOR_MODE entry of your .env file.
 SENSOR_MODE = os.getenv("SENSOR_MODE", "mock").strip().lower()
 
@@ -17,6 +18,15 @@ MOCK_MAX_STEP      = int(os.getenv("MOCK_MAX_STEP",        "2"))    # max headco
 # Comma-separated room IDs to simulate from this single container (e.g. "006,011,137").
 # Empty = just ROOM_ID. Lets one mock container fill many rooms at once (no hardware).
 MOCK_ROOM_IDS      = [r.strip() for r in os.getenv("MOCK_ROOM_IDS", "").split(",") if r.strip()]
+
+# --- Demo Scenario (only used when SENSOR_MODE=demo) ---
+# Rooms the demo drives, as comma-separated roomId:capacity pairs. The capacity
+# must match the room's capacity in Postgres — the frontend computes the traffic
+# light from count / capacity(Postgres), so a mismatch shifts every band.
+DEMO_ROOMS            = os.getenv("DEMO_ROOMS", "016E:50,136:20,011:250")
+DEMO_INTERVAL         = float(os.getenv("DEMO_INTERVAL", "15"))  # seconds between readings per room (keep within 10-30)
+DEMO_MAX_STEP         = int(os.getenv("DEMO_MAX_STEP", "3"))     # max headcount change per reading (small steps)
+DEMO_METRICS_INTERVAL = float(os.getenv("DEMO_METRICS_INTERVAL", "45"))  # seconds between health snapshots (keep within 30-60)
 
 # --- Serial ---
 SERIAL_CFG_PORT  = os.getenv("SERIAL_CFG_PORT",  "/dev/ttyUSB0")

--- a/raspberry/demo_data.py
+++ b/raspberry/demo_data.py
@@ -1,0 +1,266 @@
+import logging
+import random
+import re
+import threading
+import time
+from collections import defaultdict
+
+from config import (
+    DEMO_INTERVAL,
+    DEMO_MAX_STEP,
+    DEMO_METRICS_INTERVAL,
+)
+from mock_data import estimate_confidence
+
+log = logging.getLogger(__name__)
+
+# The dashboard colours a room green below 50 %, yellow below 80 % and red from
+# 80 % occupancy. These targets sit safely inside each band, so every colour
+# shows up and idle jitter around a target never flickers across a boundary.
+BAND_TARGETS = (0.30, 0.65, 0.90)
+
+# How long a room rests at a band target before heading for the next one, and
+# how long an over-capacity excursion lasts (seconds).
+HOLD_RANGE_S = (120, 300)
+OVERCAP_HOLD_RANGE_S = (120, 240)
+OVERCAP_CHANCE = 0.35   # chance to overshoot capacity after reaching the top band
+OVERCAP_EXTRA = (1, 3)  # people above capacity during an excursion
+
+# Backend room IDs are restricted to this charset; anything else would be
+# stored but never matched to a room, so reject it before sending.
+_ROOM_ID_PATTERN = re.compile(r"^[a-zA-Z0-9-]+$")
+
+# One profile per configured room, assigned in order (cycling) — so the default
+# three demo rooms cover all three states of the admin panel's metrics section,
+# which colours a value yellow above 70 % and red above 90 %.
+HEALTH_PROFILES = (
+    {"name": "healthy",  "cpu": (35, 65), "memory": (40, 65), "queue": (0, 4),   "process_ms": (3, 12),   "drop_chance": 0.00},
+    {"name": "warning",  "cpu": (72, 88), "memory": (55, 68), "queue": (5, 20),  "process_ms": (15, 45),  "drop_chance": 0.10},
+    {"name": "critical", "cpu": (91, 98), "memory": (80, 95), "queue": (20, 80), "process_ms": (60, 180), "drop_chance": 0.50},
+)
+
+
+def parse_rooms(spec: str) -> list[dict]:
+    """
+    Parse the DEMO_ROOMS spec ("roomId:capacity,...") into room dicts.
+
+    Fails fast on malformed entries so a typo in .env surfaces at startup
+    instead of as a silently missing room on the dashboard. Each room gets a
+    derived sensor identity so occupancy and health snapshots line up.
+    """
+    rooms = []
+    for entry in (e.strip() for e in spec.split(",") if e.strip()):
+        room_id, sep, capacity = entry.partition(":")
+        room_id, capacity = room_id.strip(), capacity.strip()
+        if not _ROOM_ID_PATTERN.match(room_id):
+            raise ValueError(f"DEMO_ROOMS: room id {room_id!r} must match [a-zA-Z0-9-]")
+        if not sep or not capacity.isdigit() or int(capacity) < 1:
+            raise ValueError(f"DEMO_ROOMS: entry {entry!r} needs a positive capacity (roomId:capacity)")
+        rooms.append({"roomId": room_id, "capacity": int(capacity), "sensorId": f"sensor-{room_id}"})
+    if not rooms:
+        raise ValueError("DEMO_ROOMS is empty — the demo needs at least one roomId:capacity pair")
+    return rooms
+
+
+def _step_toward(current: int, target: int, max_step: int) -> int:
+    """One walk step toward the target: always moves, never overshoots."""
+    gap = target - current
+    if gap == 0:
+        return current
+    step = min(random.randint(1, max_step), abs(gap))
+    return current + step if gap > 0 else current - step
+
+
+class RoomScenario:
+    """
+    Scripted occupancy walk for one room.
+
+    The count moves in small steps toward the current band target, rests there
+    for a few minutes, then heads for the neighbouring band (low → mid → high
+    → mid → low → …). After the top band it sometimes overshoots capacity by a
+    few people for a couple of minutes — enough to trigger the dashboard's
+    over-capacity pulse without looking broken.
+    """
+
+    def __init__(self, room_id: str, capacity: int, band_index: int):
+        self.room_id = room_id
+        self.capacity = capacity
+        self._band = band_index % len(BAND_TARGETS)
+        self._direction = 1 if self._band < len(BAND_TARGETS) - 1 else -1
+        self._over_capacity = False
+        self._target = self._band_target()
+        # Start resting on the band target, so with three rooms the dashboard
+        # shows green, yellow and red from the very first frame.
+        self.count = self._target
+        self._resting_until = time.monotonic() + random.uniform(*HOLD_RANGE_S)
+
+    def _band_target(self) -> int:
+        jitter = random.uniform(-0.03, 0.03)
+        return max(0, round(self.capacity * (BAND_TARGETS[self._band] + jitter)))
+
+    def _advance(self) -> None:
+        """Pick the next target once a rest is over."""
+        if self._over_capacity:
+            # Excursion over — come back down through the bands.
+            self._over_capacity = False
+            self._direction = -1
+            self._target = self._band_target()
+            return
+        at_top = self._band == len(BAND_TARGETS) - 1
+        if at_top and random.random() < OVERCAP_CHANCE:
+            self._over_capacity = True
+            self._target = self.capacity + random.randint(*OVERCAP_EXTRA)
+            return
+        if at_top:
+            self._direction = -1
+        elif self._band == 0:
+            self._direction = 1
+        self._band += self._direction
+        self._target = self._band_target()
+
+    def step(self) -> int:
+        """Advance the scenario by one reading and return the new count."""
+        now = time.monotonic()
+        if self._resting_until is not None:
+            if now < self._resting_until:
+                # Anchored idle jitter: ±1 around the target so the tile keeps
+                # breathing, held at the target during an excursion so the
+                # over-capacity pulse doesn't flicker.
+                if not self._over_capacity:
+                    self.count = max(0, min(self.capacity, self._target + random.choice((-1, 0, 0, 1))))
+                return self.count
+            self._resting_until = None
+            self._advance()
+        self.count = _step_toward(self.count, self._target, DEMO_MAX_STEP)
+        if self.count == self._target:
+            hold = OVERCAP_HOLD_RANGE_S if self._over_capacity else HOLD_RANGE_S
+            self._resting_until = now + random.uniform(*hold)
+        return self.count
+
+
+class SentCounters:
+    """Per-sensor count of enqueued readings, shared with the metrics thread."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._sent: defaultdict[str, int] = defaultdict(int)
+
+    def record(self, sensor_id: str) -> None:
+        with self._lock:
+            self._sent[sensor_id] += 1
+
+    def get(self, sensor_id: str) -> int:
+        with self._lock:
+            return self._sent[sensor_id]
+
+
+class SensorHealth:
+    """
+    Slowly drifting synthetic health values for one demo sensor.
+
+    CPU, memory and queue size take a small random step inside the profile's
+    band on every snapshot, so the metrics section visibly lives while each
+    sensor keeps its colour. `sent` mirrors the readings actually enqueued for
+    the room; `dropped` accumulates for the stressed profiles.
+    """
+
+    def __init__(self, sensor_id: str, profile: dict, counters: SentCounters):
+        self.sensor_id = sensor_id
+        self.profile = profile
+        self._counters = counters
+        self._cpu = random.uniform(*profile["cpu"])
+        self._memory = random.uniform(*profile["memory"])
+        self._queue = float(random.randint(*profile["queue"]))
+        self._dropped = 0
+
+    @staticmethod
+    def _drift(value: float, bounds: tuple, step: float = 2.5) -> float:
+        return min(bounds[1], max(bounds[0], value + random.uniform(-step, step)))
+
+    def snapshot(self) -> dict:
+        """One metrics payload in the backend's field shape (see #110)."""
+        self._cpu = self._drift(self._cpu, self.profile["cpu"])
+        self._memory = self._drift(self._memory, self.profile["memory"])
+        self._queue = self._drift(self._queue, self.profile["queue"])
+        if random.random() < self.profile["drop_chance"]:
+            self._dropped += random.randint(1, 3)
+        return {
+            "cpuPercentage": round(self._cpu, 1),
+            "memoryPercentage": round(self._memory, 1),
+            "queueSize": round(self._queue),
+            "sent": self._counters.get(self.sensor_id),
+            "dropped": self._dropped,
+            "avgProcessTime": round(random.uniform(*self.profile["process_ms"]), 2),
+        }
+
+
+def _demo_metrics_loop(sensors: list, send_fn) -> None:
+    while True:
+        time.sleep(DEMO_METRICS_INTERVAL)
+        for sensor in sensors:
+            snapshot = sensor.snapshot()
+            send_fn(snapshot, sensor.sensor_id)
+            log.info(
+                "[demo metrics] %s (%s): cpu=%s%% mem=%s%% queue=%d sent=%d dropped=%d",
+                sensor.sensor_id, sensor.profile["name"],
+                snapshot["cpuPercentage"], snapshot["memoryPercentage"],
+                snapshot["queueSize"], snapshot["sent"], snapshot["dropped"],
+            )
+
+
+def start_demo_metrics(rooms: list[dict], counters: SentCounters, send_fn) -> None:
+    """
+    Start the synthetic Pi-health loop in a daemon thread: one snapshot per
+    sensor every DEMO_METRICS_INTERVAL, profiles cycling healthy → warning →
+    critical across the configured rooms.
+    """
+    sensors = [
+        SensorHealth(room["sensorId"], HEALTH_PROFILES[i % len(HEALTH_PROFILES)], counters)
+        for i, room in enumerate(rooms)
+    ]
+    t = threading.Thread(target=_demo_metrics_loop, args=(sensors, send_fn), daemon=True)
+    t.start()
+    log.info(
+        "Demo metrics started for %d sensor(s), one snapshot each every %.0fs.",
+        len(sensors), DEMO_METRICS_INTERVAL,
+    )
+
+
+def demo_sensor_loop(enqueue_frame, rooms: list[dict], counters: SentCounters) -> None:
+    """
+    Continuously produce scripted occupancy readings for the demo rooms.
+
+    Each room follows its own RoomScenario; sends are spread evenly across
+    DEMO_INTERVAL like the mock generator does, so the backend never gets a
+    burst and the write rate stays inside the InfluxDB file-limit guidance
+    (#294): with the defaults that is one point per room every 15 s.
+    """
+    scenarios = [
+        RoomScenario(room["roomId"], room["capacity"], band_index=i)
+        for i, room in enumerate(rooms)
+    ]
+    per_room_delay = DEMO_INTERVAL / len(scenarios)
+    frame_num = 0
+    log.info(
+        "Demo scenario started for %d room(s), one reading per room every %.0fs.",
+        len(scenarios), DEMO_INTERVAL,
+    )
+
+    while True:
+        frame_num += 1
+        for scenario, room in zip(scenarios, rooms):
+            count = scenario.step()
+            enqueue_frame({
+                "frameNum": frame_num,
+                "roomId": room["roomId"],
+                "sensorId": room["sensorId"],
+                "numDetectedTracks": count,
+                "confidence": estimate_confidence(count, room["capacity"]),
+            })
+            counters.record(room["sensorId"])
+            time.sleep(per_room_delay)
+
+        log.info(
+            "Tick %d: %s", frame_num,
+            ", ".join(f"{s.room_id}={s.count}/{s.capacity}" for s in scenarios),
+        )

--- a/raspberry/main.py
+++ b/raspberry/main.py
@@ -16,13 +16,14 @@ from config import (
     QUEUE_MAX_SIZE,
     WS_RECONNECT_DELAY, WS_MAX_RETRIES, BACKEND_WS_PATH,
     BACKEND_TLS, BACKEND_TLS_CA,
-    SENSOR_MODE, SENSOR_ID, ROOM_ID, MOCK_ROOM_IDS,
+    SENSOR_MODE, SENSOR_ID, ROOM_ID, MOCK_ROOM_IDS, DEMO_ROOMS,
     USE_VISUALIZER, VISUALIZER_MAX_FPS,
 )
 from sensor.receiver import open_ports, send_config, read_frame, CONFIG_FILE
 from sensor.metrics import ThroughputMetrics, start_metrics_monitor
 from sender.processor import map_to_occupancy
 from mock_data import mock_sensor_loop
+from demo_data import SentCounters, demo_sensor_loop, parse_rooms, start_demo_metrics
 from stomp import exception as stomp_exception
 
 # Logging configuration
@@ -33,9 +34,16 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-# Size the queue for the workload: in multi-room mock the generator enqueues one
-# frame per room each tick, so the queue must hold more than the room count.
-_queue: queue.Queue = queue.Queue(maxsize=max(QUEUE_MAX_SIZE, len(MOCK_ROOM_IDS) * 3))
+# Parsed once at import: a malformed DEMO_ROOMS fails fast at startup instead
+# of mid-demo, and the queue below can be sized for the room count.
+DEMO_ROOM_SPECS = parse_rooms(DEMO_ROOMS) if SENSOR_MODE == "demo" else []
+
+# Size the queue for the workload: in multi-room mock and demo the generator
+# enqueues one frame per room each tick, so the queue must hold more than the
+# room count.
+_queue: queue.Queue = queue.Queue(
+    maxsize=max(QUEUE_MAX_SIZE, len(MOCK_ROOM_IDS) * 3, len(DEMO_ROOM_SPECS) * 3)
+)
 _metrics = ThroughputMetrics()
 
 # Shared STOMP connection, owned by the sender loop. The metrics thread reads it
@@ -131,16 +139,17 @@ def start_sender() -> None:
     log.info("Sender thread started.")
 
 
-def _send_metrics(snapshot: dict) -> None:
+def _send_metrics(snapshot: dict, sensor_id: str = SENSOR_ID) -> None:
     """Forwards a metrics snapshot to the backend over the shared STOMP link (#110).
     Tags it with the sensorId and a UTC timestamp, sent explicitly so the backend
-    does not have to assign one (see #186). Skips the send when the link is down."""
+    does not have to assign one (see #186). Skips the send when the link is down.
+    Demo mode passes per-room sensor ids; everything else reports as SENSOR_ID."""
     conn = _conn
     if conn is None or not conn.is_connected():
         log.debug("STOMP not connected, skipping metrics snapshot.")
         return
     payload = {
-        "sensorId": SENSOR_ID,
+        "sensorId": sensor_id,
         **snapshot,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
@@ -162,9 +171,23 @@ if __name__ == '__main__':
 
     try:
         start_sender()
-        start_metrics_monitor(_queue, _metrics, send_fn=_send_metrics)
+        # In demo mode the backend gets the scripted per-sensor health instead —
+        # the real psutil snapshot would sit next to the demo sensors as one
+        # always-green entry. The local metrics log line stays on in every mode.
+        start_metrics_monitor(
+            _queue, _metrics,
+            send_fn=None if SENSOR_MODE == "demo" else _send_metrics,
+        )
 
-        if SENSOR_MODE == "mock":
+        if SENSOR_MODE == "demo":
+            log.info(
+                "Starting in DEMO mode, scripted dashboard scenario for %d room(s).",
+                len(DEMO_ROOM_SPECS),
+            )
+            counters = SentCounters()
+            start_demo_metrics(DEMO_ROOM_SPECS, counters, send_fn=_send_metrics)
+            demo_sensor_loop(enqueue_frame, DEMO_ROOM_SPECS, counters)  # runs until stopped
+        elif SENSOR_MODE == "mock":
             rooms = MOCK_ROOM_IDS or [ROOM_ID]
             log.info("Starting in MOCK mode, fake occupancy for %d room(s).", len(rooms))
             mock_sensor_loop(enqueue_frame, rooms)  # runs until the process is stopped

--- a/raspberry/mock_data.py
+++ b/raspberry/mock_data.py
@@ -27,7 +27,7 @@ def _next_count(current: int, target: int, capacity: int, max_step: int) -> int:
     return max(0, min(capacity, current + step))
 
 
-def _estimate_confidence(count: int, capacity: int) -> float:
+def estimate_confidence(count: int, capacity: int) -> float:
     """
     Fake a plausible confidence: high for a near-empty room, a little lower as it
     fills up (more people are harder to separate), with light random jitter.
@@ -79,7 +79,7 @@ def mock_sensor_loop(enqueue_frame, room_ids) -> None:
                 "frameNum": frame_num,
                 "roomId": room_id,
                 "numDetectedTracks": s["count"],
-                "confidence": _estimate_confidence(s["count"], capacity),
+                "confidence": estimate_confidence(s["count"], capacity),
             })
             time.sleep(per_room_delay)
 

--- a/raspberry/pytest.ini
+++ b/raspberry/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/raspberry/requirements-dev.txt
+++ b/raspberry/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development-only dependencies (tests). Runtime deps stay in requirements.txt.
+-r requirements.txt
+pytest>=8

--- a/raspberry/sender/processor.py
+++ b/raspberry/sender/processor.py
@@ -11,8 +11,9 @@ def map_to_occupancy(frame: dict) -> dict:
         OccupancyData als Dict (JSON-serialisierbar)
     """
     return {
-        "roomId":     frame.get("roomId", ROOM_ID),  # Mock setzt pro Raum eine ID; Real-Pfad nutzt ROOM_ID
-        "sensorId":   SENSOR_ID,
+        "roomId":     frame.get("roomId", ROOM_ID),  # Mock/Demo setzen pro Raum eine ID; Real-Pfad nutzt ROOM_ID
+        "sensorId":   frame.get("sensorId", SENSOR_ID),  # Demo setzt pro Raum einen Sensor; sonst SENSOR_ID
+
         "count":      frame.get("numDetectedTracks", 0),
         "confidence": frame.get("confidence", 1.0),  # Mock liefert echte Werte; Real-Pfad bleibt 1.0 bis echte Logik existiert
         "timestamp":  datetime.now(timezone.utc).isoformat(),

--- a/raspberry/tests/test_demo_data.py
+++ b/raspberry/tests/test_demo_data.py
@@ -1,0 +1,187 @@
+import random
+
+import pytest
+
+import demo_data
+from demo_data import (
+    BAND_TARGETS,
+    HEALTH_PROFILES,
+    OVERCAP_EXTRA,
+    RoomScenario,
+    SensorHealth,
+    SentCounters,
+    _step_toward,
+    parse_rooms,
+)
+
+
+class FakeClock:
+    """Controllable stand-in for time.monotonic, advanced by the tests."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def tick(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def clock(monkeypatch) -> FakeClock:
+    fake = FakeClock()
+    monkeypatch.setattr(demo_data.time, "monotonic", fake)
+    return fake
+
+
+# --- parse_rooms ---------------------------------------------------------------
+
+def test_parse_rooms_reads_ids_capacities_and_derives_sensor_ids():
+    rooms = parse_rooms(" 016E:50 , 136:20 ")
+    assert rooms == [
+        {"roomId": "016E", "capacity": 50, "sensorId": "sensor-016E"},
+        {"roomId": "136", "capacity": 20, "sensorId": "sensor-136"},
+    ]
+
+
+@pytest.mark.parametrize("spec", ["bad room:5", "raum_1:5", "läb:5", ":5"])
+def test_parse_rooms_rejects_ids_outside_the_backend_charset(spec):
+    with pytest.raises(ValueError, match="a-zA-Z0-9"):
+        parse_rooms(spec)
+
+
+@pytest.mark.parametrize("spec", ["016E", "016E:", "016E:0", "016E:-5", "016E:abc"])
+def test_parse_rooms_rejects_missing_or_invalid_capacity(spec):
+    with pytest.raises(ValueError, match="positive capacity"):
+        parse_rooms(spec)
+
+
+def test_parse_rooms_rejects_an_empty_spec():
+    with pytest.raises(ValueError, match="at least one"):
+        parse_rooms(" , ")
+
+
+# --- _step_toward ---------------------------------------------------------------
+
+def test_step_toward_progresses_and_never_overshoots():
+    random.seed(1)
+    for target in (20, 0):  # up and down
+        current = 10
+        seen = [current]
+        for _ in range(100):
+            nxt = _step_toward(current, target, max_step=3)
+            if current == target:
+                assert nxt == target  # stays put once arrived
+                break
+            assert abs(nxt - current) <= 3
+            assert abs(target - nxt) < abs(target - current)  # always moves closer
+            current = nxt
+            seen.append(current)
+        assert current == target
+
+
+# --- RoomScenario ----------------------------------------------------------------
+
+def test_scenario_starts_on_its_band_target(clock):
+    random.seed(2)
+    capacity = 100
+    for band, fraction in enumerate(BAND_TARGETS):
+        scenario = RoomScenario("016E", capacity, band_index=band)
+        # band targets carry ±3 % jitter
+        assert abs(scenario.count - capacity * fraction) <= capacity * 0.03 + 1
+
+
+def test_scenario_stays_in_bounds_and_visits_every_band(clock):
+    random.seed(3)
+    capacity = 20
+    scenario = RoomScenario("136", capacity, band_index=0)
+    counts = []
+    previous = scenario.count
+    for _ in range(5000):
+        clock.tick(15)  # one reading every DEMO_INTERVAL seconds
+        count = scenario.step()
+        assert 0 <= count <= capacity + OVERCAP_EXTRA[1]
+        assert abs(count - previous) <= 3  # small steps only (±1–3 people)
+        counts.append(count)
+        previous = count
+    # All three traffic-light bands show up over a long enough run.
+    assert min(counts) < capacity * 0.5
+    assert any(capacity * 0.5 <= c < capacity * 0.8 for c in counts)
+    assert max(counts) >= capacity * 0.8
+
+
+def test_scenario_overshoots_capacity_and_recovers(clock, monkeypatch):
+    random.seed(4)
+    # Force the over-capacity branch whenever the top band rest ends.
+    monkeypatch.setattr(demo_data.random, "random", lambda: 0.0)
+    capacity = 20
+    scenario = RoomScenario("136", capacity, band_index=len(BAND_TARGETS) - 1)
+    over_seen = False
+    back_after_over = False
+    for _ in range(3000):
+        clock.tick(15)
+        count = scenario.step()
+        if count > capacity:
+            over_seen = True
+        elif over_seen:
+            back_after_over = True
+            break
+    assert over_seen, "scenario never exceeded capacity"
+    assert back_after_over, "scenario never came back below capacity"
+
+
+# --- SentCounters ------------------------------------------------------------------
+
+def test_sent_counters_accumulate_per_sensor():
+    counters = SentCounters()
+    counters.record("sensor-016E")
+    counters.record("sensor-016E")
+    counters.record("sensor-136")
+    assert counters.get("sensor-016E") == 2
+    assert counters.get("sensor-136") == 1
+    assert counters.get("sensor-unknown") == 0
+
+
+# --- SensorHealth ------------------------------------------------------------------
+
+def test_health_profiles_match_the_frontend_bands():
+    """The admin panel colours values yellow above 70 % and red above 90 % —
+    keep each profile inside its intended colour."""
+    healthy, warning, critical = HEALTH_PROFILES
+    assert healthy["cpu"][1] < 70 and healthy["memory"][1] < 70
+    assert 70 < warning["cpu"][0] and warning["cpu"][1] < 90
+    assert critical["cpu"][0] > 90
+
+
+def test_snapshots_drift_inside_the_profile_bands():
+    random.seed(5)
+    counters = SentCounters()
+    for profile in HEALTH_PROFILES:
+        sensor = SensorHealth("sensor-x", profile, counters)
+        for _ in range(200):
+            snap = sensor.snapshot()
+            assert profile["cpu"][0] <= snap["cpuPercentage"] <= profile["cpu"][1]
+            assert profile["memory"][0] <= snap["memoryPercentage"] <= profile["memory"][1]
+            assert profile["queue"][0] <= snap["queueSize"] <= profile["queue"][1]
+            assert profile["process_ms"][0] <= snap["avgProcessTime"] <= profile["process_ms"][1]
+
+
+def test_healthy_sensor_never_drops_and_critical_does():
+    random.seed(6)
+    counters = SentCounters()
+    healthy = SensorHealth("sensor-h", HEALTH_PROFILES[0], counters)
+    critical = SensorHealth("sensor-c", HEALTH_PROFILES[2], counters)
+    healthy_drops = [healthy.snapshot()["dropped"] for _ in range(100)]
+    critical_drops = [critical.snapshot()["dropped"] for _ in range(100)]
+    assert healthy_drops[-1] == 0
+    assert critical_drops[-1] > 0
+    assert critical_drops == sorted(critical_drops)  # dropped only accumulates
+
+
+def test_snapshot_reports_the_readings_actually_enqueued():
+    counters = SentCounters()
+    sensor = SensorHealth("sensor-016E", HEALTH_PROFILES[0], counters)
+    counters.record("sensor-016E")
+    counters.record("sensor-016E")
+    assert sensor.snapshot()["sent"] == 2


### PR DESCRIPTION
## Summary
The mock data requirement V2 asks for constantly changing occupancy in a few
prominent rooms, visible live in the running frontend. This adds a third sender
mode, `SENSOR_MODE=demo`: one hardware-free container that walks 2–3 rooms
through the traffic-light bands, occasionally overshoots capacity to trigger
the dashboard pulse (#244), and emits synthetic Pi-health snapshots so the
admin metrics section (#224) shows a healthy, a warning and a critical sensor.
Everything goes over the normal STOMP path (`/app/data`, `/app/metrics`), so
the readings run through Receiver → InfluxDB → `/topic/occupancy` broadcast and
the frontend updates live without a reload. On the Pi a single
`docker compose --profile demo up -d --build demo` is enough — without a `.env`
the service defaults straight to the production endpoint over TLS.

## Changes
- `demo_data.py` — scripted scenario: per-room band walk (~30 % → ~65 % → ~90 %
  of capacity, ±1–3 people per reading, a few minutes rest per band), occasional
  over-capacity excursions (capacity + 1–3 for 2–4 min), per-room sensor
  identity (`sensor-<roomId>`), and slowly drifting health profiles (healthy /
  warning / critical around the frontend's 70/90 thresholds, `dropped`
  accumulating on the stressed sensors)
- `config.py` — `DEMO_ROOMS` (`roomId:capacity`, validated against
  `[a-zA-Z0-9-]`, fail-fast on typos), `DEMO_INTERVAL` (15 s), `DEMO_MAX_STEP`
  (3), `DEMO_METRICS_INTERVAL` (45 s); defaults sit inside the 10–30 s / 30–60 s
  guidance so InfluxDB stays clear of the parquet-file limit (#294)
- `main.py` / `sender/processor.py` — demo branch wired in; `_send_metrics`
  takes a per-sensor id; in demo mode the real psutil snapshot is logged but not
  sent (it would sit next to the demo sensors as one always-green entry)
- `compose.yml` — `demo` profile service without device mappings, defaulting to
  the production backend
- `mock_data.py` — `estimate_confidence` made public and reused by the demo
- Tests (`tests/test_demo_data.py`, pytest via `requirements-dev.txt`): room-spec
  parsing, walk bounds/step size, band coverage, over-capacity recovery, health
  profile bands, counters
- Docs: README demo section (capacity must match Postgres, which rooms to leave
  out), `.env.example`, changelog; removed two stale README notes (wss and #110
  are long done)

## Verification
- `python -m pytest` → 20 passed
- End-to-end against the local docker stack (dev profile): `/api/occupancy/all`
  returned all three rooms sitting in their bands (016E 16/50 green, 136 12/20
  yellow, 011 218/250 red), `/api/metrics` showed the three sensors at 59/78/96 %
  CPU with `dropped > 0` only on the stressed ones, and a STOMP subscription on
  `/topic/occupancy` received 10 broadcasts in 10 s
- `docker compose --profile demo build demo` builds; the image was also run
  against the local backend and connected/streamed (`Starting in DEMO mode …`,
  `STOMP connection established`)

Closes #297
