### PR TITLE
refactor: hide rooms from navigation and rename analytics to Räume #284

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import { Login } from './pages/Login';
-import Rooms from './pages/Rooms';
 import Analytics from './pages/Analytics';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { MainLayout } from './layouts/MainLayout';
@@ -23,7 +22,7 @@ function App() {
                 <Route element={<ProtectedRoute />}>
                     <Route element={<MainLayout />}>
                         <Route path="/dashboard" element={<Dashboard />} />
-                        <Route path="/rooms" element={<Rooms />} />
+                        <Route path="/rooms" element={<Navigate to="/analytics" replace />} />
                         <Route path="/analytics" element={<Analytics />} />
                     </Route>
                 </Route>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { LayoutDashboard, ChartColumn, DoorOpen, PanelLeftOpen, PanelLeftClose, LogOut, Shield } from 'lucide-react';
+import { LayoutDashboard, DoorOpen, PanelLeftOpen, PanelLeftClose, LogOut, Shield } from 'lucide-react';
 import { useAuthStore} from "../hooks/useAuthStore";
 
 export const Sidebar = ({ mobileOpen, onMobileClose }: { mobileOpen: boolean; onMobileClose: () => void }) => {
@@ -25,8 +25,7 @@ export const Sidebar = ({ mobileOpen, onMobileClose }: { mobileOpen: boolean; on
     // it's an array/list - easier and shorter
     const navItems = [
         { path: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-        { path: '/rooms', label: 'Räume', icon: DoorOpen },
-        { path: '/analytics', label: 'Analytics', icon: ChartColumn },
+        { path: '/analytics', label: 'Räume', icon: DoorOpen },
         //if admin
         ...(user?.role === 'admin' ? [{ path: '/admin', label: 'Admin', icon: Shield}] : [])
     ];

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -51,7 +51,7 @@ export default function Analytics() {
     return (
         <div className="max-w-7xl mx-auto">
             <header className="mb-8">
-                <h1 className="text-3xl font-bold text-purple-600">Analytics</h1>
+                <h1 className="text-3xl font-bold text-purple-600">Räume</h1>
                 <p className="text-gray-500 mt-2">Campus-Überblick, Filter, Sortierung & Export</p>
             </header>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">


### PR DESCRIPTION
## Summary
Light step toward the Rooms/Analytics consolidation (#284): the Rooms page
is removed from the navigation and Analytics is renamed to "Räume", so
"Räume" is now the single room list in the UI. No files deleted or features
migrated yet — that's the full cleanup, still tracked in #284.

## Changes
- `Sidebar.tsx` — removed the Rooms nav item; the Analytics entry is now
  labelled "Räume" with the door icon
- `App.tsx` — `/rooms` redirects to `/analytics` (page kept, just unlinked)
- `Analytics.tsx` — page heading changed to "Räume"

## Notes
Part of #284 — full consolidation (delete Rooms.tsx, carry over the
occupancy bar / "Aktualisiert" column) remains open there.