### PR TITLE
fix: make admin panel responsive on mobile #305

### DIFF
--- a/frontend/src/components/MetricsSection.tsx
+++ b/frontend/src/components/MetricsSection.tsx
@@ -42,34 +42,36 @@ export function MetricsSection() {
             ) : metrics.length === 0 ? (
                 <p className="text-gray-400">Keine Sensoren melden aktuell Metriken.</p>
             ) : (
+                <div className="overflow-x-auto">
                 <table className="w-full text-left">
                     <thead>
                     <tr className="border-b border-gray-200 text-gray-500 text-sm">
-                        <th className="pb-3">Sensor</th>
-                        <th className="pb-3">CPU</th>
-                        <th className="pb-3">RAM</th>
-                        <th className="pb-3">Queue</th>
-                        <th className="pb-3">Gesendet</th>
-                        <th className="pb-3">Verworfen</th>
-                        <th className="pb-3">Ø Zeit</th>
-                        <th className="pb-3">Aktualisiert</th>
+                        <th className="pb-3 pr-6 whitespace-nowrap">Sensor</th>
+                        <th className="pb-3 pr-6 whitespace-nowrap">CPU</th>
+                        <th className="pb-3 pr-6 whitespace-nowrap">RAM</th>
+                        <th className="pb-3 pr-6 whitespace-nowrap">Queue</th>
+                        <th className="pb-3 pr-6 whitespace-nowrap">Gesendet</th>
+                        <th className="pb-3 pr-6 whitespace-nowrap">Verworfen</th>
+                        <th className="pb-3 pr-6 whitespace-nowrap">Ø Zeit</th>
+                        <th className="pb-3 pr-6 whitespace-nowrap">Aktualisiert</th>
                     </tr>
                     </thead>
                     <tbody>
                     {metrics.map((m) => (
                         <tr key={m.sensorId} className="border-b border-gray-100">
-                            <td className="py-3">{m.sensorId}</td>
-                            <td className={`py-3 ${healthColor(m.cpuPercentage)}`}>{Math.round(m.cpuPercentage)}%</td>
-                            <td className={`py-3 ${healthColor(m.memoryPercentage)}`}>{Math.round(m.memoryPercentage)}%</td>
-                            <td className="py-3">{m.queueSize}</td>
-                            <td className="py-3">{m.sent}</td>
-                            <td className="py-3">{m.dropped}</td>
-                            <td className="py-3">{m.avgProcessTime.toFixed(1)} ms</td>
-                            <td className="py-3">{new Date(m.timestamp).toLocaleString('de-DE', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })}</td>
+                            <td className="py-3 pr-6 whitespace-nowrap">{m.sensorId}</td>
+                            <td className={`py-3 pr-6 whitespace-nowrap ${healthColor(m.cpuPercentage)}`}>{Math.round(m.cpuPercentage)}%</td>
+                            <td className={`py-3 pr-6 whitespace-nowrap ${healthColor(m.memoryPercentage)}`}>{Math.round(m.memoryPercentage)}%</td>
+                            <td className="py-3 pr-6 whitespace-nowrap">{m.queueSize}</td>
+                            <td className="py-3 pr-6 whitespace-nowrap">{m.sent}</td>
+                            <td className="py-3 pr-6 whitespace-nowrap">{m.dropped}</td>
+                            <td className="py-3 pr-6 whitespace-nowrap">{m.avgProcessTime.toFixed(1)} ms</td>
+                            <td className="py-3 pr-6 whitespace-nowrap">{new Date(m.timestamp).toLocaleString('de-DE', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })}</td>
                         </tr>
                     ))}
                     </tbody>
                 </table>
+                </div>
             )}
         </section>
     );

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -78,7 +78,7 @@ const AdminPanel = () => {
                             status === 409 ? 'Raum-ID existiert bereits.' : 'Fehler beim Speichern.');
                     }
                 }}>
-                    <div className="grid grid-cols-2 md:grid-cols-5 gap-4 mb-4">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-5 gap-4 mb-4">
                         <input
                             type="text"
                             placeholder="Raum-ID"
@@ -153,15 +153,16 @@ const AdminPanel = () => {
             {/* Room Table */}
             <section className="bg-white rounded-xl shadow p-6">
                 <h2 className="text-xl font-semibold text-gray-900 mb-4">Rooms</h2>
+                <div className="overflow-x-auto">
                 <table className="w-full text-left">
                     <thead>
                         <tr className="border-b border-gray-200 text-gray-500 text-sm">
-                            <th className="pb-3">Raum-ID</th>
-                            <th className="pb-3">Name</th>
-                            <th className="pb-3">Gebäude</th>
-                            <th className="pb-3">Etage</th>
-                            <th className="pb-3">Kapazität</th>
-                            <th className="pb-3">Aktionen</th>
+                            <th className="pb-3 pr-6 whitespace-nowrap">Raum-ID</th>
+                            <th className="pb-3 pr-6 whitespace-nowrap">Name</th>
+                            <th className="pb-3 pr-6 whitespace-nowrap">Gebäude</th>
+                            <th className="pb-3 pr-6 whitespace-nowrap">Etage</th>
+                            <th className="pb-3 pr-6 whitespace-nowrap">Kapazität</th>
+                            <th className="pb-3 pr-6 whitespace-nowrap">Aktionen</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -177,11 +178,11 @@ const AdminPanel = () => {
                         ))
                     ) : ( rooms.map((room) =>
                     <tr key={room.roomId} className="border-b border-gray-100">
-                        <td className="py-3">{room.roomId}</td>
-                        <td className="py-3">{room.name}</td>
-                        <td className="py-3">{room.building}</td>
-                        <td className="py-3">{room.floor}</td>
-                        <td className="py-3">{room.capacity}</td>
+                        <td className="py-3 pr-6 whitespace-nowrap">{room.roomId}</td>
+                        <td className="py-3 pr-6 whitespace-nowrap">{room.name}</td>
+                        <td className="py-3 pr-6 whitespace-nowrap">{room.building}</td>
+                        <td className="py-3 pr-6 whitespace-nowrap">{room.floor}</td>
+                        <td className="py-3 pr-6 whitespace-nowrap">{room.capacity}</td>
                         <td className="py-3 flex gap-2">
                             <button onClick={() => { setFormData(room);
                             setEditingId(room.roomId); }}
@@ -197,6 +198,7 @@ const AdminPanel = () => {
                     ))}
                     </tbody>
                 </table>
+                </div>
             </section>
 
             {/* Delete Confirmation Dialog*/}


### PR DESCRIPTION
## Summary
The Admin Panel wasn't part of the responsive layout work (#296), so on
phone-sized viewports its tables overflowed and got cut off, cells ran
together, and the room form was cramped. This applies the same responsive
pattern used for the Analytics table.

## Changes
- `AdminPanel.tsx` — "Raum hinzufügen" form grid stacks on mobile
  (`grid-cols-1 sm:grid-cols-2 md:grid-cols-5`); the Rooms table is wrapped
  in `overflow-x-auto`; cells get `pr-6 whitespace-nowrap` for column
  spacing and to stop content running together.
- `MetricsSection.tsx` — the 8-column Pi Metrics table is wrapped in
  `overflow-x-auto` with the same cell spacing.

## Verification
- ~390px: both tables scroll horizontally without cut-off, cells are
  readable and spaced; the room form stacks cleanly
- No regression on desktop
- `npm run build` and `npm run lint` green

Closes #305