### PR TITLE
Feature/room filter component #48

### DIFF
--- a/frontend/src/components/RoomFilters.tsx
+++ b/frontend/src/components/RoomFilters.tsx
@@ -10,6 +10,14 @@ interface RoomFiltersProps {
     availableFloors: string[];
     selectedFloors: string[];
     setSelectedFloors: (floor: string[]) => void;
+
+    // search and dropdown
+    search: string;
+    setSearch: (value: string) => void;
+    statusFilter: string;
+    setStatusFilter: (value: string) => void;
+    sortBy: string;
+    setSortBy: (value: string) => void;
 }
 
 export const RoomFilters: React.FC<RoomFiltersProps> =
@@ -19,9 +27,16 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
          setSelectedBuildings,
          availableFloors,
          selectedFloors,
-         setSelectedFloors }) => {
+         setSelectedFloors,
+         search,
+         setSearch,
+         statusFilter,
+         setStatusFilter,
+         sortBy,
+         setSortBy
+     }) => {
 
-    // logic for toggle building checkbox
+        // logic for toggle building checkbox
         const toggleBuildings = (building: string) => {
             //if building is already selected, remove it, else add it
             if (selectedBuildings.includes(building)) {
@@ -32,65 +47,152 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
             }
         };
 
-     const toggleFloor = (floor: string) => {
-         //if building is already selected, remove it, else add it
-         if (selectedFloors.includes(floor)) {
-             setSelectedFloors(selectedFloors.filter((b) => b !== floor));
-         } else {
-             // if not selected yet, add it to the list
-             setSelectedFloors([...selectedFloors, floor]);
-         }
-     };
+        const toggleFloor = (floor: string) => {
+            //if building is already selected, remove it, else add it
+            if (selectedFloors.includes(floor)) {
+                setSelectedFloors(selectedFloors.filter((b) => b !== floor));
+            } else {
+                // if not selected yet, add it to the list
+                setSelectedFloors([...selectedFloors, floor]);
+            }
+        };
         return (
-    <div className="bg-white p-5 rounded-2xl border border-gray-100 mb-6 flex flex-col gap-2">
-            {/* building filters */}
-        <div className={"flex flex-col gap-2"}>
+            <div className="bg-white p-5 rounded-2xl border border-gray-100 mb-6 flex flex-col gap-6">
+                {/* building filters */}
+                <div className={"flex flex-col gap-2"}>
             <span className="text-sm text-gray-400 mb-1">
                 Filter buildings
             </span>
 
-            <div className="flex flex-wrap gap-2">
-                {availableBuildings.map((building) => {
-                    const isSelected = selectedBuildings.includes(building);
+                    <div className="flex flex-wrap gap-2">
+                        {availableBuildings.map((building) => {
+                            const isSelected = selectedBuildings.includes(building);
 
-                    return(
-                        <button key={building}
-                        onClick={() => toggleBuildings(building)}
-                        className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${ isSelected
-                            ? 'bg-[#111827] border-[#111827] text-white shadow-sm' // dark blue like the website - test
-                            : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
-                        }`}
-                        >
-                            {building}
-                        </button>
-                    );
-                })}
-            </div>
-        </div>
+                            return (
+                                <button key={building}
+                                        onClick={() => toggleBuildings(building)}
+                                        className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${isSelected
+                                            ? 'bg-[#111827] border-[#111827] text-white shadow-sm' // dark blue like the website - test
+                                            : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+                                        }`}
+                                >
+                                    {building}
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
 
-        {/* floor filters */}
-            <span className="text-sm text-gray-400 mb-1">
-                Filter floors
-            </span>
+                {/* the row with filter occupancy and filter floors*/}
+                <div className="flex flex-col sm:flex-row gap-6 sm:gap-16">
 
-                <div className="flex flex-wrap gap-2">
-                {availableFloors.map((floor) => {
-                    const isSelected = selectedFloors.includes(floor);
-                    return (
-                         <button
-                        key={floor}
-                        onClick={() => toggleFloor(floor)}
-                        className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${
-                            isSelected
-                                ? 'bg-[#111827] border-[#111827] text-white shadow-sm' // test
-                                : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
-                        }`}
+                    {/* Filter floors */}
+                    <div className={"flex flex-col gap-2"}>
+                <span className="text-sm text-gray-400 mb-1">
+                    Filter floors
+                </span>
+
+                        <div className="flex flex-wrap gap-2">
+                            {availableFloors.map((floor) => {
+                                const isSelected = selectedFloors.includes(floor);
+                                return (
+                                    <button
+                                        key={floor}
+                                        onClick={() => toggleFloor(floor)}
+                                        className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${
+                                            isSelected
+                                                ? 'bg-[#111827] border-[#111827] text-white shadow-sm' // test
+                                                : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+                                        }`}
+                                    >
+                                        {floor}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+
+                    {/* Filter occupancy */}
+                    <div className={"flex flex-col gap-2"}>
+                <span className="text-sm text-gray-400 mb-1">
+                    Filter occupancy
+                </span>
+
+                        <div className="flex flex-wrap gap-2">
+                            {/* Low Button*/}
+                            <button
+                                onClick={() => setStatusFilter(statusFilter === 'low' ? '' : 'low')}
+                                className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${
+                                    statusFilter === 'low'
+                                        ? 'bg-green-100 border-green-800 text-green-800'
+                                        : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+                                }`}
+                            >
+                                Low
+                            </button>
+
+                            {/* Medium Button*/}
+                            <button
+                                onClick={() => setStatusFilter(statusFilter === 'medium' ? '' : 'medium')}
+                                className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${
+                                    statusFilter === 'medium'
+                                        ? 'bg-yellow-100 border-yellow-800 text-yellow-800'
+                                        : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+                                }`}
+                            >
+                                Medium
+                            </button>
+
+                            <button
+                                onClick={() => setStatusFilter(statusFilter === 'high' ? '' : 'high')}
+                                className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${
+                                    statusFilter === 'high'
+                                        ? 'bg-red-100 border-red-800 text-red-800'
+                                        : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+                                }`}
+                            >
+                                Hoch
+                            </button>
+                        </div>
+                    </div>
+
+                </div>
+                {/* end of the flex row */}
+
+                {/* separation line*/}
+                <hr className="border-gray-100 mt-2"/>
+
+                <div className="flex flex-wrap gap-3 mt-2 mb-4">
+
+                    {/* Search input */}
+                    <input type="text" placeholder="Suche..." value={search} onChange={(e) => setSearch(e.target.value)}
+                           className="bg-white w-full md:w-72 px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100"/>
+
+                    {/* Status filter
+            <select
+                value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value)}
+                className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100">
+
+                <option value="" disabled hidden>Auslastung</option> // Eher
+                <option value="low">Niedrig</option>
+                <option value="medium">Mittel</option>
+                <option value="high">Hoch</option>
+            </select>
+            TODO: delete if not needed anymore*/}
+
+                    {/* Sort */}
+                    <select
+                        value={sortBy}
+                        onChange={(e) => setSortBy(e.target.value)}
+                        className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100"
                     >
-                        {floor}
-                        </button>
-                        );
-                    })}
+                        <option value="" disabled>Sortierung</option>
+                        <option value="least">Auslastung: Niedrigste zuerst</option>
+                        <option value="most">Auslastung: Höchste zuerst</option>
+                        <option value="building">Gebäude: Alphabetisch</option>
+                    </select>
                 </div>
             </div>
-    );
+        );
     };

--- a/frontend/src/components/RoomFilters.tsx
+++ b/frontend/src/components/RoomFilters.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+
+interface RoomFiltersProps {
+    // buildings
+    availableBuildings: string[];
+    selectedBuildings: string[];
+    setSelectedBuildings: (building: string[]) => void;
+
+    // floors
+    availableFloors: string[];
+    selectedFloors: string[];
+    setSelectedFloors: (floor: string[]) => void;
+}
+
+export const RoomFilters: React.FC<RoomFiltersProps> =
+    ({
+         availableBuildings,
+         selectedBuildings,
+         setSelectedBuildings,
+         availableFloors,
+         selectedFloors,
+         setSelectedFloors }) => {
+
+    // logic for toggle building checkbox
+        const toggleBuildings = (building: string) => {
+            //if building is already selected, remove it, else add it
+            if (selectedBuildings.includes(building)) {
+                setSelectedBuildings(selectedBuildings.filter((b) => b !== building));
+            } else {
+                // if not selected yet, add it to the list
+                setSelectedBuildings([...selectedBuildings, building]);
+            }
+        };
+
+     const toggleFloor = (floor: string) => {
+         //if building is already selected, remove it, else add it
+         if (selectedFloors.includes(floor)) {
+             setSelectedFloors(selectedFloors.filter((b) => b !== floor));
+         } else {
+             // if not selected yet, add it to the list
+             setSelectedFloors([...selectedFloors, floor]);
+         }
+     };
+        return (
+    <div className="bg-white p-5 rounded-2xl border border-gray-100 mb-6 flex flex-col gap-2">
+            {/* building filters */}
+        <div className={"flex flex-col gap-2"}>
+            <span className="text-sm text-gray-400 mb-1">
+                Filter buildings
+            </span>
+
+            <div className="flex flex-wrap gap-2">
+                {availableBuildings.map((building) => {
+                    const isSelected = selectedBuildings.includes(building);
+
+                    return(
+                        <button key={building}
+                        onClick={() => toggleBuildings(building)}
+                        className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${ isSelected
+                            ? 'bg-[#111827] border-[#111827] text-white shadow-sm' // dark blue like the website - test
+                            : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+                        }`}
+                        >
+                            {building}
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+
+        {/* floor filters */}
+            <span className="text-sm text-gray-400 mb-1">
+                Filter floors
+            </span>
+
+                <div className="flex flex-wrap gap-2">
+                {availableFloors.map((floor) => {
+                    const isSelected = selectedFloors.includes(floor);
+                    return (
+                         <button
+                        key={floor}
+                        onClick={() => toggleFloor(floor)}
+                        className={`px-4 py-1.5 text-sm rounded-xl transition-all duration-200 border ${
+                            isSelected
+                                ? 'bg-[#111827] border-[#111827] text-white shadow-sm' // test
+                                : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+                        }`}
+                    >
+                        {floor}
+                        </button>
+                        );
+                    })}
+                </div>
+            </div>
+    );
+    };

--- a/frontend/src/components/RoomFilters.tsx
+++ b/frontend/src/components/RoomFilters.tsx
@@ -56,6 +56,15 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                 setSelectedFloors([...selectedFloors, floor]);
             }
         };
+
+        const handleReset = () => {
+            setSelectedBuildings([]);
+            setSelectedFloors([]);
+            setSearch('');
+            setStatusFilter('');
+            setSortBy('');
+        }
+
         return (
             <div className="bg-white p-5 rounded-2xl border border-gray-100 mb-6 flex flex-col gap-6">
                 {/* building filters */}
@@ -160,9 +169,9 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                 {/* end of the flex row */}
 
                 {/* separation line*/}
-                <hr className="border-gray-100 mt-2"/>
+                <hr className="border-gray-100"/>
 
-                <div className="flex flex-wrap gap-3 mt-2 mb-4">
+                <div className="flex flex-wrap gap-3">
 
                     {/* Search input */}
                     <input type="text" placeholder="Suche..." value={search} onChange={(e) => setSearch(e.target.value)}
@@ -192,6 +201,15 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                         <option value="most">Auslastung: Höchste zuerst</option>
                         <option value="building">Gebäude: Alphabetisch</option>
                     </select>
+
+                    {/* reset button */}
+                    <button
+                        onClick={handleReset}
+                        className="ml-auto px-4 py-2 text-sm text-red-500 hover:bg-red-100 rounded-xl transition-colors font-medium border border-red-200"
+                    >
+                        Filter löschen
+                    </button>
+
                 </div>
             </div>
         );

--- a/frontend/src/components/RoomFilters.tsx
+++ b/frontend/src/components/RoomFilters.tsx
@@ -61,7 +61,7 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                 {/* building filters */}
                 <div className={"flex flex-col gap-2"}>
             <span className="text-sm text-gray-400 mb-1">
-                Filter buildings
+                Gebäude filtern
             </span>
 
                     <div className="flex flex-wrap gap-2">
@@ -89,7 +89,7 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                     {/* Filter floors */}
                     <div className={"flex flex-col gap-2"}>
                 <span className="text-sm text-gray-400 mb-1">
-                    Filter floors
+                    Etagen filtern
                 </span>
 
                         <div className="flex flex-wrap gap-2">
@@ -115,7 +115,7 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                     {/* Filter occupancy */}
                     <div className={"flex flex-col gap-2"}>
                 <span className="text-sm text-gray-400 mb-1">
-                    Filter occupancy
+                    Auslastung filtern
                 </span>
 
                         <div className="flex flex-wrap gap-2">
@@ -128,7 +128,7 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                                         : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
                                 }`}
                             >
-                                Low
+                                Niedrig
                             </button>
 
                             {/* Medium Button*/}
@@ -140,7 +140,7 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                                         : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
                                 }`}
                             >
-                                Medium
+                                Mittel
                             </button>
 
                             <button

--- a/frontend/src/components/RoomFilters.tsx
+++ b/frontend/src/components/RoomFilters.tsx
@@ -177,19 +177,6 @@ export const RoomFilters: React.FC<RoomFiltersProps> =
                     <input type="text" placeholder="Suche..." value={search} onChange={(e) => setSearch(e.target.value)}
                            className="bg-white w-full md:w-72 px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100"/>
 
-                    {/* Status filter
-            <select
-                value={statusFilter}
-                onChange={(e) => setStatusFilter(e.target.value)}
-                className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100">
-
-                <option value="" disabled hidden>Auslastung</option> // Eher
-                <option value="low">Niedrig</option>
-                <option value="medium">Mittel</option>
-                <option value="high">Hoch</option>
-            </select>
-            TODO: delete if not needed anymore*/}
-
                     {/* Sort */}
                     <select
                         value={sortBy}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -4,6 +4,7 @@ import {useState} from "react";
 import { useFetchRooms } from '../hooks/useFetchRooms';
 import { RoomDetailModal} from "../components/RoomDetailModal";
 import type { Room } from '../types/room'
+import { RoomFilters} from "../components/RoomFilters";
 
 function SummaryCard({ label, value }: {label: string; value: string | number }) {
     return (
@@ -20,7 +21,8 @@ export default function Analytics() {
     useFetchRooms();
     // Filter & sort state
     const [search, setSearch] = useState('');
-    const [buildingFilter, setBuildingFilter] = useState('');
+    const [selectedBuildings, setSelectedBuildings] = useState<string[]>([]);
+    const [selectedFloors, setSelectedFloors] = useState<string[]>([]);
     const [statusFilter, setStatusFilter] = useState('');
     const [sortBy, setSortBy] = useState('');
     const [selectedRoom, setSelectedRoom] = useState<Room | null>(null);
@@ -28,7 +30,8 @@ export default function Analytics() {
     //Filtered & sorted room list
     const filteredRooms = rooms
             .filter((r) => r.name.toLowerCase().includes(search.toLowerCase()))
-            .filter((r) => buildingFilter === '' || r.building === buildingFilter)
+            .filter((r) => selectedBuildings.length === 0 || selectedBuildings.includes(r.building))
+            .filter((r) => selectedFloors.length === 0 || selectedFloors.includes(String(r.floor)))
             .filter((r) => statusFilter === '' || r.occupancyRate === statusFilter)
         .sort((a, b) => {
             if (sortBy === 'least') return a.count / a.capacity - b.count / b.capacity;
@@ -41,12 +44,12 @@ export default function Analytics() {
     const buildings = [...new Set(rooms.map((r) => r.building))];
 
     //Summary card values
-    const totalRooms = rooms.length;
-    const totalCapacity = rooms.reduce((sum, r) => sum + r.capacity, 0);
-    const totalPeople = rooms.reduce((sum, r) => sum + r.count, 0);
+    const totalRooms = filteredRooms.length;
+    const totalCapacity = filteredRooms.reduce((sum, r) => sum + r.capacity, 0);
+    const totalPeople = filteredRooms.reduce((sum, r) => sum + r.count, 0);
     const occupancyPct = totalCapacity > 0 ? Math.round((totalPeople / totalCapacity) * 100) : 0;
 
-    const columns = ['Raum', 'Gebäude', 'Belegung', 'Auslastung'];
+    const columns = ['Raum', 'Gebäude', 'Etage', 'Belegung', 'Auslastung'];
 
     return (
         <div className="max-w-7xl mx-auto">
@@ -54,6 +57,7 @@ export default function Analytics() {
                 <h1 className="text-3xl font-bold text-purple-600">Analytics</h1>
                 <p className="text-gray-500 mt-2">Campus-Überblick, Filter, Sortierung & Export</p>
             </header>
+
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
                 <SummaryCard label="Räume" value={totalRooms}/>
                 <SummaryCard label="Kapazität" value={totalCapacity}/>
@@ -61,23 +65,20 @@ export default function Analytics() {
                 <SummaryCard label="Auslastung" value={`${occupancyPct}%`}/>
             </div>
 
+            {/* new componoent for room filters*/}
+            <RoomFilters
+                availableBuildings={buildings}
+                selectedBuildings={selectedBuildings}
+                setSelectedBuildings={setSelectedBuildings}
+                availableFloors={['-1', '0', '1', '2']}
+                selectedFloors={selectedFloors}
+                setSelectedFloors={setSelectedFloors}/>
+
             <div className="flex flex-wrap gap-3 mb-4">
 
                 {/* Search input */}
                 <input type="text" placeholder="Suche..." value={search} onChange={(e) => setSearch(e.target.value)}
                        className="bg-white w-full md:w-72 px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100"/>
-
-                {/* Building filter */}
-                <select
-                    value={buildingFilter}
-                    onChange={(e) => setBuildingFilter(e.target.value)}
-                    className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100">
-
-                    <option value="">Alle Gebäude</option>
-                    {buildings.map((b) => (
-                        <option key={b} value={b}>{b}</option>
-                    ))}
-                </select>
 
                 {/* Status filter */}
                 <select
@@ -85,7 +86,7 @@ export default function Analytics() {
                     onChange={(e) => setStatusFilter(e.target.value)}
                     className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100">
 
-                    <option value="">Alle Status</option>
+                    <option value="">Auslastung</option> // Eher
                     <option value="low">Niedrig</option>
                     <option value="medium">Mittel</option>
                     <option value="high">Hoch</option>
@@ -125,6 +126,7 @@ export default function Analytics() {
                                 <span className="ml-2 text-gray-400 font-normal">{room.roomId}</span>
                             </td>
                             <td className="px-4 py-3 text-sm text-gray-600">{room.building}</td>
+                            <td className="px-4 py-3 text-sm text-gray-600">{room.floor}</td>
                             <td className="px-4 py-3 text-sm text-gray-600">{room.count} / {room.capacity}</td>
                             <td className="px-4 py-3 text-sm">
                                 <StatusBadge occupancyRate={room.occupancyRate} />

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -1,12 +1,12 @@
-import { useRoomStore } from '../hooks/useRoomStore';
-import { StatusBadge} from '../components/RoomStatus';
+import {useRoomStore} from '../hooks/useRoomStore';
+import {StatusBadge} from '../components/RoomStatus';
 import {useState} from "react";
-import { useFetchRooms } from '../hooks/useFetchRooms';
-import { RoomDetailModal} from "../components/RoomDetailModal";
-import type { Room } from '../types/room'
-import { RoomFilters} from "../components/RoomFilters";
+import {useFetchRooms} from '../hooks/useFetchRooms';
+import {RoomDetailModal} from "../components/RoomDetailModal";
+import type {Room} from '../types/room'
+import {RoomFilters} from "../components/RoomFilters";
 
-function SummaryCard({ label, value }: {label: string; value: string | number }) {
+function SummaryCard({label, value}: { label: string; value: string | number }) {
     return (
         <div className="bg-white rounded-2xl border border-gray-100 p-4">
             <p className="text-sm text-gray-400 mb-1">{label}</p>
@@ -17,7 +17,7 @@ function SummaryCard({ label, value }: {label: string; value: string | number })
 }
 
 export default function Analytics() {
-    const { rooms } = useRoomStore();
+    const {rooms} = useRoomStore();
     useFetchRooms();
     // Filter & sort state
     const [search, setSearch] = useState('');
@@ -29,10 +29,10 @@ export default function Analytics() {
 
     //Filtered & sorted room list
     const filteredRooms = rooms
-            .filter((r) => r.name.toLowerCase().includes(search.toLowerCase()))
-            .filter((r) => selectedBuildings.length === 0 || selectedBuildings.includes(r.building))
-            .filter((r) => selectedFloors.length === 0 || selectedFloors.includes(String(r.floor)))
-            .filter((r) => statusFilter === '' || r.occupancyRate === statusFilter)
+        .filter((r) => r.name.toLowerCase().includes(search.toLowerCase()))
+        .filter((r) => selectedBuildings.length === 0 || selectedBuildings.includes(r.building))
+        .filter((r) => selectedFloors.length === 0 || selectedFloors.includes(String(r.floor)))
+        .filter((r) => statusFilter === '' || r.occupancyRate === statusFilter)
         .sort((a, b) => {
             if (sortBy === 'least') return a.count / a.capacity - b.count / b.capacity;
             if (sortBy === 'most') return b.count / b.capacity - a.count / a.capacity;
@@ -72,39 +72,14 @@ export default function Analytics() {
                 setSelectedBuildings={setSelectedBuildings}
                 availableFloors={['-1', '0', '1', '2']}
                 selectedFloors={selectedFloors}
-                setSelectedFloors={setSelectedFloors}/>
-
-            <div className="flex flex-wrap gap-3 mb-4">
-
-                {/* Search input */}
-                <input type="text" placeholder="Suche..." value={search} onChange={(e) => setSearch(e.target.value)}
-                       className="bg-white w-full md:w-72 px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100"/>
-
-                {/* Status filter */}
-                <select
-                    value={statusFilter}
-                    onChange={(e) => setStatusFilter(e.target.value)}
-                    className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100">
-
-                    <option value="">Auslastung</option> // Eher
-                    <option value="low">Niedrig</option>
-                    <option value="medium">Mittel</option>
-                    <option value="high">Hoch</option>
-                </select>
-
-                {/* Sort */}
-                <select
-                    value={sortBy}
-                    onChange={(e) => setSortBy(e.target.value)}
-                    className="bg-white px-4 py-2 text-sm border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-100"
-                >
-                    <option value="">Sortierung</option>
-                    <option value="least">Aktuell am leersten</option>
-                    <option value="most">Aktuell am vollsten</option>
-                    <option value="building">Nach Gebäude</option>
-                </select>
-
-            </div>
+                setSelectedFloors={setSelectedFloors}
+                search={search}
+                setSearch={setSearch}
+                statusFilter={statusFilter}
+                setStatusFilter={setStatusFilter}
+                sortBy={sortBy}
+                setSortBy={setSortBy}
+            />
 
             <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
                 <table className="w-full">
@@ -112,7 +87,7 @@ export default function Analytics() {
                     <tr className="border-b border-gray-100">
                         {columns.map((col) => (
                             <th key={col} className="text-left px-4 py-3 text-sm font-medium text-gray-600">
-                            {col}
+                                {col}
                             </th>
                         ))}
                     </tr>
@@ -120,7 +95,7 @@ export default function Analytics() {
                     <tbody>
                     {filteredRooms.map((room) => (
                         <tr key={room.roomId} className="border-b border-gray-100 hover:bg-gray-50 cursor-pointer"
-                        onClick={() => setSelectedRoom(room)}>
+                            onClick={() => setSelectedRoom(room)}>
                             <td className="px-4 py-3 text-sm font-medium text-gray-900">
                                 {room.name}
                                 <span className="ml-2 text-gray-400 font-normal">{room.roomId}</span>
@@ -129,7 +104,7 @@ export default function Analytics() {
                             <td className="px-4 py-3 text-sm text-gray-600">{room.floor}</td>
                             <td className="px-4 py-3 text-sm text-gray-600">{room.count} / {room.capacity}</td>
                             <td className="px-4 py-3 text-sm">
-                                <StatusBadge occupancyRate={room.occupancyRate} />
+                                <StatusBadge occupancyRate={room.occupancyRate}/>
                             </td>
                         </tr>
                     ))}
@@ -137,7 +112,7 @@ export default function Analytics() {
                 </table>
             </div>
             {selectedRoom && (
-                <RoomDetailModal room={selectedRoom} isOpen={true} onClose={() => setSelectedRoom(null)} />
+                <RoomDetailModal room={selectedRoom} isOpen={true} onClose={() => setSelectedRoom(null)}/>
             )}
 
         </div>

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -109,7 +109,7 @@ export default function Analytics() {
                                 <StatusBadge occupancyRate={room.occupancyRate}/>
                             </td>
                             <td className="px-4 py-3">
-                                <PinButton roomId={room.roomId} />
+                                <PinButton roomId={room.roomId}/>
                             </td>
                         </tr>
                     ))}

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -70,7 +70,7 @@ export default function Analytics() {
                 availableBuildings={buildings}
                 selectedBuildings={selectedBuildings}
                 setSelectedBuildings={setSelectedBuildings}
-                availableFloors={['-1', '0', '1', '2']}
+                availableFloors={[...new Set(rooms.map(r => String(r.floor)))].sort((a, b) => Number(a) - Number(b))}
                 selectedFloors={selectedFloors}
                 setSelectedFloors={setSelectedFloors}
                 search={search}


### PR DESCRIPTION
## Summary
Adds a reusable `RoomFilters` component to the "Räume" (Analytics) page:
multi-select building and floor filters, occupancy status toggles, search,
sort, and a reset button.

## Changes
- New `RoomFilters.tsx` — building & floor multi-select (toggle buttons),
  occupancy status filter, search, sort dropdown, reset button
- `Analytics.tsx` — integrates `RoomFilters`, adds a floor column, derives
  the available floors dynamically from the room data
- Removed the leftover commented-out status dropdown

## Notes
- Reusable by design; integration into the (now retired) Rooms page was
  intentionally skipped — Rooms is being consolidated into "Räume" in #284
  (see comment on this issue).
- `npm run build` and `npm run lint` green

Closes #48