### PR TITLE
Feature/mobile responsive layout #296

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -110,36 +110,39 @@ export const Sidebar = ({ mobileOpen, onMobileClose }: { mobileOpen: boolean; on
                     <LogOut size={22} className="shrink-0" />
                     {!isCollapsed && <span className="ml-4 truncate">Log out</span>}
                 </button>
-                {showLogoutDialog && (
-                    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center">
-                        {/* White Box */}
-                        <div className="bg-white rounded-xl shadow-2xl p-6 max-w-sm w-full mx-4">
-                            <h2 className="text-xl font-bold text-gray-900 mb-2">Log out</h2>
-                            <p className="text-gray-500 mb-6">Do you really want to log out of the system?</p>
-
-                            <div className="flex justify-end space-x-3">
-                                <button
-                                    onClick={() => setShowLogoutDialog(false)}
-                                    className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    onClick={() => {
-                                        useAuthStore.getState().logout();
-                                        setShowLogoutDialog(false);
-                                        navigate('/login')
-                                    }}
-                                    className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
-                                >
-                                    Log out
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                )}
             </div>
         </aside>
+
+        {/* Logout confirmation lives OUTSIDE <aside> so its fixed overlay is
+            positioned to the viewport, not the transformed sidebar */}
+        {showLogoutDialog && (
+            <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center">
+                {/* White Box */}
+                <div className="bg-white rounded-xl shadow-2xl p-6 max-w-sm w-full mx-4">
+                    <h2 className="text-xl font-bold text-gray-900 mb-2">Log out</h2>
+                    <p className="text-gray-500 mb-6">Do you really want to log out of the system?</p>
+
+                    <div className="flex justify-end space-x-3">
+                        <button
+                            onClick={() => setShowLogoutDialog(false)}
+                            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            onClick={() => {
+                                useAuthStore.getState().logout();
+                                setShowLogoutDialog(false);
+                                navigate('/login')
+                            }}
+                            className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-lg transition-colors"
+                        >
+                            Log out
+                        </button>
+                    </div>
+                </div>
+            </div>
+        )}
     </>
 );
 };

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -8,9 +8,9 @@ import {RoomFilters} from "../components/RoomFilters";
 
 function SummaryCard({label, value}: { label: string; value: string | number }) {
     return (
-        <div className="bg-white rounded-2xl border border-gray-100 p-4">
+        <div className="bg-white rounded-2xl border border-gray-100 p-3 sm:p-4">
             <p className="text-sm text-gray-400 mb-1">{label}</p>
-            <p className="text-2xl font-semibold text-gray-900">{value}</p>
+            <p className="text-xl sm:text-2xl font-semibold text-gray-900">{value}</p>
         </div>
     );
 
@@ -58,7 +58,7 @@ export default function Analytics() {
                 <p className="text-gray-500 mt-2">Campus-Überblick, Filter, Sortierung & Export</p>
             </header>
 
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 mb-8">
                 <SummaryCard label="Räume" value={totalRooms}/>
                 <SummaryCard label="Kapazität" value={totalCapacity}/>
                 <SummaryCard label="Personen anwesend" value={occupancyUnavailable ? '—' : totalPeople}/>
@@ -81,12 +81,12 @@ export default function Analytics() {
                 setSortBy={setSortBy}
             />
 
-            <div className="bg-white rounded-2xl border border-gray-100 overflow-hidden">
+            <div className="bg-white rounded-2xl border border-gray-100 overflow-x-auto">
                 <table className="w-full">
                     <thead>
                     <tr className="border-b border-gray-100">
                         {columns.map((col) => (
-                            <th key={col} className="text-left px-4 py-3 text-sm font-medium text-gray-600">
+                            <th key={col} className={`text-left px-2 sm:px-4 py-3 text-sm font-medium text-gray-600 ${col === 'Gebäude' || col === 'Etage' ? 'hidden sm:table-cell' : ''}`}>
                                 {col}
                             </th>
                         ))}
@@ -96,17 +96,17 @@ export default function Analytics() {
                     {filteredRooms.map((room) => (
                         <tr key={room.roomId} className="border-b border-gray-100 hover:bg-gray-50 cursor-pointer"
                             onClick={() => setSelectedRoom(room)}>
-                            <td className="px-4 py-3 text-sm font-medium text-gray-900">
+                            <td className="px-2 sm:px-4 py-3 text-sm font-medium text-gray-900 whitespace-nowrap">
                                 {room.name}
                                 <span className="ml-2 text-gray-400 font-normal">{room.roomId}</span>
                             </td>
-                            <td className="px-4 py-3 text-sm text-gray-600">{room.building}</td>
-                            <td className="px-4 py-3 text-sm text-gray-600">{room.floor}</td>
-                            <td className="px-4 py-3 text-sm text-gray-600">{room.occupancyRate === 'unknown' ? '—' : `${room.count} / ${room.capacity}`}</td>
-                            <td className="px-4 py-3 text-sm">
+                            <td className="px-2 sm:px-4 py-3 text-sm text-gray-600 hidden sm:table-cell">{room.building}</td>
+                            <td className="px-2 sm:px-4 py-3 text-sm text-gray-600 hidden sm:table-cell">{room.floor}</td>
+                            <td className="px-2 sm:px-4 py-3 text-sm text-gray-600">{room.occupancyRate === 'unknown' ? '—' : `${room.count} / ${room.capacity}`}</td>
+                            <td className="px-2 sm:px-4 py-3 text-sm">
                                 <StatusBadge occupancyRate={room.occupancyRate}/>
                             </td>
-                            <td className="px-4 py-3">
+                            <td className="px-2 sm:px-4 py-3">
                                 <PinButton roomId={room.roomId}/>
                             </td>
                         </tr>
@@ -118,7 +118,7 @@ export default function Analytics() {
                 <RoomDetailModal room={selectedRoom} isOpen={true} onClose={() => setSelectedRoom(null)}/>
             )}
 
-        </div>
+            </div>
 
 
     );


### PR DESCRIPTION
## Summary
Makes the app usable on phone-sized viewports. The sidebar becomes an overlay
drawer on mobile instead of squeezing the content, the room table adapts its
columns, and cards/navbar are tuned for small screens.

## Changes
- `Sidebar.tsx` — below `md` the sidebar is a `fixed` off-canvas drawer
  (`translate-x`) with a click-to-close backdrop; from `md` up it keeps the
  in-flow collapse/expand. Collapse toggle hidden on mobile, nav links close
  the drawer. Logout dialog moved outside the (now transformed) `<aside>` so
  its `fixed` overlay covers the viewport instead of being trapped in the
  sidebar.
- `Navbar.tsx` — hamburger button (`md:hidden`) opens the drawer; user panel
  stays right-aligned.
- `MainLayout.tsx` — owns the drawer open state, wires it to Navbar/Sidebar.
- `Analytics.tsx` — table scrolls horizontally (`overflow-x-auto`), Gebäude
  column `hidden sm:table-cell`, tighter cell padding (`px-2 sm:px-4`), name
  cell `whitespace-nowrap`; summary cards `p-3 sm:p-4` / `text-xl sm:text-2xl`.

## Verification
- ~390px: sidebar closed by default, opens as overlay over full-width content,
  closes via backdrop/nav; logout dialog centered over the viewport
- `md`+ : unchanged collapse/expand, no regression
- `npm run build` and `npm run lint` green

Closes #296