### PR TITLE
feat: sensor registry admin API #311

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- Sensor admin API for the panel's correction path: `GET /api/sensors` lists every
+  device with claim, effective room, derived status (claimed / overridden /
+  unresolved), last seen and dropped-point counters; `PUT /api/sensors/{id}/assignment`
+  assigns a room (override), `DELETE .../assignment` clears it, `PUT /{id}` renames,
+  `DELETE /{id}` removes the entry. Writes require the Keycloak `admin` role at both
+  the URL and method level, like rooms. Deleting a room that still has assigned
+  sensors now fails with `409` naming the sensors instead of an opaque error (#311).
 - Sensor registry: every Pi that ever reported gets a row in the new Postgres
   `sensors` table (device id, claimed room, admin override, last seen). The room id a
   Pi sends is now a *claim* — it flows into exactly that room the moment a matching

--- a/backend/src/main/java/com/occupi/feature/room/RoomHasAssignedSensorsException.java
+++ b/backend/src/main/java/com/occupi/feature/room/RoomHasAssignedSensorsException.java
@@ -1,0 +1,20 @@
+package com.occupi.feature.room;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.util.List;
+
+/**
+ * Thrown when a room deletion is blocked because admin overrides still point at
+ * the room. Mapped to HTTP 409; the message names the sensors so the admin panel
+ * can tell the user exactly what to reassign first.
+ */
+@ResponseStatus(HttpStatus.CONFLICT)
+public class RoomHasAssignedSensorsException extends RuntimeException {
+
+    public RoomHasAssignedSensorsException(String roomId, List<String> sensorIds) {
+        super("Room '" + roomId + "' still has assigned sensors: " + String.join(", ", sensorIds)
+                + " — reassign them first");
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/room/RoomServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/room/RoomServiceImpl.java
@@ -2,6 +2,8 @@ package com.occupi.feature.room;
 
 import com.occupi.feature.room.dto.RoomRequest;
 import com.occupi.feature.room.dto.RoomResponse;
+import com.occupi.feature.sensor.Sensor;
+import com.occupi.feature.sensor.SensorRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ import java.util.Optional;
 public class RoomServiceImpl implements RoomService {
 
     private final RoomRepository roomRepository;
+    private final SensorRepository sensorRepository;
 
     @Override
     public List<RoomResponse> getAllRooms() {
@@ -67,6 +70,14 @@ public class RoomServiceImpl implements RoomService {
     public void deleteRoom(String roomId) {
         if (!roomRepository.existsById(roomId)) {
             throw new RoomNotFoundException(roomId);
+        }
+        // Overrides are a real FK — the database would block this delete anyway;
+        // checking first turns an opaque 500 into a 409 that names the sensors.
+        List<String> assigned = sensorRepository.findByOverrideRoomId(roomId).stream()
+                .map(Sensor::getSensorId)
+                .toList();
+        if (!assigned.isEmpty()) {
+            throw new RoomHasAssignedSensorsException(roomId, assigned);
         }
         roomRepository.deleteById(roomId);
         log.info("Deleted room: {}", roomId);

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorAdminService.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorAdminService.java
@@ -1,0 +1,33 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.sensor.dto.SensorResponse;
+
+import java.util.List;
+
+/**
+ * Admin operations on the sensor registry — the correction path: list every device
+ * that ever reported, assign or unassign a room, rename, delete.
+ */
+public interface SensorAdminService {
+
+    /** All registered devices with their derived status, ordered by sensorId. */
+    List<SensorResponse> getAllSensors();
+
+    /**
+     * Assigns a device to a room (sets the override). The override remembers the
+     * current claim, so a later NEW claim voids it.
+     *
+     * @throws SensorNotFoundException when the device is unknown
+     * @throws com.occupi.feature.room.RoomNotFoundException when the room does not exist
+     */
+    SensorResponse assignRoom(String sensorId, String roomId);
+
+    /** Clears the override — the device falls back to its claim. */
+    SensorResponse clearAssignment(String sensorId);
+
+    /** Renames the device in the panel. */
+    SensorResponse rename(String sensorId, String name);
+
+    /** Removes the registry entry; the device re-registers on its next message. */
+    void delete(String sensorId);
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorAdminServiceImpl.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorAdminServiceImpl.java
@@ -1,0 +1,121 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.room.Room;
+import com.occupi.feature.room.RoomNotFoundException;
+import com.occupi.feature.room.RoomRepository;
+import com.occupi.feature.sensor.dto.SensorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Default {@link SensorAdminService} implementation. Every assignment change
+ * invalidates the resolution cache, so the next message from the device already
+ * follows the new mapping — the panel's change is live within one message.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SensorAdminServiceImpl implements SensorAdminService {
+
+    private final SensorRepository sensorRepository;
+    private final RoomRepository roomRepository;
+    private final SensorRegistryService sensorRegistry;
+
+    @Override
+    public List<SensorResponse> getAllSensors() {
+        Set<String> existingRooms = roomRepository.findAll().stream()
+                .map(Room::getRoomId)
+                .collect(Collectors.toSet());
+        return sensorRepository.findAll().stream()
+                .sorted(Comparator.comparing(Sensor::getSensorId))
+                .map(sensor -> toResponse(sensor, existingRooms.contains(sensor.getClaimedRoomId())))
+                .toList();
+    }
+
+    @Override
+    public SensorResponse assignRoom(String sensorId, String roomId) {
+        Sensor sensor = sensorRepository.findById(sensorId)
+                .orElseThrow(() -> new SensorNotFoundException(sensorId));
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new RoomNotFoundException(roomId));
+
+        sensor.setOverrideRoom(room);
+        sensor.setClaimedAtOverride(sensor.getClaimedRoomId());
+        Sensor saved = sensorRepository.save(sensor);
+        sensorRegistry.invalidate(sensorId);
+        log.info("Sensor '{}' assigned to room '{}' (was claiming '{}')",
+                sensorId, roomId, saved.getClaimedRoomId());
+        return toResponse(saved, claimResolves(saved));
+    }
+
+    @Override
+    public SensorResponse clearAssignment(String sensorId) {
+        Sensor sensor = sensorRepository.findById(sensorId)
+                .orElseThrow(() -> new SensorNotFoundException(sensorId));
+
+        sensor.setOverrideRoom(null);
+        sensor.setClaimedAtOverride(null);
+        Sensor saved = sensorRepository.save(sensor);
+        sensorRegistry.invalidate(sensorId);
+        log.info("Sensor '{}' assignment cleared — falls back to claim '{}'",
+                sensorId, saved.getClaimedRoomId());
+        return toResponse(saved, claimResolves(saved));
+    }
+
+    @Override
+    public SensorResponse rename(String sensorId, String name) {
+        Sensor sensor = sensorRepository.findById(sensorId)
+                .orElseThrow(() -> new SensorNotFoundException(sensorId));
+
+        sensor.setName(name);
+        return toResponse(sensorRepository.save(sensor), claimResolves(sensor));
+    }
+
+    @Override
+    public void delete(String sensorId) {
+        if (!sensorRepository.existsById(sensorId)) {
+            throw new SensorNotFoundException(sensorId);
+        }
+        sensorRepository.deleteById(sensorId);
+        sensorRegistry.invalidate(sensorId);
+        log.info("Deleted sensor '{}' from the registry", sensorId);
+    }
+
+    private boolean claimResolves(Sensor sensor) {
+        return sensor.getClaimedRoomId() != null && roomRepository.existsById(sensor.getClaimedRoomId());
+    }
+
+    private SensorResponse toResponse(Sensor sensor, boolean claimResolves) {
+        SensorStatus status;
+        String effectiveRoomId;
+        if (sensor.getOverrideRoom() != null) {
+            status = SensorStatus.OVERRIDDEN;
+            effectiveRoomId = sensor.getOverrideRoom().getRoomId();
+        } else if (claimResolves) {
+            status = SensorStatus.CLAIMED;
+            effectiveRoomId = sensor.getClaimedRoomId();
+        } else {
+            status = SensorStatus.UNRESOLVED;
+            effectiveRoomId = null;
+        }
+
+        var dropped = sensorRegistry.droppedInfo(sensor.getSensorId());
+        return new SensorResponse(
+                sensor.getSensorId(),
+                sensor.getName(),
+                sensor.getClaimedRoomId(),
+                effectiveRoomId,
+                status,
+                sensor.getCreatedAt(),
+                sensor.getLastSeenAt(),
+                dropped.map(SensorRegistryService.DropInfo::count).orElse(null),
+                dropped.map(SensorRegistryService.DropInfo::since).orElse(null)
+        );
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorController.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorController.java
@@ -1,0 +1,76 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.sensor.dto.SensorAssignmentRequest;
+import com.occupi.feature.sensor.dto.SensorNameRequest;
+import com.occupi.feature.sensor.dto.SensorResponse;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * REST API for the sensor registry used by the Admin Panel — the correction path
+ * of the room mapping.
+ *
+ * <pre>
+ * GET    /api/sensors                  → list all devices with derived status
+ * PUT    /api/sensors/{id}             → rename                    (admin only)
+ * PUT    /api/sensors/{id}/assignment  → assign a room (override)  (admin only)
+ * DELETE /api/sensors/{id}/assignment  → clear the override        (admin only)
+ * DELETE /api/sensors/{id}             → remove the registry entry (admin only)
+ * </pre>
+ *
+ * Write operations are restricted to the Keycloak {@code admin} realm role via
+ * {@code @PreAuthorize}, doubled by the URL rules in {@code SecurityConfig} — the
+ * same two-layer setup the room endpoints use.
+ */
+@RestController
+@RequestMapping("/api/sensors")
+public class SensorController {
+
+    private final SensorAdminService sensorAdminService;
+
+    public SensorController(SensorAdminService sensorAdminService) {
+        this.sensorAdminService = sensorAdminService;
+    }
+
+    @GetMapping
+    public List<SensorResponse> getAllSensors() {
+        return sensorAdminService.getAllSensors();
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<SensorResponse> rename(@PathVariable String id,
+                                                 @Valid @RequestBody SensorNameRequest request) {
+        return ResponseEntity.ok(sensorAdminService.rename(id, request.name()));
+    }
+
+    @PutMapping("/{id}/assignment")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<SensorResponse> assignRoom(@PathVariable String id,
+                                                     @Valid @RequestBody SensorAssignmentRequest request) {
+        return ResponseEntity.ok(sensorAdminService.assignRoom(id, request.roomId()));
+    }
+
+    @DeleteMapping("/{id}/assignment")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<SensorResponse> clearAssignment(@PathVariable String id) {
+        return ResponseEntity.ok(sensorAdminService.clearAssignment(id));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deleteSensor(@PathVariable String id) {
+        sensorAdminService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorNotFoundException.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorNotFoundException.java
@@ -1,0 +1,16 @@
+package com.occupi.feature.sensor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Thrown when a sensor operation targets a sensorId that does not exist.
+ * Mapped to HTTP 404 by Spring.
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class SensorNotFoundException extends RuntimeException {
+
+    public SensorNotFoundException(String sensorId) {
+        super("Sensor not found: " + sensorId);
+    }
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/SensorStatus.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/SensorStatus.java
@@ -1,0 +1,17 @@
+package com.occupi.feature.sensor;
+
+/**
+ * Derived assignment state of a device — never stored, always computed from the
+ * claim, the override and the existing rooms.
+ */
+public enum SensorStatus {
+
+    /** The claimed room exists; data flows there (the normal case). */
+    CLAIMED,
+
+    /** An admin override redirects the data; it wins until a new claim voids it. */
+    OVERRIDDEN,
+
+    /** Claim matches no room and no override is set — occupancy is dropped, visibly. */
+    UNRESOLVED
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/dto/SensorAssignmentRequest.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/dto/SensorAssignmentRequest.java
@@ -1,0 +1,13 @@
+package com.occupi.feature.sensor.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Admin request assigning a device to a room (sets the override).
+ *
+ * @param roomId the target room; must exist
+ */
+public record SensorAssignmentRequest(
+        @NotBlank(message = "roomId must not be blank") String roomId
+) {
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/dto/SensorNameRequest.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/dto/SensorNameRequest.java
@@ -1,0 +1,13 @@
+package com.occupi.feature.sensor.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Admin request renaming a device in the panel.
+ *
+ * @param name the display name
+ */
+public record SensorNameRequest(
+        @NotBlank(message = "name must not be blank") String name
+) {
+}

--- a/backend/src/main/java/com/occupi/feature/sensor/dto/SensorResponse.java
+++ b/backend/src/main/java/com/occupi/feature/sensor/dto/SensorResponse.java
@@ -1,0 +1,31 @@
+package com.occupi.feature.sensor.dto;
+
+import com.occupi.feature.sensor.SensorStatus;
+
+import java.time.Instant;
+
+/**
+ * Registry view of one device for the admin panel.
+ *
+ * @param sensorId      stable device identity (SENSOR_ID on the Pi)
+ * @param name          optional display name
+ * @param claimedRoomId last room id the device claimed via its .env
+ * @param effectiveRoomId room its data currently lands in; null when unresolved
+ * @param status        derived assignment state
+ * @param createdAt     first contact
+ * @param lastSeenAt    last message (occupancy or metrics), flushed periodically
+ * @param droppedCount  points dropped while unresolved; null when none
+ * @param droppedSince  start of the current drop window; null when none
+ */
+public record SensorResponse(
+        String sensorId,
+        String name,
+        String claimedRoomId,
+        String effectiveRoomId,
+        SensorStatus status,
+        Instant createdAt,
+        Instant lastSeenAt,
+        Long droppedCount,
+        Instant droppedSince
+) {
+}

--- a/backend/src/main/java/com/occupi/security/SecurityConfig.java
+++ b/backend/src/main/java/com/occupi/security/SecurityConfig.java
@@ -24,6 +24,8 @@ import org.springframework.security.web.SecurityFilterChain;
  *   <li>OpenAPI / Swagger UI — public</li>
  *   <li>Room mutations (POST/PUT/DELETE {@code /api/rooms/**}) — {@code admin} role only,
  *       enforced both here at the URL level and via {@code @PreAuthorize} on the controller</li>
+ *   <li>Sensor registry mutations (PUT/DELETE {@code /api/sensors/**}) — {@code admin}
+ *       role only, same two-layer enforcement</li>
  *   <li>everything else — any authenticated user with a valid JWT</li>
  * </ul>
  *
@@ -47,6 +49,8 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/rooms/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/rooms/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/api/rooms/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/api/sensors/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/sensors/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .oauth2ResourceServer(oauth2 -> oauth2

--- a/backend/src/test/java/com/occupi/feature/room/RoomServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/room/RoomServiceImplTest.java
@@ -2,6 +2,8 @@ package com.occupi.feature.room;
 
 import com.occupi.feature.room.dto.RoomRequest;
 import com.occupi.feature.room.dto.RoomResponse;
+import com.occupi.feature.sensor.Sensor;
+import com.occupi.feature.sensor.SensorRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +24,9 @@ class RoomServiceImplTest {
 
     @Mock
     private RoomRepository roomRepository;
+
+    @Mock
+    private SensorRepository sensorRepository;
 
     @InjectMocks
     private RoomServiceImpl service;
@@ -120,6 +125,21 @@ class RoomServiceImplTest {
         service.deleteRoom("room-1");
 
         verify(roomRepository).deleteById("room-1");
+    }
+
+    @Test
+    @DisplayName("deleteRoom is blocked with 409 while sensors are assigned to the room")
+    void deleteRoom_withAssignedSensors_throwsConflict() {
+        when(roomRepository.existsById("room-1")).thenReturn(true);
+        when(sensorRepository.findByOverrideRoomId("room-1")).thenReturn(List.of(
+                Sensor.builder().sensorId("pi-a").build(),
+                Sensor.builder().sensorId("pi-b").build()));
+
+        assertThatThrownBy(() -> service.deleteRoom("room-1"))
+                .isInstanceOf(RoomHasAssignedSensorsException.class)
+                .hasMessageContaining("pi-a")
+                .hasMessageContaining("pi-b");
+        verify(roomRepository, never()).deleteById(anyString());
     }
 
     @Test

--- a/backend/src/test/java/com/occupi/feature/sensor/SensorAdminServiceImplTest.java
+++ b/backend/src/test/java/com/occupi/feature/sensor/SensorAdminServiceImplTest.java
@@ -1,0 +1,153 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.room.Room;
+import com.occupi.feature.room.RoomNotFoundException;
+import com.occupi.feature.room.RoomRepository;
+import com.occupi.feature.sensor.dto.SensorResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SensorAdminServiceImpl")
+class SensorAdminServiceImplTest {
+
+    @Mock
+    private SensorRepository sensorRepository;
+
+    @Mock
+    private RoomRepository roomRepository;
+
+    @Mock
+    private SensorRegistryService sensorRegistry;
+
+    @InjectMocks
+    private SensorAdminServiceImpl service;
+
+    private Room room(String id) {
+        return Room.builder().roomId(id).name("Raum " + id).capacity(20).build();
+    }
+
+    private Sensor sensor(String id, String claim) {
+        return Sensor.builder().sensorId(id).claimedRoomId(claim).createdAt(Instant.now()).build();
+    }
+
+    @Test
+    @DisplayName("list derives the three statuses and sorts by sensorId")
+    void listDerivesStatuses() {
+        Sensor claimed = sensor("pi-b", "006");
+        Sensor overridden = sensor("pi-a", "wrong");
+        overridden.setOverrideRoom(room("011"));
+        overridden.setClaimedAtOverride("wrong");
+        Sensor unresolved = sensor("pi-c", "nope");
+        when(sensorRepository.findAll()).thenReturn(List.of(claimed, overridden, unresolved));
+        when(roomRepository.findAll()).thenReturn(List.of(room("006"), room("011")));
+        when(sensorRegistry.droppedInfo(anyString())).thenReturn(Optional.empty());
+        when(sensorRegistry.droppedInfo("pi-c")).thenReturn(
+                Optional.of(new SensorRegistryService.DropInfo(17, Instant.parse("2026-07-04T10:00:00Z"))));
+
+        List<SensorResponse> result = service.getAllSensors();
+
+        assertThat(result).extracting(SensorResponse::sensorId)
+                .containsExactly("pi-a", "pi-b", "pi-c");
+        assertThat(result).extracting(SensorResponse::status)
+                .containsExactly(SensorStatus.OVERRIDDEN, SensorStatus.CLAIMED, SensorStatus.UNRESOLVED);
+        assertThat(result).extracting(SensorResponse::effectiveRoomId)
+                .containsExactly("011", "006", null);
+        assertThat(result.get(2).droppedCount()).isEqualTo(17);
+    }
+
+    @Test
+    @DisplayName("assignRoom sets the override, remembers the claim and invalidates the cache")
+    void assignRoomSetsOverride() {
+        Sensor sensor = sensor("pi-1", "wrong-claim");
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(sensor));
+        when(roomRepository.findById("011")).thenReturn(Optional.of(room("011")));
+        when(sensorRepository.save(any(Sensor.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        SensorResponse response = service.assignRoom("pi-1", "011");
+
+        ArgumentCaptor<Sensor> captor = ArgumentCaptor.forClass(Sensor.class);
+        verify(sensorRepository).save(captor.capture());
+        assertThat(captor.getValue().getOverrideRoom().getRoomId()).isEqualTo("011");
+        assertThat(captor.getValue().getClaimedAtOverride()).isEqualTo("wrong-claim");
+        verify(sensorRegistry).invalidate("pi-1");
+        assertThat(response.status()).isEqualTo(SensorStatus.OVERRIDDEN);
+        assertThat(response.effectiveRoomId()).isEqualTo("011");
+    }
+
+    @Test
+    @DisplayName("assignRoom fails with 404s for unknown sensor or room")
+    void assignRoomNotFoundCases() {
+        when(sensorRepository.findById("ghost")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.assignRoom("ghost", "011"))
+                .isInstanceOf(SensorNotFoundException.class);
+
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(sensor("pi-1", "x")));
+        when(roomRepository.findById("nope")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> service.assignRoom("pi-1", "nope"))
+                .isInstanceOf(RoomNotFoundException.class);
+
+        verify(sensorRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("clearAssignment removes the override and falls back to the claim")
+    void clearAssignmentFallsBackToClaim() {
+        Sensor sensor = sensor("pi-1", "006");
+        sensor.setOverrideRoom(room("011"));
+        sensor.setClaimedAtOverride("006");
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(sensor));
+        when(sensorRepository.save(any(Sensor.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(roomRepository.existsById("006")).thenReturn(true);
+        when(sensorRegistry.droppedInfo("pi-1")).thenReturn(Optional.empty());
+
+        SensorResponse response = service.clearAssignment("pi-1");
+
+        assertThat(response.status()).isEqualTo(SensorStatus.CLAIMED);
+        assertThat(response.effectiveRoomId()).isEqualTo("006");
+        verify(sensorRegistry).invalidate("pi-1");
+    }
+
+    @Test
+    @DisplayName("rename updates only the display name")
+    void renameUpdatesName() {
+        Sensor sensor = sensor("pi-1", "006");
+        when(sensorRepository.findById("pi-1")).thenReturn(Optional.of(sensor));
+        when(sensorRepository.save(any(Sensor.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        SensorResponse response = service.rename("pi-1", "Bibliothek links");
+
+        assertThat(response.name()).isEqualTo("Bibliothek links");
+        verify(sensorRegistry, never()).invalidate(anyString());
+    }
+
+    @Test
+    @DisplayName("delete removes the entry; unknown ids yield 404")
+    void deleteRemovesOr404() {
+        when(sensorRepository.existsById("pi-1")).thenReturn(true);
+        service.delete("pi-1");
+        verify(sensorRepository).deleteById("pi-1");
+        verify(sensorRegistry).invalidate("pi-1");
+
+        when(sensorRepository.existsById("ghost")).thenReturn(false);
+        assertThatThrownBy(() -> service.delete("ghost"))
+                .isInstanceOf(SensorNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/sensor/SensorControllerMethodSecurityTest.java
+++ b/backend/src/test/java/com/occupi/feature/sensor/SensorControllerMethodSecurityTest.java
@@ -1,0 +1,116 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.sensor.dto.SensorResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Verifies the {@code @PreAuthorize} method security on {@link SensorController} in
+ * isolation, over a deliberately permissive URL layer — the same honest setup the
+ * room endpoints use: a 403 can only come from the method-level role check.
+ */
+@WebMvcTest(SensorController.class)
+@Import(SensorControllerMethodSecurityTest.MethodSecurityConfig.class)
+@DisplayName("SensorController method security (@PreAuthorize)")
+class SensorControllerMethodSecurityTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockitoBean
+    private SensorAdminService sensorAdminService;
+
+    // Satisfies OAuth2ResourceServerAutoConfiguration; the test injects auth via jwt().
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    private static final String ASSIGN_BODY = "{\"roomId\":\"011\"}";
+
+    private static final SensorResponse SENSOR = new SensorResponse(
+            "pi-1", null, "006", "006", SensorStatus.CLAIMED,
+            Instant.now(), Instant.now(), null, null);
+
+    @Test
+    @DisplayName("reads are open to any authenticated user")
+    void list_authenticated_returns200() throws Exception {
+        when(sensorAdminService.getAllSensors()).thenReturn(List.of(SENSOR));
+
+        mvc.perform(get("/api/sensors").with(jwt()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("blocks an assignment for a non-admin token (403)")
+    void assign_nonAdmin_returns403() throws Exception {
+        mvc.perform(put("/api/sensors/pi-1/assignment")
+                        .contentType("application/json").content(ASSIGN_BODY).with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("allows an assignment for an admin token (200)")
+    void assign_admin_returns200() throws Exception {
+        when(sensorAdminService.assignRoom(anyString(), anyString())).thenReturn(SENSOR);
+
+        mvc.perform(put("/api/sensors/pi-1/assignment")
+                        .contentType("application/json").content(ASSIGN_BODY)
+                        .with(jwt().authorities(new SimpleGrantedAuthority("ROLE_ADMIN"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("blocks clearing an assignment for a non-admin token (403)")
+    void clear_nonAdmin_returns403() throws Exception {
+        mvc.perform(delete("/api/sensors/pi-1/assignment").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("blocks a delete for a non-admin token (403)")
+    void delete_nonAdmin_returns403() throws Exception {
+        mvc.perform(delete("/api/sensors/pi-1").with(jwt()))
+                .andExpect(status().isForbidden());
+    }
+
+    /**
+     * Method security enabled over a deliberately permissive URL layer, so the only
+     * thing that can deny a request is {@code @PreAuthorize} on the controller.
+     */
+    @TestConfiguration
+    @EnableWebSecurity
+    @EnableMethodSecurity
+    static class MethodSecurityConfig {
+
+        @Bean
+        SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(csrf -> csrf.disable())
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/sensor/SensorControllerTest.java
+++ b/backend/src/test/java/com/occupi/feature/sensor/SensorControllerTest.java
@@ -1,0 +1,86 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.feature.sensor.dto.SensorAssignmentRequest;
+import com.occupi.feature.sensor.dto.SensorNameRequest;
+import com.occupi.feature.sensor.dto.SensorResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SensorController")
+class SensorControllerTest {
+
+    @Mock
+    private SensorAdminService sensorAdminService;
+
+    @InjectMocks
+    private SensorController controller;
+
+    private static final SensorResponse SENSOR = new SensorResponse(
+            "pi-1", "Bibliothek", "006", "006", SensorStatus.CLAIMED,
+            Instant.parse("2026-07-01T08:00:00Z"), Instant.parse("2026-07-04T09:00:00Z"),
+            null, null);
+
+    @Test
+    @DisplayName("GET /api/sensors returns the registry list")
+    void getAllSensors() {
+        when(sensorAdminService.getAllSensors()).thenReturn(List.of(SENSOR));
+
+        assertThat(controller.getAllSensors()).containsExactly(SENSOR);
+    }
+
+    @Test
+    @DisplayName("PUT /api/sensors/{id}/assignment assigns and returns the updated view")
+    void assignRoom() {
+        when(sensorAdminService.assignRoom("pi-1", "011")).thenReturn(SENSOR);
+
+        ResponseEntity<SensorResponse> response =
+                controller.assignRoom("pi-1", new SensorAssignmentRequest("011"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEqualTo(SENSOR);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/sensors/{id}/assignment clears the override")
+    void clearAssignment() {
+        when(sensorAdminService.clearAssignment("pi-1")).thenReturn(SENSOR);
+
+        ResponseEntity<SensorResponse> response = controller.clearAssignment("pi-1");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("PUT /api/sensors/{id} renames the device")
+    void rename() {
+        when(sensorAdminService.rename("pi-1", "Neu")).thenReturn(SENSOR);
+
+        ResponseEntity<SensorResponse> response =
+                controller.rename("pi-1", new SensorNameRequest("Neu"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("DELETE /api/sensors/{id} returns 204")
+    void deleteSensor() {
+        ResponseEntity<Void> response = controller.deleteSensor("pi-1");
+
+        verify(sensorAdminService).delete("pi-1");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+}

--- a/backend/src/test/java/com/occupi/feature/sensor/SensorControllerValidationTest.java
+++ b/backend/src/test/java/com/occupi/feature/sensor/SensorControllerValidationTest.java
@@ -1,0 +1,66 @@
+package com.occupi.feature.sensor;
+
+import com.occupi.config.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class SensorControllerValidationTest {
+
+    private MockMvc mockMvc;
+    private SensorAdminService sensorAdminService;
+
+    @BeforeEach
+    void setUp() {
+        sensorAdminService = Mockito.mock(SensorAdminService.class);
+        mockMvc = MockMvcBuilders
+                .standaloneSetup(new SensorController(sensorAdminService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void assign_withBlankRoomId_returns400() throws Exception {
+        mockMvc.perform(put("/api/sensors/pi-1/assignment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"roomId\":\"  \"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void rename_withBlankName_returns400() throws Exception {
+        mockMvc.perform(put("/api/sensors/pi-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"name\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void assign_unknownSensor_returns404() throws Exception {
+        when(sensorAdminService.assignRoom(anyString(), anyString()))
+                .thenThrow(new SensorNotFoundException("ghost"));
+
+        mockMvc.perform(put("/api/sensors/ghost/assignment")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"roomId\":\"011\"}"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void delete_unknownSensor_returns404() throws Exception {
+        Mockito.doThrow(new SensorNotFoundException("ghost"))
+                .when(sensorAdminService).delete("ghost");
+
+        mockMvc.perform(delete("/api/sensors/ghost"))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## Summary
The correction path of the room mapping: the admin panel can now list every Pi that
ever reported and fix its assignment — including devices whose claimed room id
matches nothing (previously the silent-failure case). Stacked on #325; this PR's
base is the registry branch and retargets to develop once #325 merges.

## Changes
- `SensorAdminService(+Impl)` — list with derived status (claimed / overridden /
  unresolved, effective room, lastSeen, dropped counters from the registry), assign
  (sets the override and remembers the corrected claim), clear, rename, delete.
  Every assignment change invalidates the resolution cache: the next message from
  the device already follows the new mapping.
- `SensorController` — `GET /api/sensors`, `PUT /{id}`, `PUT /{id}/assignment`,
  `DELETE /{id}/assignment`, `DELETE /{id}`; writes admin-only via `@PreAuthorize`,
  doubled by new URL rules in `SecurityConfig` (same two-layer setup as rooms).
- `RoomServiceImpl.deleteRoom` — pre-checks assigned sensors and answers `409` with
  the sensor list; the FK stays as the race backstop.
- DTOs: `SensorResponse`, `SensorAssignmentRequest`, `SensorNameRequest`; new
  `SensorNotFoundException` (404), `RoomHasAssignedSensorsException` (409).

## Tests
`SensorAdminServiceImplTest` (status derivation, assign/clear/rename/delete, 404s),
`SensorControllerTest`, `SensorControllerValidationTest` (blank bodies → 400,
404 passthrough), `SensorControllerMethodSecurityTest` (mirrors the room setup),
`RoomServiceImplTest` extended for the 409 guard.

## Verification
- `./mvnw test` green (282 tests)

Closes #311