### PR TITLE
feat: env-driven InfluxDB and CORS configuration #309

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   live occupancy for room 137 (#201).
 
 ### Changed
+- The backend's InfluxDB connection (`INFLUXDB_URL`/`INFLUXDB_DATABASE`/`INFLUXDB_TOKEN`)
+  and the CORS origins (`CORS_ALLOWED_ORIGINS`, comma-separated patterns) are now plain
+  environment variables with the previous values as local defaults. The origin list is
+  one property consumed by both the HTTP CORS config and the WebSocket handshake — the
+  two hardcoded copies could drift apart before. The open `dev` profile now logs a loud
+  startup warning, since it is the default for unconfigured deployments (#309).
 - Re-sliced the backend into strict package-by-feature. The layer-style packages
   `feature/database`, `feature/receiver` and `feature/provider` are gone: the occupancy
   and Pi-metrics domains each own their ingestion, persistence and read API in

--- a/backend/src/main/java/com/occupi/config/CorsConfig.java
+++ b/backend/src/main/java/com/occupi/config/CorsConfig.java
@@ -1,5 +1,6 @@
 package com.occupi.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -16,19 +17,17 @@ import java.util.List;
  * preflight requests are allowed through before authentication. This is required
  * for the browser-based frontend (different origin) to call the secured REST API.
  *
- * WebSocket CORS is configured separately in WebSocketConfig.
+ * The allowed origins come from {@link CorsProperties}; the WebSocket handshake
+ * in WebSocketConfig consumes the same list.
  */
 @Configuration
+@EnableConfigurationProperties(CorsProperties.class)
 public class CorsConfig {
 
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource(CorsProperties corsProperties) {
         CorsConfiguration config = new CorsConfiguration();
-        // Any localhost port (dev servers, test pages) + the production domain.
-        config.setAllowedOriginPatterns(List.of(
-                "http://localhost:*",
-                "https://occupi.mi.hdm-stuttgart.de"
-        ));
+        config.setAllowedOriginPatterns(corsProperties.getAllowedOrigins());
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/backend/src/main/java/com/occupi/config/CorsProperties.java
+++ b/backend/src/main/java/com/occupi/config/CorsProperties.java
@@ -1,0 +1,22 @@
+package com.occupi.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+/**
+ * Origin patterns allowed for cross-origin access.
+ *
+ * Bound from {@code occupi.cors.allowed-origins} (env {@code CORS_ALLOWED_ORIGINS},
+ * comma-separated). Shared by the HTTP CORS configuration and the WebSocket
+ * handshake so the two lists can never drift apart again — they used to be
+ * maintained as two separate hardcoded copies.
+ */
+@Data
+@ConfigurationProperties(prefix = "occupi.cors")
+public class CorsProperties {
+
+    /** Allowed origin patterns, e.g. {@code http://localhost:*} or a full https origin. */
+    private List<String> allowedOrigins;
+}

--- a/backend/src/main/java/com/occupi/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/occupi/config/WebSocketConfig.java
@@ -41,6 +41,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Autowired
     private ObjectMapper objectMapper;
 
+    /** Same allowed-origin list as the HTTP CORS config — one property, two consumers. */
+    @Autowired
+    private CorsProperties corsProperties;
+
     /**
      * Registers a custom STOMP message converter backed by the Spring Boot
      * auto-configured Jackson 3 ObjectMapper.
@@ -115,21 +119,17 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
      */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
+        String[] allowedOrigins = corsProperties.getAllowedOrigins().toArray(String[]::new);
+
         // Raw WebSocket endpoint for native clients (Raspberry Pi / stomp.py)
         registry
                 .addEndpoint("/ws")
-                .setAllowedOriginPatterns(
-                        "http://localhost:*",
-                        "https://occupi.mi.hdm-stuttgart.de"
-                );
+                .setAllowedOriginPatterns(allowedOrigins);
 
         // SockJS endpoint for browser clients
         registry
                 .addEndpoint("/ws/occupancy")
-                .setAllowedOriginPatterns(
-                        "http://localhost:*",
-                        "https://occupi.mi.hdm-stuttgart.de"
-                )
+                .setAllowedOriginPatterns(allowedOrigins)
                 .withSockJS();
     }
 

--- a/backend/src/main/java/com/occupi/security/DevSecurityConfig.java
+++ b/backend/src/main/java/com/occupi/security/DevSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.occupi.security;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -9,12 +10,17 @@ import org.springframework.security.web.SecurityFilterChain;
 
 // Active only for local development — all requests are permitted.
 // In production the 'dev' profile must not be active.
+@Slf4j
 @Profile("dev")
 @Configuration
 public class DevSecurityConfig {
 
     @Bean
     public SecurityFilterChain devFilterChain(HttpSecurity http) throws Exception {
+        // The default profile is 'dev', so an unconfigured deployment lands here —
+        // make that impossible to miss in the logs.
+        log.warn("dev profile active: security is DISABLED, every endpoint is open. "
+                + "Never expose this profile on a public host — set SPRING_PROFILES_ACTIVE=prod.");
         http
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -28,6 +28,14 @@ influxdb:
   database: ${INFLUXDB_DATABASE:occupi}
   token: ${INFLUXDB_TOKEN:}
 
+# Origin patterns for browser access, consumed by both the HTTP CORS configuration
+# and the WebSocket handshake (CorsProperties). The default allows any localhost
+# port plus the production domain; deployments under another hostname override via
+# CORS_ALLOWED_ORIGINS (comma-separated).
+occupi:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:*,https://occupi.mi.hdm-stuttgart.de}
+
 # "Latest per room / per sensor" reads are the union of InfluxDB's in-memory last
 # value cache (#294) — latest-lookback-days is that cache's TTL — and a scan
 # bounded to latest-fallback-days, which restores rooms the cache lost across an

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -21,10 +21,12 @@ spring:
       ddl-auto: update
     open-in-view: false
 
+# Same env-with-local-default pattern as the datasource above: Docker/prod override
+# via INFLUXDB_*, a bare local run works without any environment.
 influxdb:
-  url: http://localhost:8181
-  database: occupi
-  token: ""
+  url: ${INFLUXDB_URL:http://localhost:8181}
+  database: ${INFLUXDB_DATABASE:occupi}
+  token: ${INFLUXDB_TOKEN:}
 
 # "Latest per room / per sensor" reads are the union of InfluxDB's in-memory last
 # value cache (#294) — latest-lookback-days is that cache's TTL — and a scan

--- a/backend/src/test/java/com/occupi/config/CorsConfigOverrideTest.java
+++ b/backend/src/test/java/com/occupi/config/CorsConfigOverrideTest.java
@@ -1,0 +1,48 @@
+package com.occupi.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that CORS_ALLOWED_ORIGINS replaces the default origin list without a
+ * code change — the property a docker/server deployment sets for its hostname.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = "CORS_ALLOWED_ORIGINS=https://occupi.example.org,http://intranet:8443")
+@DisplayName("CORS configuration override via CORS_ALLOWED_ORIGINS")
+class CorsConfigOverrideTest {
+
+    @Autowired
+    private CorsConfigurationSource corsConfigurationSource;
+
+    @Autowired
+    private CorsProperties corsProperties;
+
+    @Test
+    @DisplayName("override replaces the defaults for the HTTP CORS source")
+    void overrideReplacesDefaults() {
+        CorsConfiguration config = ((UrlBasedCorsConfigurationSource) corsConfigurationSource)
+                .getCorsConfigurations().get("/**");
+
+        assertThat(config).isNotNull();
+        assertThat(config.getAllowedOriginPatterns())
+                .containsExactly("https://occupi.example.org", "http://intranet:8443");
+    }
+
+    @Test
+    @DisplayName("shared property reflects the override for the WebSocket consumer")
+    void sharedPropertyReflectsOverride() {
+        assertThat(corsProperties.getAllowedOrigins())
+                .containsExactly("https://occupi.example.org", "http://intranet:8443");
+    }
+}

--- a/backend/src/test/java/com/occupi/config/CorsConfigTest.java
+++ b/backend/src/test/java/com/occupi/config/CorsConfigTest.java
@@ -1,0 +1,47 @@
+package com.occupi.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies the default origin list: without CORS_ALLOWED_ORIGINS set, behavior
+ * must match what used to be hardcoded — any localhost port plus the production
+ * domain — for both consumers of {@link CorsProperties}.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("CORS configuration defaults")
+class CorsConfigTest {
+
+    @Autowired
+    private CorsConfigurationSource corsConfigurationSource;
+
+    @Autowired
+    private CorsProperties corsProperties;
+
+    @Test
+    @DisplayName("HTTP CORS source carries the default origin patterns")
+    void httpCorsUsesDefaultOrigins() {
+        CorsConfiguration config = ((UrlBasedCorsConfigurationSource) corsConfigurationSource)
+                .getCorsConfigurations().get("/**");
+
+        assertThat(config).isNotNull();
+        assertThat(config.getAllowedOriginPatterns())
+                .containsExactly("http://localhost:*", "https://occupi.mi.hdm-stuttgart.de");
+    }
+
+    @Test
+    @DisplayName("shared property holds the same default list")
+    void sharedPropertyHoldsDefaults() {
+        assertThat(corsProperties.getAllowedOrigins())
+                .containsExactly("http://localhost:*", "https://occupi.mi.hdm-stuttgart.de");
+    }
+}

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -20,3 +20,15 @@ KC_HOSTNAME=occupi.mi.hdm-stuttgart.de
 # Optional: override the backend Spring profile (local overlay defaults to 'dev',
 # prod overlay forces 'prod' — normally you do NOT need to set this).
 # SPRING_PROFILES_ACTIVE=dev
+
+# ── InfluxDB (backend connection) ────────────────────────────────────────────
+# The compose files already point the backend at the internal influxdb service;
+# set these only to override, e.g. once InfluxDB runs with token auth.
+# INFLUXDB_URL=http://influxdb:8181
+# INFLUXDB_DATABASE=occupi
+# INFLUXDB_TOKEN=
+
+# ── CORS (backend, HTTP + WebSocket) ─────────────────────────────────────────
+# Comma-separated origin patterns. Default allows any localhost port plus the
+# production domain — override when deploying under a different hostname.
+# CORS_ALLOWED_ORIGINS=http://localhost:*,https://occupi.mi.hdm-stuttgart.de


### PR DESCRIPTION
## Summary
First backend step of the restructuring plan: the server stack must be configurable
from one .env. The InfluxDB connection values were literals in `application.yaml`
(worked in Docker only through Spring's relaxed binding — implicit and undocumented),
and the CORS origins were hardcoded twice: in `CorsConfig` for HTTP and again in
`WebSocketConfig` for the two STOMP endpoints.

## Changes
- `application.yaml` — `influxdb.url/database/token` use `${INFLUXDB_*:local-default}`
  like the datasource block; new `occupi.cors.allowed-origins` property bound from
  `CORS_ALLOWED_ORIGINS` with the previous origins as default.
- `CorsProperties` (new, `config/`) — one binding for the origin list, same
  `@ConfigurationProperties` idiom as `InfluxDBProperties`.
- `CorsConfig` + `WebSocketConfig` — both consume `CorsProperties`; the duplicated
  hardcoded lists are gone.
- `DevSecurityConfig` — loud startup WARN: the open dev profile is the default for
  unconfigured deployments.
- `docker/.env.example` — the new variables, commented with their defaults.
- Tests: `CorsConfigTest` (defaults match the previously hardcoded behavior) and
  `CorsConfigOverrideTest` (`CORS_ALLOWED_ORIGINS` replaces the list for both
  consumers).

## Verification
- `./mvnw test` green after every commit (207 + 4 new tests)
- Defaults keep today's behavior — no compose change required for the running VM

Closes #309