### PR TITLE
feat: seed rooms from OCCUPI_SEED_ROOMS on startup #312

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- The backend seeds rooms at startup when `OCCUPI_SEED_ROOMS` is set
+  (`roomId:capacity` pairs, e.g. `006:20,011:15`): create-if-missing, existing rooms
+  are never touched, a malformed spec aborts startup with a message naming the bad
+  entry. Built for the upcoming one-command local stack, where the same value drives
+  the mock Pi fleet and the room seed; unset (the server case) the seeder is inert (#312).
 - Server-side demo data seed (`deploy/seed-demo-data.py`): drops and rewrites the
   InfluxDB `occupancy` table with eight weeks of 5-minute occupancy history — as
   backfill for the live demo rooms and shaped per dashboard edge case for the static

--- a/backend/src/main/java/com/occupi/feature/room/RoomSeeder.java
+++ b/backend/src/main/java/com/occupi/feature/room/RoomSeeder.java
@@ -1,0 +1,112 @@
+package com.occupi.feature.room;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Seeds rooms at startup from the {@code OCCUPI_SEED_ROOMS} environment variable
+ * ({@code roomId:capacity} pairs, comma-separated — e.g. {@code 006:20,011:15}).
+ *
+ * <p>Exists for the local docker stack: the compose file passes the mock fleet's
+ * room list into this variable, so a fresh clone shows every simulated room in the
+ * dashboard without anyone creating rooms by hand. Unset or empty (the server case)
+ * the seeder does nothing.</p>
+ *
+ * <p>Create-if-missing only: an existing room is never updated, otherwise every
+ * restart would revert capacity edits made in the admin panel. A capacity that
+ * diverges from the spec is logged instead. A malformed spec aborts startup —
+ * a silently half-seeded stack would defeat the zero-click purpose.</p>
+ */
+@Slf4j
+@Component
+public class RoomSeeder implements ApplicationRunner {
+
+    /** Same charset rule as the ingestion path uses for room ids. */
+    private static final String ROOM_ID_PATTERN = "[a-zA-Z0-9-]+";
+
+    private final RoomRepository roomRepository;
+    private final String seedSpec;
+
+    public RoomSeeder(RoomRepository roomRepository,
+                      @Value("${OCCUPI_SEED_ROOMS:}") String seedSpec) {
+        this.roomRepository = roomRepository;
+        this.seedSpec = seedSpec;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (seedSpec == null || seedSpec.isBlank()) {
+            return;
+        }
+        List<Room> seeds = parse(seedSpec);
+        for (Room seed : seeds) {
+            roomRepository.findById(seed.getRoomId()).ifPresentOrElse(
+                    existing -> {
+                        if (existing.getCapacity() != seed.getCapacity()) {
+                            log.info("Room '{}' already exists with capacity {} (seed says {}) — not changed",
+                                    existing.getRoomId(), existing.getCapacity(), seed.getCapacity());
+                        }
+                    },
+                    () -> {
+                        roomRepository.save(seed);
+                        log.info("Seeded room '{}' with capacity {}", seed.getRoomId(), seed.getCapacity());
+                    });
+        }
+        log.info("Room seed processed: {} entries from OCCUPI_SEED_ROOMS", seeds.size());
+    }
+
+    /**
+     * Parses the {@code roomId:capacity,...} spec. Any malformed entry throws with a
+     * message naming the entry, so the container log explains exactly what to fix.
+     */
+    static List<Room> parse(String spec) {
+        List<Room> rooms = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (String entry : spec.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.isEmpty()) {
+                throw new IllegalStateException(
+                        "OCCUPI_SEED_ROOMS: empty entry in '" + spec + "' — expected roomId:capacity,...");
+            }
+            String[] parts = trimmed.split(":");
+            if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+                throw new IllegalStateException(
+                        "OCCUPI_SEED_ROOMS: entry '" + trimmed + "' must be roomId:capacity");
+            }
+            String roomId = parts[0].trim();
+            if (!roomId.matches(ROOM_ID_PATTERN)) {
+                throw new IllegalStateException(
+                        "OCCUPI_SEED_ROOMS: room id '" + roomId + "' must match " + ROOM_ID_PATTERN);
+            }
+            int capacity;
+            try {
+                capacity = Integer.parseInt(parts[1].trim());
+            } catch (NumberFormatException e) {
+                throw new IllegalStateException(
+                        "OCCUPI_SEED_ROOMS: capacity in '" + trimmed + "' is not a number");
+            }
+            if (capacity <= 0) {
+                throw new IllegalStateException(
+                        "OCCUPI_SEED_ROOMS: capacity in '" + trimmed + "' must be positive");
+            }
+            if (!seen.add(roomId)) {
+                throw new IllegalStateException(
+                        "OCCUPI_SEED_ROOMS: room id '" + roomId + "' appears twice");
+            }
+            rooms.add(Room.builder()
+                    .roomId(roomId)
+                    .name(roomId)
+                    .capacity(capacity)
+                    .build());
+        }
+        return rooms;
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/room/RoomSeederIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/room/RoomSeederIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.occupi.feature.room;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Boots the full context with OCCUPI_SEED_ROOMS set and verifies the rooms exist
+ * afterwards — the zero-click path the local docker stack relies on.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@TestPropertySource(properties = "OCCUPI_SEED_ROOMS=006:20,011:15")
+@DisplayName("RoomSeeder — seeds rooms on startup (integration)")
+class RoomSeederIntegrationTest {
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Test
+    @DisplayName("configured rooms exist after startup with name = roomId")
+    void seedsConfiguredRooms() {
+        assertThat(roomRepository.findById("006")).hasValueSatisfying(room -> {
+            assertThat(room.getName()).isEqualTo("006");
+            assertThat(room.getCapacity()).isEqualTo(20);
+        });
+        assertThat(roomRepository.findById("011")).hasValueSatisfying(room ->
+                assertThat(room.getCapacity()).isEqualTo(15));
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/room/RoomSeederTest.java
+++ b/backend/src/test/java/com/occupi/feature/room/RoomSeederTest.java
@@ -1,0 +1,86 @@
+package com.occupi.feature.room;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RoomSeeder — OCCUPI_SEED_ROOMS parsing and create-if-missing")
+class RoomSeederTest {
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    @Test
+    @DisplayName("does nothing when the spec is empty")
+    void emptySpecIsInert() {
+        new RoomSeeder(roomRepository, "").run(null);
+        new RoomSeeder(roomRepository, "   ").run(null);
+
+        verifyNoInteractions(roomRepository);
+    }
+
+    @Test
+    @DisplayName("creates missing rooms with the room id as name")
+    void createsMissingRooms() {
+        when(roomRepository.findById("006")).thenReturn(Optional.empty());
+        when(roomRepository.findById("011")).thenReturn(Optional.empty());
+
+        new RoomSeeder(roomRepository, "006:20, 011:15").run(null);
+
+        verify(roomRepository).save(Room.builder().roomId("006").name("006").capacity(20).build());
+        verify(roomRepository).save(Room.builder().roomId("011").name("011").capacity(15).build());
+    }
+
+    @Test
+    @DisplayName("never updates an existing room, even when the capacity diverges")
+    void existingRoomIsLeftAlone() {
+        Room existing = Room.builder().roomId("006").name("Seminarraum 006").capacity(40).build();
+        when(roomRepository.findById("006")).thenReturn(Optional.of(existing));
+
+        new RoomSeeder(roomRepository, "006:20").run(null);
+
+        verify(roomRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("rejects malformed entries with a readable message")
+    void malformedSpecAbortsStartup() {
+        assertThatThrownBy(() -> new RoomSeeder(roomRepository, "006").run(null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("roomId:capacity");
+        assertThatThrownBy(() -> new RoomSeeder(roomRepository, "006:zwanzig").run(null))
+                .hasMessageContaining("not a number");
+        assertThatThrownBy(() -> new RoomSeeder(roomRepository, "006:0").run(null))
+                .hasMessageContaining("positive");
+        assertThatThrownBy(() -> new RoomSeeder(roomRepository, "raum_6:10").run(null))
+                .hasMessageContaining("must match");
+        assertThatThrownBy(() -> new RoomSeeder(roomRepository, "006:10,006:12").run(null))
+                .hasMessageContaining("twice");
+        assertThatThrownBy(() -> new RoomSeeder(roomRepository, "006:10,,011:5").run(null))
+                .hasMessageContaining("empty entry");
+
+        verify(roomRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("parser keeps the spec order")
+    void parserKeepsOrder() {
+        List<Room> rooms = RoomSeeder.parse("b:1,a:2");
+
+        assertThat(rooms).extracting(Room::getRoomId).containsExactly("b", "a");
+    }
+}


### PR DESCRIPTION
## Summary
The upcoming one-command local stack must show rooms with zero clicks. Today nothing
seeds rooms locally: the dashboard stays empty until someone creates them via the
admin panel, even while the mock sender is already writing occupancy for them. This
adds a startup seeder driven by one environment variable — the same value the local
compose will pass to both the mock fleet and the backend.

## Changes
- `RoomSeeder` (new, `feature/room/`) — `ApplicationRunner`, inert unless
  `OCCUPI_SEED_ROOMS` is set (`roomId:capacity,...`). Create-if-missing with
  name = roomId; an existing room is never updated (restarts must not revert admin
  edits — divergence is logged instead). A malformed spec aborts startup with a
  message naming the bad entry.
- Room id charset matches the ingestion path (`[a-zA-Z0-9-]+`); duplicates in the
  spec are rejected.
- Tests: `RoomSeederTest` (parsing, create-if-missing, never-update, all failure
  messages) and `RoomSeederIntegrationTest` (full context boot with the variable set,
  rooms exist afterwards).

## Verification
- `./mvnw test` green (7 new tests)
- Variable unset → no repository interaction (server behavior unchanged)

Closes #312