### PR TITLE
feat: sensor registry with claim and override room resolution #310

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- Sensor registry: every Pi that ever reported gets a row in the new Postgres
+  `sensors` table (device id, claimed room, admin override, last seen). The room id a
+  Pi sends is now a *claim* — it flows into exactly that room the moment a matching
+  room exists, with no admin step. An admin override corrects a wrong claim and
+  expires automatically when the Pi reports a new claim (a freshly edited Pi `.env`
+  wins over an old correction); an override is a real foreign key, so a room with
+  assigned sensors cannot be deleted. Data from an unresolved device (claim matches
+  no room) is no longer written under an invisible tag — the old silent-typo trap:
+  the points are dropped and counted, the device stays visible with `lastSeen` via
+  its metrics stream, and both the persisted point and the `/topic/occupancy`
+  broadcast always carry the *effective* room. Ingest ids are validated
+  (`[A-Za-z0-9._-]{1,64}`), auto-registration is capped
+  (`OCCUPI_SENSOR_AUTOREGISTER_CAP`, default 100) because `/ws` is unauthenticated,
+  and a registry outage drops single messages instead of killing the STOMP session (#310).
 - Server-side demo data seed (`deploy/seed-demo-data.py`): drops and rewrites the
   InfluxDB `occupancy` table with eight weeks of 5-minute occupancy history — as
   backfill for the live demo rooms and shaped per dashboard edge case for the static

--- a/backend/src/main/java/com/occupi/feature/metrics/PiMetricsServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/metrics/PiMetricsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.occupi.feature.metrics;
 
 import com.occupi.feature.metrics.dto.Metrics;
+import com.occupi.feature.sensor.SensorRegistryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,10 +23,15 @@ import org.springframework.stereotype.Service;
 public class PiMetricsServiceImpl implements PiMetricsService {
 
     private final MetricsService metricsService;
+    private final SensorRegistryService sensorRegistry;
 
     /**
      * Processes incoming Pi metrics by mapping them to a metrics record
      * and persisting it to the database.
+     *
+     * The metrics stream also feeds the sensor registry: a freshly connected Pi
+     * shows up in the admin panel with a live "last seen" before it ever sends
+     * occupancy, and regardless of whether its room claim resolves.
      *
      * @param metrics the Pi metrics received via STOMP
      *                If null, the data is silently ignored.
@@ -36,6 +42,11 @@ public class PiMetricsServiceImpl implements PiMetricsService {
             log.warn("Received null PiMetrics, ignoring");
             return;
         }
+        if (!SensorRegistryService.isValidSensorId(metrics.sensorId())) {
+            log.warn("Rejected Pi metrics with invalid sensorId '{}'", metrics.sensorId());
+            return;
+        }
+        sensorRegistry.touch(metrics.sensorId());
 
         try {
             MetricsData metricsData = mapToMetricsData(metrics);

--- a/backend/src/main/java/com/occupi/feature/occupancy/SensorDataServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/occupancy/SensorDataServiceImpl.java
@@ -1,21 +1,26 @@
 package com.occupi.feature.occupancy;
 
 import com.occupi.feature.occupancy.dto.SensorData;
+import com.occupi.feature.sensor.SensorRegistryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 /**
  * Implementation of {@link SensorDataService}.
  *
- * Transforms incoming sensor data from the Raspberry Pi into occupancy records
- * and persists them.
+ * The payload's {@code roomId} is a <em>claim</em> from the Pi's .env, not the
+ * truth: the {@link SensorRegistryService} resolves the effective room (an admin
+ * override wins over the claim). Both the persisted point and the dashboard
+ * broadcast carry the effective room — a corrected device must never live-update
+ * the wrong tile while writing to the right one.
  *
- * Responsibilities:
- * - Map {@link SensorData} (ingestion DTO) to {@link OccupancyData} (persistence model)
- * - Delegate persistence to {@link OccupancyService}
- * - Handle null or invalid input gracefully
+ * Unresolved devices (claim matches no room, no override) are dropped point by
+ * point, counted, and stay visible through the registry — the silent-typo case
+ * this replaces used to write invisible data forever.
  */
 @Slf4j
 @Service
@@ -24,13 +29,15 @@ public class SensorDataServiceImpl implements SensorDataService {
 
     private final OccupancyService occupancyService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final SensorRegistryService sensorRegistry;
 
     /**
-     * Processes incoming sensor data by mapping it to an occupancy record
-     * and persisting it to the database.
+     * Processes one occupancy message: validate, resolve the room, persist and
+     * broadcast. Never throws — a bad message or a registry hiccup must not take
+     * down the STOMP session shared with every other Pi.
      *
-     * @param data the sensor data received from the mmWave sensor via STOMP
-     *             If null, the data is silently ignored.
+     * @param data the sensor data received from the mmWave sensor via STOMP;
+     *             null is ignored
      */
     @Override
     public void process(SensorData data) {
@@ -38,35 +45,41 @@ public class SensorDataServiceImpl implements SensorDataService {
             log.warn("Received null SensorData, ignoring");
             return;
         }
+        if (!SensorRegistryService.isValidSensorId(data.sensorId())
+                || !SensorRegistryService.isValidRoomId(data.roomId())) {
+            log.warn("Rejected sensor data with invalid ids: sensorId='{}', roomId='{}'",
+                    data.sensorId(), data.roomId());
+            return;
+        }
+
+        Optional<String> effectiveRoom = sensorRegistry.resolveEffectiveRoom(data.sensorId(), data.roomId());
+        if (effectiveRoom.isEmpty()) {
+            sensorRegistry.recordDroppedPoint(data.sensorId());
+            return;
+        }
 
         try {
-            OccupancyData occupancyData = mapToOccupancyData(data);
+            occupancyService.recordOccupancy(mapToOccupancyData(data, effectiveRoom.get()));
 
-            occupancyService.recordOccupancy(occupancyData);
-
-            messagingTemplate.convertAndSend("/topic/occupancy", data);
+            SensorData broadcast = new SensorData(effectiveRoom.get(), data.sensorId(),
+                    data.count(), data.confidence(), data.timestamp());
+            messagingTemplate.convertAndSend("/topic/occupancy", broadcast);
 
             log.debug("Successfully processed sensor data: room={}, sensor={}, count={}",
-                    data.roomId(), data.sensorId(), data.count());
+                    effectiveRoom.get(), data.sensorId(), data.count());
         } catch (Exception e) {
             log.error("Error processing sensor data for room={}, sensor={}",
-                    data.roomId(), data.sensorId(), e);
-            throw e;
+                    effectiveRoom.get(), data.sensorId(), e);
         }
     }
 
     /**
-     * Maps a {@link SensorData} (ingestion DTO) to {@link OccupancyData} (persistence model).
-     *
-     * All fields are copied directly as the two models share the same structure.
-     * The mapping is kept simple and explicit to avoid over-engineering.
-     *
-     * @param sensorData the sensor data to map
-     * @return the mapped occupancy data ready for persistence
+     * Maps a {@link SensorData} (ingestion DTO) to {@link OccupancyData} (persistence
+     * model), stamping the resolved room instead of the raw claim.
      */
-    private OccupancyData mapToOccupancyData(SensorData sensorData) {
+    private OccupancyData mapToOccupancyData(SensorData sensorData, String effectiveRoomId) {
         return OccupancyData.builder()
-                .roomId(sensorData.roomId())
+                .roomId(effectiveRoomId)
                 .sensorId(sensorData.sensorId())
                 .count(sensorData.count())
                 .confidence(sensorData.confidence())

--- a/backend/src/main/java/com/occupi/feature/sensor/Sensor.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/Sensor.java
@@ -1,0 +1,74 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.room.Room;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.Instant;
+
+/**
+ * Registry entry for a Raspberry Pi (one Pi = one radar = one room), persisted in
+ * PostgreSQL. Every device that ever reported over STOMP gets a row here, so the
+ * admin panel can see and correct it — including devices whose claimed room id
+ * matches nothing (the case that used to fail silently).
+ *
+ * Room resolution: {@code overrideRoom} wins if set; otherwise the claim counts,
+ * provided a room with that id exists. The override remembers the claim it
+ * corrected ({@code claimedAtOverride}) — a NEW claim voids the override, because a
+ * freshly edited Pi .env is newer operator intent than an old correction.
+ */
+@Entity
+@Table(name = "sensors")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Sensor {
+
+    /** Stable device identity (SENSOR_ID in the Pi's .env), e.g. "pi-bibliothek". */
+    @Id
+    @Column(name = "sensor_id", nullable = false, updatable = false)
+    private String sensorId;
+
+    /**
+     * Last room id the device claimed via its .env (ROOM_ID). A plain string on
+     * purpose: claims may reference rooms that do not exist (yet) — that is exactly
+     * the error case the registry makes visible.
+     */
+    @Column(name = "claimed_room_id")
+    private String claimedRoomId;
+
+    /**
+     * Admin-set correction, as a real foreign key: a room that still has overrides
+     * pointing at it cannot be deleted (RESTRICT), so a dangling override is
+     * impossible by construction instead of being a runtime branch.
+     */
+    @ManyToOne
+    @JoinColumn(name = "override_room_id")
+    @ToString.Exclude
+    @EqualsAndHashCode.Exclude
+    private Room overrideRoom;
+
+    /** The claim that was current when the override was set — a different, new claim voids it. */
+    @Column(name = "claimed_at_override")
+    private String claimedAtOverride;
+
+    /** Optional display name for the admin panel. */
+    private String name;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "last_seen_at")
+    private Instant lastSeenAt;
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorRegistryService.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorRegistryService.java
@@ -1,0 +1,61 @@
+package com.occupi.feature.sensor;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Resolves which room a reporting Pi belongs to and keeps the registry current.
+ *
+ * Resolution order: admin override, else the device's claimed room id when a room
+ * with that id exists, else empty ("unresolved"). Callers on the ingest path must
+ * treat empty as "drop the point, keep the device visible".
+ */
+public interface SensorRegistryService {
+
+    /** Device ids as they appear in Pi configs: pi-bibliothek, sensor-01, mock-pi-006. */
+    Pattern SENSOR_ID_PATTERN = Pattern.compile("[A-Za-z0-9._-]{1,64}");
+
+    /** Room ids follow the ingest/repository rule established for Influx tags. */
+    Pattern ROOM_ID_PATTERN = Pattern.compile("[a-zA-Z0-9-]{1,64}");
+
+    static boolean isValidSensorId(String id) {
+        return id != null && SENSOR_ID_PATTERN.matcher(id).matches();
+    }
+
+    static boolean isValidRoomId(String id) {
+        return id != null && ROOM_ID_PATTERN.matcher(id).matches();
+    }
+
+    /**
+     * Resolves the effective room for a message, updating the registry as a side
+     * effect: unknown devices are auto-registered (up to a cap), a changed claim is
+     * stored, and an override whose corrected claim changed expires. Fails closed —
+     * a registry/database problem yields empty for this message instead of throwing.
+     *
+     * @return the effective room id, or empty when the device is unresolved
+     */
+    Optional<String> resolveEffectiveRoom(String sensorId, String claimedRoomId);
+
+    /**
+     * Marks a device as alive without a room claim — the metrics path. Registers
+     * the device if unknown so a freshly connected Pi is visible in the admin panel
+     * before it ever sends occupancy.
+     */
+    void touch(String sensorId);
+
+    /** Counts an occupancy point dropped because the device is unresolved. */
+    void recordDroppedPoint(String sensorId);
+
+    /** Dropped-point info for the admin panel, empty when nothing was dropped. */
+    Optional<DropInfo> droppedInfo(String sensorId);
+
+    /** Evicts one device from the resolution cache (assignment changed). */
+    void invalidate(String sensorId);
+
+    /** Evicts everything — rooms were created or deleted, claims may resolve differently now. */
+    void invalidateAll();
+
+    record DropInfo(long count, Instant since) {
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorRegistryServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorRegistryServiceImpl.java
@@ -1,0 +1,241 @@
+package com.occupi.feature.sensor;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.occupi.feature.room.RoomRepository;
+import jakarta.annotation.PreDestroy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Default {@link SensorRegistryService} implementation.
+ *
+ * Hot path: one Caffeine lookup per message. The cache entry remembers the claim it
+ * was computed for, so a Pi restart (same claim) never touches the database; only a
+ * changed claim, a cache miss or an explicit invalidation goes to Postgres. The
+ * short TTL is a backstop — every user-visible change (assignment, room CRUD)
+ * invalidates explicitly.
+ *
+ * last-seen updates are buffered in memory and flushed on a schedule, the same
+ * decoupling the occupancy write buffer uses: at one message per second per Pi,
+ * writing the timestamp per message would hammer Postgres for no benefit.
+ */
+@Slf4j
+@Service
+public class SensorRegistryServiceImpl implements SensorRegistryService {
+
+    /** One warning per device per interval — ingest runs at ~1 msg/s per Pi. */
+    private static final Duration WARN_INTERVAL = Duration.ofMinutes(1);
+
+    private final SensorRepository sensorRepository;
+    private final RoomRepository roomRepository;
+
+    /** Refuse auto-registration beyond this many devices — /ws is unauthenticated (#322). */
+    private final long autoRegisterCap;
+
+    private final Cache<String, CachedResolution> resolutions;
+    private final ConcurrentHashMap<String, Instant> pendingSeen = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, DropCounter> drops = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Instant> lastWarnAt = new ConcurrentHashMap<>();
+
+    /** claim the entry was computed for + the effective room (null = unresolved). */
+    private record CachedResolution(String claimedRoomId, String effectiveRoomId) {
+    }
+
+    private record DropCounter(AtomicLong count, Instant since) {
+    }
+
+    public SensorRegistryServiceImpl(SensorRepository sensorRepository,
+                                     RoomRepository roomRepository,
+                                     @Value("${OCCUPI_SENSOR_AUTOREGISTER_CAP:100}") long autoRegisterCap,
+                                     @Value("${OCCUPI_SENSOR_CACHE_TTL_SECONDS:60}") long cacheTtlSeconds) {
+        this.sensorRepository = sensorRepository;
+        this.roomRepository = roomRepository;
+        this.autoRegisterCap = autoRegisterCap;
+        this.resolutions = Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(cacheTtlSeconds))
+                .maximumSize(10_000)
+                .build();
+    }
+
+    @Override
+    public Optional<String> resolveEffectiveRoom(String sensorId, String claimedRoomId) {
+        CachedResolution cached = resolutions.getIfPresent(sensorId);
+        if (cached != null && Objects.equals(cached.claimedRoomId(), claimedRoomId)) {
+            pendingSeen.put(sensorId, Instant.now());
+            return Optional.ofNullable(cached.effectiveRoomId());
+        }
+        try {
+            CachedResolution fresh = resolveAgainstDatabase(sensorId, claimedRoomId);
+            resolutions.put(sensorId, fresh);
+            pendingSeen.put(sensorId, Instant.now());
+            if (fresh.effectiveRoomId() != null) {
+                drops.remove(sensorId);
+            }
+            return Optional.ofNullable(fresh.effectiveRoomId());
+        } catch (DataAccessException e) {
+            // Fail closed: this message counts as unresolved, the STOMP handler
+            // must survive a registry hiccup. Nothing is cached so the next
+            // message retries.
+            warnRateLimited(sensorId, "sensor registry unavailable ({}) — treating '{}' as unresolved",
+                    e.getMessage(), sensorId);
+            return Optional.empty();
+        }
+    }
+
+    private CachedResolution resolveAgainstDatabase(String sensorId, String claimedRoomId) {
+        Sensor sensor = sensorRepository.findById(sensorId).orElse(null);
+
+        if (sensor == null) {
+            if (sensorRepository.count() >= autoRegisterCap) {
+                warnRateLimited(sensorId,
+                        "refusing to auto-register '{}': registry already holds {} devices "
+                                + "(cap OCCUPI_SENSOR_AUTOREGISTER_CAP) — data is dropped",
+                        sensorId, autoRegisterCap);
+                return new CachedResolution(claimedRoomId, null);
+            }
+            sensor = Sensor.builder()
+                    .sensorId(sensorId)
+                    .claimedRoomId(claimedRoomId)
+                    .createdAt(Instant.now())
+                    .lastSeenAt(Instant.now())
+                    .build();
+            try {
+                sensorRepository.saveAndFlush(sensor);
+                log.info("Auto-registered sensor '{}' claiming room '{}'", sensorId, claimedRoomId);
+            } catch (DataIntegrityViolationException race) {
+                // Two ingest threads saw the same unknown device — the other insert won.
+                sensor = sensorRepository.findById(sensorId).orElseThrow(() -> race);
+            }
+        } else if (!Objects.equals(claimedRoomId, sensor.getClaimedRoomId())) {
+            sensor.setClaimedRoomId(claimedRoomId);
+            if (sensor.getOverrideRoom() != null
+                    && !Objects.equals(claimedRoomId, sensor.getClaimedAtOverride())) {
+                // The .env was edited since the admin corrected the old claim: fresh
+                // operator intent wins, the stale correction expires.
+                log.info("Sensor '{}': new claim '{}' voids the admin override to '{}'",
+                        sensorId, claimedRoomId, sensor.getOverrideRoom().getRoomId());
+                sensor.setOverrideRoom(null);
+                sensor.setClaimedAtOverride(null);
+            }
+            sensorRepository.save(sensor);
+        }
+
+        String effective;
+        if (sensor.getOverrideRoom() != null) {
+            effective = sensor.getOverrideRoom().getRoomId();
+        } else if (claimedRoomId != null && roomRepository.existsById(claimedRoomId)) {
+            effective = claimedRoomId;
+        } else {
+            effective = null;
+            warnRateLimited(sensorId,
+                    "sensor '{}' claims unknown room '{}' — occupancy is dropped until the room "
+                            + "exists or an admin assigns one", sensorId, claimedRoomId);
+        }
+        return new CachedResolution(claimedRoomId, effective);
+    }
+
+    @Override
+    public void touch(String sensorId) {
+        Instant now = Instant.now();
+        pendingSeen.put(sensorId, now);
+        if (resolutions.getIfPresent(sensorId) != null) {
+            return;
+        }
+        try {
+            if (sensorRepository.existsById(sensorId)) {
+                return;
+            }
+            if (sensorRepository.count() >= autoRegisterCap) {
+                warnRateLimited(sensorId, "refusing to auto-register '{}' from metrics: cap reached", sensorId);
+                return;
+            }
+            sensorRepository.saveAndFlush(Sensor.builder()
+                    .sensorId(sensorId)
+                    .createdAt(now)
+                    .lastSeenAt(now)
+                    .build());
+            log.info("Auto-registered sensor '{}' from its metrics stream (no room claim yet)", sensorId);
+        } catch (DataIntegrityViolationException race) {
+            // Already registered by a parallel message — exactly what we wanted.
+        } catch (DataAccessException e) {
+            warnRateLimited(sensorId, "sensor registry unavailable for touch of '{}': {}", sensorId, e.getMessage());
+        }
+    }
+
+    @Override
+    public void recordDroppedPoint(String sensorId) {
+        drops.computeIfAbsent(sensorId, id -> new DropCounter(new AtomicLong(), Instant.now()))
+                .count().incrementAndGet();
+    }
+
+    @Override
+    public Optional<DropInfo> droppedInfo(String sensorId) {
+        return Optional.ofNullable(drops.get(sensorId))
+                .map(counter -> new DropInfo(counter.count().get(), counter.since()));
+    }
+
+    @Override
+    public void invalidate(String sensorId) {
+        resolutions.invalidate(sensorId);
+    }
+
+    @Override
+    public void invalidateAll() {
+        resolutions.invalidateAll();
+    }
+
+    /**
+     * Writes the buffered last-seen timestamps. Failures stay local: the next flush
+     * retries with fresher timestamps anyway.
+     */
+    @Transactional
+    @Scheduled(fixedDelayString = "${OCCUPI_SENSOR_SEEN_FLUSH_MS:60000}",
+            initialDelayString = "${OCCUPI_SENSOR_SEEN_FLUSH_MS:60000}")
+    public void flushLastSeen() {
+        if (pendingSeen.isEmpty()) {
+            return;
+        }
+        Map<String, Instant> batch = new HashMap<>();
+        pendingSeen.forEach((id, ts) -> {
+            Instant pending = pendingSeen.remove(id);
+            if (pending != null) {
+                batch.put(id, pending);
+            }
+        });
+        try {
+            batch.forEach(sensorRepository::updateLastSeen);
+            log.debug("Flushed last-seen for {} sensors", batch.size());
+        } catch (DataAccessException e) {
+            log.warn("last-seen flush failed for {} sensors: {}", batch.size(), e.getMessage());
+        }
+    }
+
+    @PreDestroy
+    void flushOnShutdown() {
+        flushLastSeen();
+    }
+
+    private void warnRateLimited(String sensorId, String message, Object... args) {
+        Instant now = Instant.now();
+        Instant last = lastWarnAt.get(sensorId);
+        if (last == null || Duration.between(last, now).compareTo(WARN_INTERVAL) >= 0) {
+            lastWarnAt.put(sensorId, now);
+            log.warn(message, args);
+        }
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorRegistryServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorRegistryServiceImpl.java
@@ -26,9 +26,11 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * Hot path: one Caffeine lookup per message. The cache entry remembers the claim it
  * was computed for, so a Pi restart (same claim) never touches the database; only a
- * changed claim, a cache miss or an explicit invalidation goes to Postgres. The
- * short TTL is a backstop — every user-visible change (assignment, room CRUD)
- * invalidates explicitly.
+ * changed claim, a cache miss or an explicit invalidation goes to Postgres.
+ * Unresolved devices are never cached: the error case stays cheap (one lookup per
+ * second per misconfigured Pi) and heals on the next message once the room exists
+ * or an admin assigns one. Deleting a room can leave a resolved entry stale for at
+ * most the cache TTL — the documented backstop.
  *
  * last-seen updates are buffered in memory and flushed on a schedule, the same
  * decoupling the occupancy write buffer uses: at one message per second per Pi,
@@ -81,11 +83,15 @@ public class SensorRegistryServiceImpl implements SensorRegistryService {
         }
         try {
             CachedResolution fresh = resolveAgainstDatabase(sensorId, claimedRoomId);
-            resolutions.put(sensorId, fresh);
-            pendingSeen.put(sensorId, Instant.now());
+            // Only resolved devices are cached. An unresolved device re-checks the
+            // database on every message (~1/s), so creating the missing room or
+            // assigning one takes effect on the very next message — no invalidation
+            // hooks in the room feature needed.
             if (fresh.effectiveRoomId() != null) {
+                resolutions.put(sensorId, fresh);
                 drops.remove(sensorId);
             }
+            pendingSeen.put(sensorId, Instant.now());
             return Optional.ofNullable(fresh.effectiveRoomId());
         } catch (DataAccessException e) {
             // Fail closed: this message counts as unresolved, the STOMP handler

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorRepository.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorRepository.java
@@ -1,0 +1,24 @@
+package com.occupi.feature.sensor;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface SensorRepository extends JpaRepository<Sensor, String> {
+
+    /** Sensors whose override points at the given room — blocks that room's deletion. */
+    @Query("select s from Sensor s where s.overrideRoom.roomId = :roomId")
+    List<Sensor> findByOverrideRoomId(@Param("roomId") String roomId);
+
+    /**
+     * Direct column update for the buffered last-seen flush: no entity load, no
+     * optimistic clashes with concurrent claim updates from the ingest path.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("update Sensor s set s.lastSeenAt = :ts where s.sensorId = :id")
+    int updateLastSeen(@Param("id") String sensorId, @Param("ts") Instant lastSeenAt);
+}

--- a/backend/src/test/java/com/occupi/feature/metrics/PiMetricsServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/metrics/PiMetricsServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.occupi.feature.metrics;
 
 import com.occupi.feature.metrics.dto.Metrics;
+import com.occupi.feature.sensor.SensorRegistryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +23,9 @@ class PiMetricsServiceImplTest {
 
     @Mock
     private MetricsService metricsService;
+
+    @Mock
+    private SensorRegistryService sensorRegistry;
 
     @InjectMocks
     private PiMetricsServiceImpl service;
@@ -55,7 +59,25 @@ class PiMetricsServiceImplTest {
     void process_null_ignored() {
         service.process(null);
 
-        verifyNoInteractions(metricsService);
+        verifyNoInteractions(metricsService, sensorRegistry);
+    }
+
+    @Test
+    @DisplayName("registers the device in the sensor registry on every snapshot")
+    void process_touchesRegistry() {
+        service.process(sample());
+
+        verify(sensorRegistry).touch("sensor-A");
+    }
+
+    @Test
+    @DisplayName("rejects an invalid sensorId before registry and persistence")
+    void process_invalidSensorIdRejected() {
+        Metrics invalid = new Metrics("bad sensor!", 42.0, 60.0, 3, 100, 1, 12.5f, Instant.now());
+
+        service.process(invalid);
+
+        verifyNoInteractions(metricsService, sensorRegistry);
     }
 
     @Test

--- a/backend/src/test/java/com/occupi/feature/occupancy/SensorDataServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/occupancy/SensorDataServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.occupi.feature.occupancy;
 
 import com.occupi.feature.occupancy.dto.SensorData;
+import com.occupi.feature.sensor.SensorRegistryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,17 +13,24 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link SensorDataServiceImpl}.
- *
- * Tests the mapping of {@link SensorData} to {@link OccupancyData}
- * and delegation to {@link OccupancyService}.
+ * Unit tests for {@link SensorDataServiceImpl}: room resolution through the sensor
+ * registry, effective-room rewriting for both the persisted point and the
+ * broadcast, dropping of unresolved devices, and fail-closed error handling.
  */
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SensorDataServiceImpl Tests")
@@ -34,205 +42,132 @@ class SensorDataServiceImplTest {
     @Mock
     private SimpMessagingTemplate messagingTemplate;
 
+    @Mock
+    private SensorRegistryService sensorRegistry;
+
     private SensorDataServiceImpl sensorDataService;
 
     @BeforeEach
     void setUp() {
-        sensorDataService = new SensorDataServiceImpl(occupancyService, messagingTemplate);
+        sensorDataService = new SensorDataServiceImpl(occupancyService, messagingTemplate, sensorRegistry);
+    }
+
+    private void claimResolves(String sensorId, String claim, String effective) {
+        when(sensorRegistry.resolveEffectiveRoom(sensorId, claim)).thenReturn(Optional.ofNullable(effective));
     }
 
     @Test
-    @DisplayName("Should map all SensorData fields to OccupancyData correctly")
-    void testMappingAllFields() {
-        // Arrange
+    @DisplayName("maps all fields and stamps the resolved room")
+    void mapsAllFieldsWithResolvedRoom() {
         Instant timestamp = Instant.parse("2024-01-15T10:30:00Z");
-        SensorData sensorData = new SensorData(
-                "seminar-101",
-                "sensor-A",
-                5,
-                0.95,
-                timestamp
-        );
+        SensorData sensorData = new SensorData("seminar-101", "sensor-A", 5, 0.95, timestamp);
+        claimResolves("sensor-A", "seminar-101", "seminar-101");
 
-        // Act
         sensorDataService.process(sensorData);
 
-        // Assert
         ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
         verify(occupancyService).recordOccupancy(captor.capture());
-
-        OccupancyData captured = captor.getValue();
-        assertThat(captured)
-                .extracting(
-                        OccupancyData::getRoomId,
-                        OccupancyData::getSensorId,
-                        OccupancyData::getCount,
-                        OccupancyData::getConfidence,
-                        OccupancyData::getTimestamp
-                )
-                .containsExactly(
-                        "seminar-101",
-                        "sensor-A",
-                        5,
-                        0.95,
-                        timestamp
-                );
+        assertThat(captor.getValue())
+                .extracting(OccupancyData::getRoomId, OccupancyData::getSensorId,
+                        OccupancyData::getCount, OccupancyData::getConfidence, OccupancyData::getTimestamp)
+                .containsExactly("seminar-101", "sensor-A", 5, 0.95, timestamp);
     }
 
     @Test
-    @DisplayName("Should delegate to OccupancyService.recordOccupancy()")
-    void testDelegationToOccupancyService() {
-        // Arrange
-        SensorData sensorData = new SensorData(
-                "room-202",
-                "sensor-B",
-                8,
-                0.87,
-                Instant.now()
-        );
+    @DisplayName("an admin override wins: write AND broadcast carry the effective room")
+    void overrideRewritesWriteAndBroadcast() {
+        Instant timestamp = Instant.now();
+        SensorData sensorData = new SensorData("claimed-room", "sensor-A", 7, 0.9, timestamp);
+        claimResolves("sensor-A", "claimed-room", "corrected-room");
 
-        // Act
         sensorDataService.process(sensorData);
 
-        // Assert
-        verify(occupancyService).recordOccupancy(any(OccupancyData.class));
+        ArgumentCaptor<OccupancyData> written = ArgumentCaptor.forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(written.capture());
+        assertThat(written.getValue().getRoomId()).isEqualTo("corrected-room");
+
+        SensorData expectedBroadcast = new SensorData("corrected-room", "sensor-A", 7, 0.9, timestamp);
+        verify(messagingTemplate).convertAndSend("/topic/occupancy", expectedBroadcast);
     }
 
     @Test
-    @DisplayName("Should handle null SensorData gracefully")
-    void testHandleNullSensorData() {
-        // Act
+    @DisplayName("unresolved device: no write, no broadcast, dropped point is counted")
+    void unresolvedDeviceIsDroppedVisibly() {
+        SensorData sensorData = new SensorData("nope-999", "sensor-A", 3, 0.9, Instant.now());
+        claimResolves("sensor-A", "nope-999", null);
+
+        sensorDataService.process(sensorData);
+
+        verify(sensorRegistry).recordDroppedPoint("sensor-A");
+        verifyNoInteractions(occupancyService);
+        verifyNoInteractions(messagingTemplate);
+    }
+
+    @Test
+    @DisplayName("null payload is ignored")
+    void nullPayloadIsIgnored() {
         sensorDataService.process(null);
 
-        // Assert
-        verify(occupancyService, never()).recordOccupancy(any());
+        verifyNoInteractions(occupancyService, messagingTemplate, sensorRegistry);
     }
 
     @Test
-    @DisplayName("Should propagate exceptions from OccupancyService")
-    void testExceptionPropagation() {
-        // Arrange
-        SensorData sensorData = new SensorData(
-                "room-101",
-                "sensor-A",
-                3,
-                0.92,
-                Instant.now()
-        );
-        org.mockito.Mockito.doThrow(new RuntimeException("Database connection failed"))
-                .when(occupancyService).recordOccupancy(any());
+    @DisplayName("invalid ids are rejected before touching the registry")
+    void invalidIdsAreRejected() {
+        sensorDataService.process(new SensorData("room 1; drop", "sensor-A", 1, 0.9, Instant.now()));
+        sensorDataService.process(new SensorData("room-1", "bad sensor!", 1, 0.9, Instant.now()));
+        sensorDataService.process(new SensorData(null, "sensor-A", 1, 0.9, Instant.now()));
 
-        // Act & Assert
-        assertThatThrownBy(() -> sensorDataService.process(sensorData))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("Database connection failed");
+        verifyNoInteractions(occupancyService, messagingTemplate, sensorRegistry);
     }
 
     @Test
-    @DisplayName("Should handle edge case: confidence at boundaries")
-    void testConfidenceBoundaryValues() {
-        // Arrange - Test confidence = 0.0
-        SensorData lowConfidence = new SensorData(
-                "room-101",
-                "sensor-A",
-                0,
-                0.0,
-                Instant.now()
-        );
+    @DisplayName("fail-closed: downstream exceptions are logged, never rethrown")
+    void downstreamExceptionsAreNotRethrown() {
+        SensorData sensorData = new SensorData("room-101", "sensor-A", 3, 0.92, Instant.now());
+        claimResolves("sensor-A", "room-101", "room-101");
+        doThrow(new RuntimeException("broker down")).when(occupancyService).recordOccupancy(any());
 
-        // Act
-        sensorDataService.process(lowConfidence);
+        assertThatCode(() -> sensorDataService.process(sensorData)).doesNotThrowAnyException();
+    }
 
-        // Assert
+    @Test
+    @DisplayName("boundary values pass through unchanged (count 0, confidence 0.0 and 1.0)")
+    void boundaryValuesPassThrough() {
+        claimResolves("sensor-A", "room-101", "room-101");
+
+        sensorDataService.process(new SensorData("room-101", "sensor-A", 0, 0.0, Instant.now()));
+
         ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
         verify(occupancyService).recordOccupancy(captor.capture());
-        assertThat(captor.getValue().getConfidence()).isEqualTo(0.0);
-
-        // Arrange - Test confidence = 1.0
-        org.mockito.Mockito.reset(occupancyService);
-        SensorData highConfidence = new SensorData(
-                "room-101",
-                "sensor-A",
-                10,
-                1.0,
-                Instant.now()
-        );
-
-        // Act
-        sensorDataService.process(highConfidence);
-
-        // Assert
-        verify(occupancyService).recordOccupancy(captor.capture());
-        assertThat(captor.getValue().getConfidence()).isEqualTo(1.0);
+        assertThat(captor.getValue().getCount()).isZero();
+        assertThat(captor.getValue().getConfidence()).isZero();
     }
 
     @Test
-    @DisplayName("Should handle edge case: zero count")
-    void testZeroCountScenario() {
-        // Arrange
-        SensorData sensorData = new SensorData(
-                "room-101",
-                "sensor-A",
-                0,
-                0.85,
-                Instant.now()
-        );
-
-        // Act
-        sensorDataService.process(sensorData);
-
-        // Assert
-        ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
-        verify(occupancyService).recordOccupancy(captor.capture());
-        assertThat(captor.getValue().getCount()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("Should handle edge case: large count values")
-    void testLargeCountScenario() {
-        // Arrange
-        SensorData sensorData = new SensorData(
-                "auditorium-001",
-                "sensor-master",
-                1000,
-                0.99,
-                Instant.now()
-        );
-
-        // Act
-        sensorDataService.process(sensorData);
-
-        // Assert
-        ArgumentCaptor<OccupancyData> captor = ArgumentCaptor.forClass(OccupancyData.class);
-        verify(occupancyService).recordOccupancy(captor.capture());
-        assertThat(captor.getValue().getCount()).isEqualTo(1000);
-    }
-
-    @Test
-    @DisplayName("Should handle multiple consecutive calls")
-    void testMultipleConsecutiveCalls() {
-        // Arrange
-        SensorData data1 = new SensorData("room-101", "sensor-A", 5, 0.9, Instant.now());
-        SensorData data2 = new SensorData("room-102", "sensor-B", 3, 0.85, Instant.now());
-
-        // Act
-        sensorDataService.process(data1);
-        sensorDataService.process(data2);
-
-        // Assert
-        verify(occupancyService, org.mockito.Mockito.times(2))
-                .recordOccupancy(any());
-    }
-
-    @Test
-    @DisplayName("Should broadcast sensor data to /topic/occupancy after persistence")
-    void testBroadcastAfterPersistence() {
-        SensorData data = new SensorData("room-101", "sensor-A", 5, 0.95, Instant.now());
+    @DisplayName("broadcast happens after persistence, on /topic/occupancy")
+    void broadcastAfterPersistence() {
+        Instant timestamp = Instant.now();
+        SensorData data = new SensorData("room-101", "sensor-A", 5, 0.95, timestamp);
+        claimResolves("sensor-A", "room-101", "room-101");
 
         sensorDataService.process(data);
 
         InOrder inOrder = inOrder(occupancyService, messagingTemplate);
         inOrder.verify(occupancyService).recordOccupancy(any(OccupancyData.class));
-        inOrder.verify(messagingTemplate).convertAndSend("/topic/occupancy", data);
+        inOrder.verify(messagingTemplate).convertAndSend(eq("/topic/occupancy"), eq(data));
+    }
+
+    @Test
+    @DisplayName("consecutive messages from different devices are processed independently")
+    void multipleConsecutiveCalls() {
+        claimResolves("sensor-A", "room-101", "room-101");
+        claimResolves("sensor-B", "room-102", "room-102");
+
+        sensorDataService.process(new SensorData("room-101", "sensor-A", 5, 0.9, Instant.now()));
+        sensorDataService.process(new SensorData("room-102", "sensor-B", 3, 0.85, Instant.now()));
+
+        verify(occupancyService, org.mockito.Mockito.times(2)).recordOccupancy(any());
+        verify(sensorRegistry, never()).recordDroppedPoint(anyString());
     }
 }

--- a/backend/src/test/java/com/occupi/feature/sensor/SensorRegistryIngestIntegrationTest.java
+++ b/backend/src/test/java/com/occupi/feature/sensor/SensorRegistryIngestIntegrationTest.java
@@ -1,0 +1,180 @@
+package com.occupi.feature.sensor;
+
+import com.influxdb.v3.client.InfluxDBClient;
+import com.occupi.feature.occupancy.OccupancyData;
+import com.occupi.feature.occupancy.OccupancyService;
+import com.occupi.feature.occupancy.SensorDataService;
+import com.occupi.feature.occupancy.dto.SensorData;
+import com.occupi.feature.room.Room;
+import com.occupi.feature.room.RoomRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.mockito.ArgumentCaptor;
+
+/**
+ * End-to-end through the real service wiring (ingest service, registry, H2):
+ * the claim path, an admin override taking effect mid-stream, the override
+ * expiring on a fresh claim, and the wrong-id case staying visible instead of
+ * silently writing. Only the Influx write and the broker are mocked.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("Sensor registry ingest (integration, H2)")
+class SensorRegistryIngestIntegrationTest {
+
+    @Autowired
+    private SensorDataService sensorDataService;
+
+    @Autowired
+    private SensorRepository sensorRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private SensorRegistryService sensorRegistry;
+
+    @MockitoBean
+    private OccupancyService occupancyService;
+
+    @MockitoBean
+    private SimpMessagingTemplate messagingTemplate;
+
+    // Never let the context talk to a real InfluxDB in tests.
+    @MockitoBean
+    private InfluxDBClient influxDBClient;
+
+    private Room room(String id) {
+        return Room.builder().roomId(id).name("Raum " + id).capacity(20).build();
+    }
+
+    private SensorData message(String claim, String sensorId) {
+        return new SensorData(claim, sensorId, 4, 0.9, Instant.now());
+    }
+
+    @BeforeEach
+    void setUp() {
+        sensorRepository.deleteAll();
+        roomRepository.deleteAll();
+        sensorRegistry.invalidateAll();
+        roomRepository.save(room("006"));
+        roomRepository.save(room("011"));
+        reset(occupancyService, messagingTemplate);
+    }
+
+    @Test
+    @DisplayName("claim matching an existing room flows immediately and registers the device")
+    void claimFlowsAndRegisters() {
+        sensorDataService.process(message("006", "pi-int-1"));
+
+        ArgumentCaptor<OccupancyData> written = forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(written.capture());
+        assertThat(written.getValue().getRoomId()).isEqualTo("006");
+
+        Sensor registered = sensorRepository.findById("pi-int-1").orElseThrow();
+        assertThat(registered.getClaimedRoomId()).isEqualTo("006");
+        assertThat(registered.getOverrideRoom()).isNull();
+    }
+
+    @Test
+    @DisplayName("admin override redirects the stream mid-flight after invalidation")
+    void overrideRedirectsMidStream() {
+        sensorDataService.process(message("006", "pi-int-2"));
+
+        // Admin corrects the device to room 011 (what the B3 API will do).
+        Sensor sensor = sensorRepository.findById("pi-int-2").orElseThrow();
+        sensor.setOverrideRoom(roomRepository.findById("011").orElseThrow());
+        sensor.setClaimedAtOverride(sensor.getClaimedRoomId());
+        sensorRepository.save(sensor);
+        sensorRegistry.invalidate("pi-int-2");
+
+        reset(occupancyService);
+        sensorDataService.process(message("006", "pi-int-2"));
+
+        ArgumentCaptor<OccupancyData> written = forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(written.capture());
+        assertThat(written.getValue().getRoomId()).isEqualTo("011");
+    }
+
+    @Test
+    @DisplayName("a fresh claim voids the override — the moved Pi lands in its new room")
+    void freshClaimVoidsOverride() {
+        sensorDataService.process(message("nope-x", "pi-int-3"));
+        Sensor sensor = sensorRepository.findById("pi-int-3").orElseThrow();
+        sensor.setOverrideRoom(roomRepository.findById("011").orElseThrow());
+        sensor.setClaimedAtOverride("nope-x");
+        sensorRepository.save(sensor);
+        sensorRegistry.invalidate("pi-int-3");
+
+        reset(occupancyService);
+        sensorDataService.process(message("006", "pi-int-3"));
+
+        ArgumentCaptor<OccupancyData> written = forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(written.capture());
+        assertThat(written.getValue().getRoomId()).isEqualTo("006");
+        Sensor after = sensorRepository.findById("pi-int-3").orElseThrow();
+        assertThat(after.getOverrideRoom()).isNull();
+        assertThat(after.getClaimedAtOverride()).isNull();
+    }
+
+    @Test
+    @DisplayName("wrong claim: nothing written or broadcast, device visible with dropped counter")
+    void wrongClaimStaysVisible() {
+        sensorDataService.process(message("kellerraum-99", "pi-int-4"));
+        sensorDataService.process(message("kellerraum-99", "pi-int-4"));
+
+        verifyNoInteractions(occupancyService);
+        verifyNoInteractions(messagingTemplate);
+        assertThat(sensorRepository.findById("pi-int-4")).isPresent();
+        assertThat(sensorRegistry.droppedInfo("pi-int-4")).hasValueSatisfying(info ->
+                assertThat(info.count()).isEqualTo(2));
+    }
+
+    @Test
+    @DisplayName("room created after the fact: the next message resolves without any intervention")
+    void lateRoomCreationHeals() {
+        sensorDataService.process(message("137", "pi-int-5"));
+        verifyNoInteractions(occupancyService);
+
+        roomRepository.save(room("137"));
+        sensorDataService.process(message("137", "pi-int-5"));
+
+        ArgumentCaptor<OccupancyData> written = forClass(OccupancyData.class);
+        verify(occupancyService).recordOccupancy(written.capture());
+        assertThat(written.getValue().getRoomId()).isEqualTo("137");
+        assertThat(sensorRegistry.droppedInfo("pi-int-5")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("broadcast carries the effective room of a corrected device")
+    void broadcastCarriesEffectiveRoom() {
+        Sensor sensor = Sensor.builder().sensorId("pi-int-6").claimedRoomId("006")
+                .createdAt(Instant.now()).build();
+        sensor.setOverrideRoom(roomRepository.findById("011").orElseThrow());
+        sensor.setClaimedAtOverride("006");
+        sensorRepository.save(sensor);
+
+        sensorDataService.process(message("006", "pi-int-6"));
+
+        ArgumentCaptor<SensorData> broadcast = forClass(SensorData.class);
+        verify(messagingTemplate).convertAndSend(org.mockito.ArgumentMatchers.eq("/topic/occupancy"),
+                broadcast.capture());
+        assertThat(broadcast.getValue().roomId()).isEqualTo("011");
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/sensor/SensorRegistryServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/sensor/SensorRegistryServiceImplTest.java
@@ -162,13 +162,12 @@ class SensorRegistryServiceImplTest {
     }
 
     @Test
-    @DisplayName("room created later: after invalidateAll the pending claim resolves")
-    void roomCreatedLaterResolvesAfterInvalidation() {
+    @DisplayName("room created later: the very next message resolves — unresolved is never cached")
+    void roomCreatedLaterResolvesOnNextMessage() {
         when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(knownSensor("pi-1", "006")));
         when(roomRepository.existsById("006")).thenReturn(false).thenReturn(true);
 
         assertThat(registry.resolveEffectiveRoom("pi-1", "006")).isEmpty();
-        registry.invalidateAll();
         assertThat(registry.resolveEffectiveRoom("pi-1", "006")).contains("006");
     }
 

--- a/backend/src/test/java/com/occupi/feature/sensor/SensorRegistryServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/sensor/SensorRegistryServiceImplTest.java
@@ -1,0 +1,279 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.room.Room;
+import com.occupi.feature.room.RoomRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the precedence rules of the claim/override resolution — one test per row
+ * of the edge-case table in the registry ADR.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SensorRegistryServiceImpl — claim/override resolution")
+class SensorRegistryServiceImplTest {
+
+    private static final long CAP = 100;
+
+    @Mock
+    private SensorRepository sensorRepository;
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    private SensorRegistryServiceImpl registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new SensorRegistryServiceImpl(sensorRepository, roomRepository, CAP, 60);
+    }
+
+    private Sensor knownSensor(String sensorId, String claim) {
+        return Sensor.builder()
+                .sensorId(sensorId)
+                .claimedRoomId(claim)
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    private Sensor overriddenSensor(String sensorId, String claim, String overrideRoomId) {
+        Sensor sensor = knownSensor(sensorId, claim);
+        sensor.setOverrideRoom(Room.builder().roomId(overrideRoomId).name(overrideRoomId).capacity(10).build());
+        sensor.setClaimedAtOverride(claim);
+        return sensor;
+    }
+
+    @Test
+    @DisplayName("claim matching an existing room resolves immediately")
+    void claimResolvesWhenRoomExists() {
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(knownSensor("pi-1", "006")));
+        when(roomRepository.existsById("006")).thenReturn(true);
+
+        assertThat(registry.resolveEffectiveRoom("pi-1", "006")).contains("006");
+    }
+
+    @Test
+    @DisplayName("second message with the same claim is served from the cache")
+    void sameClaimHitsCache() {
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(knownSensor("pi-1", "006")));
+        when(roomRepository.existsById("006")).thenReturn(true);
+
+        registry.resolveEffectiveRoom("pi-1", "006");
+        registry.resolveEffectiveRoom("pi-1", "006");
+
+        verify(sensorRepository, times(1)).findById("pi-1");
+    }
+
+    @Test
+    @DisplayName("unknown device is auto-registered with its claim")
+    void unknownDeviceAutoRegisters() {
+        when(sensorRepository.findById("pi-new")).thenReturn(Optional.empty());
+        when(sensorRepository.count()).thenReturn(3L);
+        when(roomRepository.existsById("006")).thenReturn(true);
+
+        assertThat(registry.resolveEffectiveRoom("pi-new", "006")).contains("006");
+
+        ArgumentCaptor<Sensor> captor = ArgumentCaptor.forClass(Sensor.class);
+        verify(sensorRepository).saveAndFlush(captor.capture());
+        assertThat(captor.getValue().getClaimedRoomId()).isEqualTo("006");
+        assertThat(captor.getValue().getCreatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("claim to a nonexistent room is unresolved")
+    void unknownRoomIsUnresolved() {
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(knownSensor("pi-1", "nope")));
+        when(roomRepository.existsById("nope")).thenReturn(false);
+
+        assertThat(registry.resolveEffectiveRoom("pi-1", "nope")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Pi restart with the unchanged claim keeps the override")
+    void restartKeepsOverride() {
+        when(sensorRepository.findById("pi-1"))
+                .thenReturn(Optional.of(overriddenSensor("pi-1", "wrong-room", "011")));
+
+        assertThat(registry.resolveEffectiveRoom("pi-1", "wrong-room")).contains("011");
+
+        verify(sensorRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("a NEW claim voids the override — fresh .env intent wins")
+    void newClaimVoidsOverride() {
+        when(sensorRepository.findById("pi-1"))
+                .thenReturn(Optional.of(overriddenSensor("pi-1", "wrong-room", "011")));
+        when(roomRepository.existsById("137")).thenReturn(true);
+
+        assertThat(registry.resolveEffectiveRoom("pi-1", "137")).contains("137");
+
+        ArgumentCaptor<Sensor> captor = ArgumentCaptor.forClass(Sensor.class);
+        verify(sensorRepository).save(captor.capture());
+        assertThat(captor.getValue().getOverrideRoom()).isNull();
+        assertThat(captor.getValue().getClaimedAtOverride()).isNull();
+        assertThat(captor.getValue().getClaimedRoomId()).isEqualTo("137");
+    }
+
+    @Test
+    @DisplayName("claim corrected to exactly the override target: override expires, result identical")
+    void claimCorrectedToOverrideTarget() {
+        when(sensorRepository.findById("pi-1"))
+                .thenReturn(Optional.of(overriddenSensor("pi-1", "wrong-room", "011")));
+        when(roomRepository.existsById("011")).thenReturn(true);
+
+        assertThat(registry.resolveEffectiveRoom("pi-1", "011")).contains("011");
+
+        ArgumentCaptor<Sensor> captor = ArgumentCaptor.forClass(Sensor.class);
+        verify(sensorRepository).save(captor.capture());
+        assertThat(captor.getValue().getOverrideRoom()).isNull();
+    }
+
+    @Test
+    @DisplayName("invalidate forces the next resolution back to the database")
+    void invalidateForcesReload() {
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(knownSensor("pi-1", "006")));
+        when(roomRepository.existsById("006")).thenReturn(true);
+
+        registry.resolveEffectiveRoom("pi-1", "006");
+        registry.invalidate("pi-1");
+        registry.resolveEffectiveRoom("pi-1", "006");
+
+        verify(sensorRepository, times(2)).findById("pi-1");
+    }
+
+    @Test
+    @DisplayName("room created later: after invalidateAll the pending claim resolves")
+    void roomCreatedLaterResolvesAfterInvalidation() {
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(knownSensor("pi-1", "006")));
+        when(roomRepository.existsById("006")).thenReturn(false).thenReturn(true);
+
+        assertThat(registry.resolveEffectiveRoom("pi-1", "006")).isEmpty();
+        registry.invalidateAll();
+        assertThat(registry.resolveEffectiveRoom("pi-1", "006")).contains("006");
+    }
+
+    @Test
+    @DisplayName("insert race with a parallel message falls back to the winning row")
+    void insertRaceFallsBackToExistingRow() {
+        when(sensorRepository.findById("pi-1"))
+                .thenReturn(Optional.empty())
+                .thenReturn(Optional.of(knownSensor("pi-1", "006")));
+        when(sensorRepository.count()).thenReturn(0L);
+        when(sensorRepository.saveAndFlush(any(Sensor.class)))
+                .thenThrow(new DataIntegrityViolationException("duplicate key"));
+        when(roomRepository.existsById("006")).thenReturn(true);
+
+        assertThat(registry.resolveEffectiveRoom("pi-1", "006")).contains("006");
+    }
+
+    @Test
+    @DisplayName("auto-registration stops at the cap — the message is dropped, not stored")
+    void capBlocksAutoRegistration() {
+        when(sensorRepository.findById("pi-flood")).thenReturn(Optional.empty());
+        when(sensorRepository.count()).thenReturn(CAP);
+
+        assertThat(registry.resolveEffectiveRoom("pi-flood", "006")).isEmpty();
+
+        verify(sensorRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    @DisplayName("registry failure fails closed: unresolved for this message, no exception")
+    void databaseFailureFailsClosed() {
+        when(sensorRepository.findById("pi-1"))
+                .thenThrow(new DataAccessResourceFailureException("db down"));
+
+        assertThat(registry.resolveEffectiveRoom("pi-1", "006")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("dropped points are counted per device and cleared once resolved")
+    void droppedPointsAreCountedAndCleared() {
+        registry.recordDroppedPoint("pi-1");
+        registry.recordDroppedPoint("pi-1");
+
+        assertThat(registry.droppedInfo("pi-1")).hasValueSatisfying(info ->
+                assertThat(info.count()).isEqualTo(2));
+
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(knownSensor("pi-1", "006")));
+        when(roomRepository.existsById("006")).thenReturn(true);
+        registry.resolveEffectiveRoom("pi-1", "006");
+
+        assertThat(registry.droppedInfo("pi-1")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("flushLastSeen writes buffered timestamps once")
+    void flushWritesBufferedLastSeen() {
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(knownSensor("pi-1", "006")));
+        when(roomRepository.existsById("006")).thenReturn(true);
+        registry.resolveEffectiveRoom("pi-1", "006");
+
+        registry.flushLastSeen();
+        registry.flushLastSeen();
+
+        verify(sensorRepository, times(1)).updateLastSeen(eq("pi-1"), any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("touch registers an unknown device without a claim")
+    void touchRegistersUnknownDevice() {
+        when(sensorRepository.existsById("pi-metrics")).thenReturn(false);
+        when(sensorRepository.count()).thenReturn(0L);
+
+        registry.touch("pi-metrics");
+
+        ArgumentCaptor<Sensor> captor = ArgumentCaptor.forClass(Sensor.class);
+        verify(sensorRepository).saveAndFlush(captor.capture());
+        assertThat(captor.getValue().getClaimedRoomId()).isNull();
+    }
+
+    @Test
+    @DisplayName("touch of a known device only buffers the timestamp")
+    void touchOfKnownDeviceOnlyBuffers() {
+        when(sensorRepository.existsById("pi-1")).thenReturn(true);
+
+        registry.touch("pi-1");
+
+        verify(sensorRepository, never()).saveAndFlush(any());
+        registry.flushLastSeen();
+        verify(sensorRepository).updateLastSeen(eq("pi-1"), any(Instant.class));
+    }
+
+    @Test
+    @DisplayName("id validators accept the documented shapes and nothing else")
+    void idValidators() {
+        assertThat(SensorRegistryService.isValidSensorId("pi-bibliothek")).isTrue();
+        assertThat(SensorRegistryService.isValidSensorId("mock-pi-006")).isTrue();
+        assertThat(SensorRegistryService.isValidSensorId("sensor_01.a")).isTrue();
+        assertThat(SensorRegistryService.isValidSensorId("")).isFalse();
+        assertThat(SensorRegistryService.isValidSensorId(null)).isFalse();
+        assertThat(SensorRegistryService.isValidSensorId("a".repeat(65))).isFalse();
+        assertThat(SensorRegistryService.isValidSensorId("evil sensor")).isFalse();
+
+        assertThat(SensorRegistryService.isValidRoomId("016E")).isTrue();
+        assertThat(SensorRegistryService.isValidRoomId("room-101")).isTrue();
+        assertThat(SensorRegistryService.isValidRoomId("raum_6")).isFalse();
+        assertThat(SensorRegistryService.isValidRoomId(null)).isFalse();
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/sensor/SensorRepositoryTest.java
+++ b/backend/src/test/java/com/occupi/feature/sensor/SensorRepositoryTest.java
@@ -1,0 +1,122 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.room.Room;
+import com.occupi.feature.room.RoomRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies the JPA mapping of {@link Sensor} against H2, above all the foreign-key
+ * semantics that make a dangling override impossible: a room referenced by an
+ * override cannot be deleted, while rooms referenced only by claims can.
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("SensorRepository (JPA)")
+class SensorRepositoryTest {
+
+    @Autowired
+    private SensorRepository sensorRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Room room(String id) {
+        return Room.builder().roomId(id).name("Raum " + id).capacity(20).build();
+    }
+
+    private Sensor sensor(String id) {
+        return Sensor.builder()
+                .sensorId(id)
+                .claimedRoomId("claim-" + id)
+                .createdAt(Instant.now())
+                .build();
+    }
+
+    @Test
+    @DisplayName("persists and retrieves a sensor with claim and timestamps")
+    void saveAndFind() {
+        sensorRepository.saveAndFlush(sensor("pi-1"));
+
+        Optional<Sensor> found = sensorRepository.findById("pi-1");
+
+        assertThat(found).isPresent();
+        assertThat(found.get().getClaimedRoomId()).isEqualTo("claim-pi-1");
+        assertThat(found.get().getCreatedAt()).isNotNull();
+        assertThat(found.get().getOverrideRoom()).isNull();
+    }
+
+    @Test
+    @DisplayName("deleting a room that an override points at is blocked by the FK")
+    void overrideBlocksRoomDeletion() {
+        Room room = roomRepository.saveAndFlush(room("011"));
+        Sensor sensor = sensor("pi-2");
+        sensor.setOverrideRoom(room);
+        sensor.setClaimedAtOverride(sensor.getClaimedRoomId());
+        sensorRepository.saveAndFlush(sensor);
+        // Fresh persistence context, like the real delete request: the FK in the
+        // database must do the blocking, not Hibernate's in-session entity check.
+        entityManager.clear();
+
+        assertThatThrownBy(() -> {
+            roomRepository.deleteById("011");
+            roomRepository.flush();
+        }).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    @DisplayName("deleting a room that only claims point at is allowed")
+    void claimDoesNotBlockRoomDeletion() {
+        roomRepository.saveAndFlush(room("006"));
+        Sensor sensor = sensor("pi-3");
+        sensor.setClaimedRoomId("006");
+        sensorRepository.saveAndFlush(sensor);
+
+        roomRepository.deleteById("006");
+        roomRepository.flush();
+
+        assertThat(roomRepository.findById("006")).isEmpty();
+        assertThat(sensorRepository.findById("pi-3")).isPresent();
+    }
+
+    @Test
+    @DisplayName("finds sensors by their override room")
+    void findsByOverrideRoom() {
+        Room room = roomRepository.saveAndFlush(room("137"));
+        Sensor assigned = sensor("pi-4");
+        assigned.setOverrideRoom(room);
+        sensorRepository.saveAndFlush(assigned);
+        sensorRepository.saveAndFlush(sensor("pi-5"));
+
+        assertThat(sensorRepository.findByOverrideRoomId("137"))
+                .extracting(Sensor::getSensorId)
+                .containsExactly("pi-4");
+    }
+
+    @Test
+    @DisplayName("updateLastSeen touches only the timestamp column")
+    void updateLastSeenWorks() {
+        sensorRepository.saveAndFlush(sensor("pi-6"));
+        Instant ts = Instant.parse("2026-07-04T12:00:00Z");
+
+        int updated = sensorRepository.updateLastSeen("pi-6", ts);
+        sensorRepository.flush();
+
+        assertThat(updated).isEqualTo(1);
+        assertThat(sensorRepository.findById("pi-6").orElseThrow().getLastSeenAt()).isEqualTo(ts);
+    }
+}


### PR DESCRIPTION
## Summary
Core piece of the restructuring plan. Today the backend trusts the payload `roomId`
blindly: a typo in a Pi's `.env` writes data under a tag nobody sees, and the room
stays silently empty. This introduces the sensor registry with the claim/override
semantics from the plan: the Pi's `ROOM_ID` is a claim that resolves immediately
when the room exists; an admin override corrects mistakes and expires automatically
when the Pi reports a new claim (fresh `.env` intent wins).

## Changes
- `feature/sensor/` (new) — `Sensor` entity (`sensors` table: `sensor_id` PK,
  `claimed_room_id` string, `override_room_id` as real FK with RESTRICT semantics,
  `claimed_at_override`, `name`, `created_at`, `last_seen_at`) + repository with a
  direct `updateLastSeen` column update.
- `SensorRegistryService(+Impl)` — resolution `override ?? (claim if room exists) ?? unresolved`
  with a Caffeine cache keyed by device. Only resolved devices are cached: an
  unresolved device re-checks per message, so creating the missing room or assigning
  one heals on the very next message — no invalidation hooks in the room feature
  needed (simpler than planned; the plan's `RoomServiceImpl` hooks are obsolete).
  Auto-registration on first contact (capped, `OCCUPI_SENSOR_AUTOREGISTER_CAP=100`),
  insert-race safe, rate-limited warnings (1/min/device), buffered `last_seen_at`
  flush on the OccupancyService pattern, dropped-point counters for the admin panel.
- `SensorDataServiceImpl` — validates ids, resolves the room, stamps the **effective**
  room into the Influx point AND the `/topic/occupancy` broadcast (a corrected device
  must not live-update the wrong tile), drops unresolved points visibly, and no
  longer rethrows: one bad message cannot take down the shared STOMP session.
- `PiMetricsServiceImpl` — `touch()` on every snapshot: a freshly connected Pi is
  visible in the registry before it ever sends occupancy; metrics are stored always.
- Frontend WS contract unchanged (`{roomId, count}` — consumer reads only these).

## Tests
- `SensorRegistryServiceImplTest`: one test per row of the plan's edge-case table
  (restart keeps override, new claim voids it, correction to the override target,
  late room creation, insert race, cap, fail-closed, cache behavior, validators).
- `SensorRepositoryTest` (H2): FK blocks deleting a room with overrides; claims don't.
- `SensorRegistryIngestIntegrationTest` (full context, H2): claim flow, mid-stream
  reassignment, override expiry on a fresh claim, wrong-id visibility with counters,
  broadcast rewriting.
- `SensorDataServiceImplTest`/`PiMetricsServiceImplTest` adapted to the new behavior.

## Verification
- `./mvnw test` green after every commit (261 tests, incl. the Testcontainers Influx
  integration tests)
- Old Pis keep working unchanged: their payload already carries `roomId`+`sensorId`,
  which the registry now reads as claim + device id (zero-gap migration path)

## Notes
`/ws/**` stays `permitAll` (unchanged) — mitigated here by id validation + the
auto-register cap; the real per-device auth is #322.

Closes #310