### PR TITLE
add: mobile sidebar drawer with hamburger navigation #296

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,14 +1,19 @@
-import { User } from 'lucide-react';
+import { Menu, User } from 'lucide-react';
 import { useAuthStore} from "../hooks/useAuthStore";
 
-export const Navbar = () => {
+export const Navbar = ({ onMenuClick }: { onMenuClick: () => void }) => {
     const { user } = useAuthStore();
 
     return (
-        <header className="h-20 bg-white border-b border-gray-200 flex items-center justify-end px-6 shadow-sm z-10 shrink-0">
+        <header className="h-20 bg-white border-b border-gray-200 flex items-center px-4 md:px-6 shadow-sm z-10 shrink-0">
+            {/* Hamburger — only Mobile */}
+            <button onClick={onMenuClick} aria-label="Menü öffnen"
+                    className="md:hidden p-2 rounded-lg text-gray-500 hover:bg-gray-100 transition-colors">
+                <Menu className="h-6 w-6" />
+            </button>
 
             {/* User Status */}
-            <div className="flex items-center space-x-3 bg-gray-50 py-2 px-4 rounded-lg border border-gray-100">
+            <div className="ml-auto flex items-center space-x-3 bg-gray-50 py-2 px-4 rounded-lg border border-gray-100">
                 <div className="bg-white p-1.5 rounded-md border border-gray-200 shadow-sm">
                     <User className="h-5 w-5 text-gray-600" />
                 </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { LayoutDashboard, ChartColumn, DoorOpen, PanelLeftOpen, PanelLeftClose, LogOut, Shield } from 'lucide-react';
 import { useAuthStore} from "../hooks/useAuthStore";
 
-export const Sidebar = () => {
+export const Sidebar = ({ mobileOpen, onMobileClose }: { mobileOpen: boolean; onMobileClose: () => void }) => {
     const location = useLocation(); // reads the current location (link gets correspondingly highlighted in color)
 
     const navigate = useNavigate();
@@ -35,102 +35,113 @@ export const Sidebar = () => {
     const [showLogoutDialog, setShowLogoutDialog] = useState(false);
 
     return (
-    <aside className={`relative z-20 bg-[#111827] text-gray-300 flex flex-col justify-between border-r border-[#1F2937] transition-all duration-300 ease-in-out ${isCollapsed ? 'w-20' : 'w-64'}`}>
-        {/* background dark blue / test - with dynamic width*/}
+        <>
+            {mobileOpen && (
+                <div className="fixed inset-0 bg-black/50 z-30 md:hidden" onClick={onMobileClose} />
+            )}
+
+        <aside className={`fixed inset-y-0 left-0 z-40 md:relative md:z-20 w-64 transform transition-all duration-300 ease-in-out ${
+            mobileOpen ? 'translate-x-0' : '-translate-x-full'
+        } md:translate-x-0 ${
+            isCollapsed ? 'md:w-20' : 'md:w-64'
+        } bg-[#111827] text-gray-300 flex flex-col justify-between border-r border-[#1F2937]`}>
+            {/* background dark blue / test - with dynamic width*/}
 
 
-        {/* button to collapse sidebar */}
-        <button
-            onClick={() => setIsCollapsed(!isCollapsed)}
-            aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-            className="absolute -right-3 top-7 bg-[#1F2937] border border-[#374151] text-gray-300 hover:text-white p-1 rounded-md z-10 transition-colors shadow-md"
-        >
-            {isCollapsed ? <PanelLeftOpen size={18} /> : <PanelLeftClose size={18} />}
-        </button>
-
-        {/* logo at the top, TO DO: change logo*/}
-        <div className="h-20 flex items-center justify-center mb-6 border-b border-[#1F2937] overflow-hidden px-2">
-            <Link to="/dashboard" className="text-xl font-bold text-white hover:opacity-80 transition-opacity cursor-pointer truncate">
-                {/* collapsed: OP - otherwise: OccuPi */}
-                {isCollapsed ? 'OP' : 'OccuPi'}
-            </Link>
-        </div>
-
-        {/* lists of navigation items */}
-        <nav className="space-y-2 px-4 flex-1 items-center md:items-stretch">
-            {navItems.map((item) => {
-                const Icon = item.icon;
-
-                // here we check if link = right URL
-                const active = location.pathname === item.path;
-
-                return (
-                    <Link
-                        key={item.path}
-                        to={item.path}
-                        title={isCollapsed ? item.label : undefined} // shows name while hovering
-                        className={`flex items-center p-3 rounded-xl font-medium transition-all duration-200 ${
-                            active
-                                ? 'bg-gray-100 text-[#111827] shadow-sm'
-                                : 'hover:bg-[#1F2937] text-gray-400 hover:text-white'
-                        } ${isCollapsed
-                            ? 'w-12 h-12 mx-auto justify-center'
-                            : 'h-12 py-4 w-full'}`}
-                    >
-                        <Icon size={22} className="shrink-0" />
-
-                        {/* text disappears if sidebar is collapsed */}
-                        {!isCollapsed && <span className="ml-4 truncate">{item.label}</span>}
-                    </Link>
-                );
-            })}
-        </nav>
-
-
-        {/* lower section */}
-        <div className="p-4 border-t border-[#1F2937]">
+            {/* button to collapse sidebar */}
             <button
-                onClick={() => setShowLogoutDialog(true)}
-                title={isCollapsed ? 'Logout' : undefined}
-                className={`flex items-center rounded-xl font-medium transition-all duration-200 hover:bg-red-500/20 text-gray-400 hover:text-red-300 ${
-                    isCollapsed
-                        ? 'w-12 h-12 mx-auto justify-center' // like the buttons above
-                        : 'h-12 px-4 w-full'
-                }`}
+                onClick={() => setIsCollapsed(!isCollapsed)}
+                aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+                className="hidden md:block absolute -right-3 top-7 bg-[#1F2937] border border-[#374151] text-gray-300 hover:text-white p-1 rounded-md z-10 transition-colors shadow-md"
             >
-                <LogOut size={22} className="shrink-0" />
-                {!isCollapsed && <span className="ml-4 truncate">Log out</span>}
+                {isCollapsed ? <PanelLeftOpen size={18} /> : <PanelLeftClose size={18} />}
             </button>
-            {showLogoutDialog && (
-                <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center">
-                    {/* White Box */}
-                    <div className="bg-white rounded-xl shadow-2xl p-6 max-w-sm w-full mx-4">
-                        <h2 className="text-xl font-bold text-gray-900 mb-2">Log out</h2>
-                        <p className="text-gray-500 mb-6">Do you really want to log out of the system?</p>
 
-                        <div className="flex justify-end space-x-3">
-                            <button
-                                onClick={() => setShowLogoutDialog(false)}
-                                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                onClick={() => {
-                                    useAuthStore.getState().logout();
-                                    setShowLogoutDialog(false);
-                                    navigate('/login')
-                                }}
-                                className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
-                            >
-                                Log out
-                            </button>
+            {/* logo at the top, TO DO: change logo*/}
+            <div className="h-20 flex items-center justify-center mb-6 border-b border-[#1F2937] overflow-hidden px-2">
+                <Link to="/dashboard" className="text-xl font-bold text-white hover:opacity-80 transition-opacity cursor-pointer truncate">
+                    {/* collapsed: OP - otherwise: OccuPi */}
+                    {isCollapsed ? 'OP' : 'OccuPi'}
+                </Link>
+            </div>
+
+            {/* lists of navigation items */}
+            <nav className="space-y-2 px-4 flex-1 items-center md:items-stretch">
+                {navItems.map((item) => {
+                    const Icon = item.icon;
+
+                    // here we check if link = right URL
+                    const active = location.pathname === item.path;
+
+                    return (
+                        <Link
+                            key={item.path}
+                            to={item.path}
+                            onClick={onMobileClose}
+                            title={isCollapsed ? item.label : undefined} // shows name while hovering
+                            className={`flex items-center p-3 rounded-xl font-medium transition-all duration-200 ${
+                                active
+                                    ? 'bg-gray-100 text-[#111827] shadow-sm'
+                                    : 'hover:bg-[#1F2937] text-gray-400 hover:text-white'
+                            } ${isCollapsed
+                                ? 'w-12 h-12 mx-auto justify-center'
+                                : 'h-12 py-4 w-full'}`}
+                        >
+                            <Icon size={22} className="shrink-0" />
+
+                            {/* text disappears if sidebar is collapsed */}
+                            {!isCollapsed && <span className="ml-4 truncate">{item.label}</span>}
+                        </Link>
+                    );
+                })}
+            </nav>
+
+
+            {/* lower section */}
+            <div className="p-4 border-t border-[#1F2937]">
+                <button
+                    onClick={() => setShowLogoutDialog(true)}
+                    title={isCollapsed ? 'Logout' : undefined}
+                    className={`flex items-center rounded-xl font-medium transition-all duration-200 hover:bg-red-500/20 text-gray-400 hover:text-red-300 ${
+                        isCollapsed
+                            ? 'w-12 h-12 mx-auto justify-center' // like the buttons above
+                            : 'h-12 px-4 w-full'
+                    }`}
+                >
+                    <LogOut size={22} className="shrink-0" />
+                    {!isCollapsed && <span className="ml-4 truncate">Log out</span>}
+                </button>
+                {showLogoutDialog && (
+                    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center">
+                        {/* White Box */}
+                        <div className="bg-white rounded-xl shadow-2xl p-6 max-w-sm w-full mx-4">
+                            <h2 className="text-xl font-bold text-gray-900 mb-2">Log out</h2>
+                            <p className="text-gray-500 mb-6">Do you really want to log out of the system?</p>
+
+                            <div className="flex justify-end space-x-3">
+                                <button
+                                    onClick={() => setShowLogoutDialog(false)}
+                                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    onClick={() => {
+                                        useAuthStore.getState().logout();
+                                        setShowLogoutDialog(false);
+                                        navigate('/login')
+                                    }}
+                                    className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
+                                >
+                                    Log out
+                                </button>
+                            </div>
                         </div>
                     </div>
-                </div>
-            )}
-        </div>
-    </aside>
+                )}
+            </div>
+        </aside>
+    </>
 );
 };
 

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Outlet } from 'react-router-dom';
 import { Sidebar } from '../components/Sidebar';
 import { Navbar } from '../components/Navbar';
@@ -6,20 +7,21 @@ import { useFetchRooms } from "../hooks/useFetchRooms";
 
 export const MainLayout = () => {
     useWebSocket();
-    useFetchRooms()
+    useFetchRooms();
+    const [mobileNavOpen, setMobileNavOpen] = useState(false);
     return (
         <div className="h-screen flex bg-[#F3F4F6] text-[#1F2937] font-sans overflow-hidden">
 
-                <Sidebar />
+            <Sidebar mobileOpen={mobileNavOpen} onMobileClose={() => setMobileNavOpen(false)}/>
 
             <div className="flex-1 flex flex-col min-w-0">
 
-                <Navbar />
+                <Navbar onMenuClick={() => setMobileNavOpen(true)} />
 
-            <main className="flex-1 p-6 md:p-8 overflow-x-hidden overflow-y-auto"> {/**/}
+                <main className="flex-1 p-6 md:p-8 overflow-x-hidden overflow-y-auto"> {/**/}
 
-                <Outlet />
-            </main>
+                    <Outlet />
+                </main>
 
             </div>
         </div>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -19,7 +19,7 @@ export default function Dashboard() {
         <div className="max-w-7xl mx-auto">
             <header className="mb-8 flex justify-between items-start">
                 <div>
-                    <h1 className="text-3xl font-bold text-gray-900">Live-Belegung</h1>
+                    <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
                     <p className="text-gray-500">Echtzeit-Daten der mmWave-Sensoren (HdM Campus)</p>
                 </div>
                 <div className="flex items-center gap-2 text-sm">


### PR DESCRIPTION
## Summary
Makes the app layout usable on phone-sized viewports. The sidebar becomes
an overlay drawer on mobile instead of squeezing the page content, opened
via a hamburger button in the navbar.

## Changes
- `Sidebar.tsx` — below `md` the sidebar is a `fixed` off-canvas drawer
  (`-translate-x-full` / `translate-x-0`) with a click-to-close backdrop;
  from `md` upward it keeps the existing in-flow collapse/expand behavior.
  Collapse toggle is hidden on mobile; nav links close the drawer on click.
- `Navbar.tsx` — hamburger button (`md:hidden`) opens the drawer; user
  panel stays right-aligned via `ml-auto`.
- `MainLayout.tsx` — owns the drawer open state and wires it to Navbar
  (open) and Sidebar (state + close).

## Verification
- ~390px viewport: sidebar hidden by default, opens as an overlay drawer
  over full-width content, closes via backdrop or nav click
- `md`+ : unchanged in-flow collapse/expand behavior, no regression
- `npm run build` and `npm run lint` green

## Notes
Part of #296. The remaining tasks (Analytics table column priority, card
sizing) are intentionally left for a follow-up — they touch the Analytics
table, which is also being reworked in #48; doing them after #48 merges
avoids conflicts. This PR does not close #296.