### PR TITLE
refactor: docker/server fully configured stack (build from source) #314

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ docker/seed.py
 
 ### Local secrets ###
 docker/.env
+# docker/local/.env is committed on purpose (no secrets, working defaults) —
+# the server and Pi env files hold real secrets and stay out of git.
+docker/server/.env
+raspberry/docker/.env
 
 ### Python (raspberry/) ###
 .venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- `docker/server/`: the deliberately configured counterpart to `docker/local/`. One
+  `.env.example` that must be filled completely — the compose file fail-fasts with
+  `${VAR:?}` on every missing required value (Postgres, Keycloak admin, Grafana
+  admin, `PUBLIC_HOST`, `CORS_ALLOWED_ORIGINS`, `INFLUXDB_TOKEN`), so no silent
+  default passwords survive on a server. Backend and frontend build from source with
+  `VITE_*` derived from `PUBLIC_HOST`; every port binds to 127.0.0.1 (nginx stays the
+  only public entry). InfluxDB runs WITH token auth (bootstrap documented; the
+  healthcheck sends the token — `/health` answers 401 without one). The realm import
+  file uses `${OCCUPI_PUBLIC_URL}` placeholders, substitution verified against
+  Keycloak 26.2. The project name is pinned to `occupi` and the data volumes attach
+  externally to the legacy names (`docker_influxdb3-data`, `docker_postgres-data`) —
+  the VM keeps every byte across the restructure; fresh servers create the two
+  volumes once (#314).
 - `docker/local/`: the complete stack in one command. `cd docker/local && docker
   compose up -d --build` starts backend + frontend (built from source with
   localhost URLs), Postgres, Keycloak (imports a localhost realm with seeded test

--- a/docker/server/.env.example
+++ b/docker/server/.env.example
@@ -1,0 +1,34 @@
+# OccuPi server deployment — copy to .env and fill in EVERY value:
+#   cp .env.example .env
+# docker/server/.env is git-ignored; it holds real secrets and never gets
+# committed. The compose file fail-fasts on every missing required variable,
+# so an incomplete .env stops at `docker compose config` instead of running
+# half-configured.
+
+# ── Public identity ──────────────────────────────────────────────────────────
+# Hostname the deployment is served under (nginx + TLS terminate there).
+# Drives Keycloak's hostname, the realm's redirect URIs and the frontend build
+# (VITE_API_URL=https://<host>/api, VITE_KEYCLOAK_URL=https://<host>/auth).
+PUBLIC_HOST=occupi.mi.hdm-stuttgart.de
+
+# Origins allowed for browser access (CORS, HTTP + WebSocket), comma-separated.
+# Usually just the public origin.
+CORS_ALLOWED_ORIGINS=https://occupi.mi.hdm-stuttgart.de
+
+# ── PostgreSQL (backend 'occupi' DB + Keycloak's 'keycloak' DB) ──────────────
+POSTGRES_USER=occupi
+POSTGRES_PASSWORD=use-a-long-random-password
+
+# ── Keycloak bootstrap admin (console login at https://<host>/auth) ─────────
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=use-a-long-random-password
+
+# ── InfluxDB 3 admin token ───────────────────────────────────────────────────
+# The server InfluxDB runs WITH auth. Create the token once on first start
+# (see README "InfluxDB token bootstrap"), then paste it here. Consumed by the
+# backend (writes + queries) and Grafana (FlightSQL datasource).
+INFLUXDB_TOKEN=apiv3_paste-the-generated-admin-token-here
+
+# ── Grafana admin (reached via SSH tunnel to 127.0.0.1:3001) ─────────────────
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=use-a-long-random-password

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -1,0 +1,73 @@
+# OccuPi Server-Deployment
+
+Dieser Stack ist das Gegenstück zu `docker/local/`: gleiche Dienste, aber bewusst
+vollständig konfiguriert. Es gibt keine stillen Default-Passwörter — jede
+Pflichtvariable fehlt laut Fehlermeldung genau dann, wenn sie in der `.env` fehlt.
+
+```bash
+cd docker/server
+cp .env.example .env     # JEDEN Wert ausfüllen (Kommentare erklären ihn)
+docker compose config    # prüft die .env, bricht bei fehlenden Werten ab
+docker compose up -d --build
+```
+
+Backend und Frontend bauen aus dem Repo-Stand; die `VITE_*`-URLs entstehen aus
+`PUBLIC_HOST` in der `.env`. Öffentlich ist nur nginx (`deploy/nginx/occupi.conf`);
+alle Container-Ports binden an 127.0.0.1.
+
+## Bestands-VM vs. frischer Server
+
+- **Bestands-VM (occupi.mi.hdm-stuttgart.de):** Die Volumes des alten
+  `docker/`-Stacks werden extern adoptiert (`docker_influxdb3-data`,
+  `docker_postgres-data`) — der Umzug kostet null Bytes. Den kompletten Ablauf
+  inklusive Backup, Timer-Stopp und Rollback beschreibt das Runbook in
+  `deploy/README.md`. Wichtig: Alten und neuen Stack nie gleichzeitig starten
+  (gleiche Volumes, gleiche Containernamen).
+- **Frischer Server:** die zwei Volumes einmalig anlegen, dann normal starten:
+
+  ```bash
+  docker volume create docker_influxdb3-data docker_postgres-data
+  ```
+
+## InfluxDB-Token-Bootstrap (einmalig)
+
+Der Server-InfluxDB läuft mit Auth. Beim allerersten Start existiert noch kein
+Token — so entsteht es:
+
+```bash
+docker compose up -d influxdb          # Healthcheck bleibt zunächst rot: normal
+docker exec occupi-influxdb3 influxdb3 create token --admin
+# → apiv3_...-Token in .env als INFLUXDB_TOKEN eintragen
+docker compose up -d --build           # Rest des Stacks mit gültigem Token
+```
+
+Das Token konsumieren Backend (Writes, Queries, Last-Cache-Anlage) und Grafana
+(FlightSQL-Datasource). Der Influx-Healthcheck prüft MIT Token — wird das Token
+in der `.env` geändert, `docker compose up -d influxdb` nicht vergessen.
+
+## Keycloak
+
+- Realm-Import (`keycloak/realm-server.json`) läuft nur in eine leere
+  Keycloak-Datenbank. Auf der Bestands-VM existiert der Realm bereits in
+  Postgres — die Datei greift dort NIE; Änderungen laufen über die Admin-Console.
+  (Für frische Server substituiert Keycloak die `${OCCUPI_PUBLIC_URL}`-Platzhalter
+  beim Import — gegen 26.2 verifiziert.)
+- Login-Quellen: HdM-LDAP-Federation (read-only). Admin-Rollen vergibt man
+  HdM-Accounts in der Console (Realm occupi → Users → Role mapping).
+
+## Grafana
+
+Läuft auf 127.0.0.1:3001, nicht über nginx. Zugriff per SSH-Tunnel:
+
+```bash
+ssh -L 3001:127.0.0.1:3001 <server>   # dann http://localhost:3001
+```
+
+Datasource (FlightSQL, mit Token) und das Dashboard „OccuPi — Raumbelegung"
+(`docker/shared/grafana/dashboards/`) sind provisioniert.
+
+## Deploy-Automatik
+
+Der systemd-Timer (`deploy/occupi-autodeploy.timer`, alle 5 min) ruft
+`deploy/auto-deploy.sh` auf: bei neuen Commits auf `develop` wird gebaut und neu
+gestartet. Details und die Umstellung von der alten GHCR-Pull-Logik: `deploy/README.md`.

--- a/docker/server/compose.yml
+++ b/docker/server/compose.yml
@@ -1,0 +1,189 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# OccuPi — server deployment. Deliberately fully configured:
+#
+#   cp .env.example .env    → fill in EVERY value (the stack refuses to start
+#   docker compose up -d --build          with missing required variables)
+#
+# Backend and frontend build from source on the server (the VITE_* URLs come
+# from .env as build args — no registry image is tied to one hostname anymore).
+# The systemd timer runs deploy/auto-deploy.sh, which rebuilds on new commits.
+#
+# Data: the project name is pinned to 'occupi' and the volumes attach to the
+# EXISTING volumes of the legacy docker/ stack (external, legacy names) — the
+# move to this file costs zero bytes of data. A fresh server creates them once:
+#   docker volume create docker_influxdb3-data docker_postgres-data
+#
+# Only nginx (deploy/nginx) is public; every port here binds to 127.0.0.1.
+# ─────────────────────────────────────────────────────────────────────────────
+name: occupi
+
+services:
+  backend:
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile
+    container_name: occupi-backend
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      JAVA_TOOL_OPTIONS: -Xms256m -Xmx512m
+      POSTGRES_URL: jdbc:postgresql://postgres:5432/occupi
+      POSTGRES_USER: ${POSTGRES_USER:?set POSTGRES_USER in docker/server/.env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in docker/server/.env}
+      INFLUXDB_URL: http://influxdb:8181
+      INFLUXDB_TOKEN: ${INFLUXDB_TOKEN:?set INFLUXDB_TOKEN in docker/server/.env — see README, token bootstrap}
+      KEYCLOAK_JWK_SET_URI: http://keycloak:8080/auth/realms/occupi/protocol/openid-connect/certs
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:?set CORS_ALLOWED_ORIGINS in docker/server/.env}
+    ports:
+      - "127.0.0.1:8080:8080"
+    depends_on:
+      influxdb:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "bash", "-c", "exec 3<>/dev/tcp/localhost/8080 && printf 'GET /v3/api-docs HTTP/1.0\\r\\n\\r\\n' >&3 && grep -q openapi <&3"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 40s
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ../../frontend
+      dockerfile: Dockerfile
+      args:
+        VITE_API_URL: https://${PUBLIC_HOST:?set PUBLIC_HOST in docker/server/.env}/api
+        VITE_KEYCLOAK_URL: https://${PUBLIC_HOST}/auth
+        VITE_KEYCLOAK_REALM: occupi
+        VITE_KEYCLOAK_CLIENT_ID: occupi-frontend
+    container_name: occupi-frontend
+    ports:
+      - "127.0.0.1:3000:80"
+    restart: unless-stopped
+
+  influxdb:
+    image: influxdb:3.9.3-core
+    container_name: occupi-influxdb3
+    environment:
+      INFLUXDB3_HOST_ID: occupi-prod
+    # Token auth is ON (no --without-auth, unlike local). First-time setup
+    # creates the admin token once — see README "InfluxDB token bootstrap".
+    command: >
+      serve --host-id occupi-prod --http-bind 0.0.0.0:8181
+      --object-store file --data-dir /var/lib/influxdb3
+      --query-file-limit 10000
+    volumes:
+      - influxdb3-data:/var/lib/influxdb3
+    # With auth on, /health also requires the token (verified against 3.9.3-core:
+    # 401 without). During the first-boot token bootstrap the check stays red —
+    # that is expected and documented in the README; `docker exec` works anyway.
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "Authorization: Bearer ${INFLUXDB_TOKEN}", "http://localhost:8181/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    # One heavy query must never starve the single-core host (#273).
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 2g
+        reservations:
+          memory: 256m
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16
+    container_name: occupi-postgres
+    environment:
+      POSTGRES_DB: occupi
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ../shared/postgres-init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d occupi"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.2
+    container_name: occupi-keycloak
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:?set KEYCLOAK_ADMIN in docker/server/.env}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in docker/server/.env}
+      KC_HOSTNAME: ${PUBLIC_HOST}
+      KC_HOSTNAME_STRICT: "true"
+      # Served under https://<host>/auth — matches the host nginx /auth route.
+      KC_HTTP_RELATIVE_PATH: /auth/
+      # Keep the management/health endpoint (port 9000) at root, otherwise /auth
+      # also moves /health/ready and the container healthcheck fails.
+      KC_HTTP_MANAGEMENT_RELATIVE_PATH: "/"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+      KC_PROXY_HEADERS: xforwarded
+      KC_DB: postgres
+      KC_DB_URL: jdbc:postgresql://postgres:5432/keycloak
+      KC_DB_USERNAME: ${POSTGRES_USER}
+      KC_DB_PASSWORD: ${POSTGRES_PASSWORD}
+      # Substituted INSIDE realm-server.json by Keycloak's --import-realm
+      # placeholder support (redirect URIs / webOrigins). Import only applies
+      # when the realm does not exist yet — on the VM the realm already lives
+      # in Postgres, so changes there go through the admin console.
+      OCCUPI_PUBLIC_URL: https://${PUBLIC_HOST}
+    command: start --import-realm
+    volumes:
+      - ./keycloak/realm-server.json:/opt/keycloak/data/import/realm-server.json:ro
+    ports:
+      - "127.0.0.1:8180:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && echo -e 'GET /health/ready HTTP/1.0\\r\\n\\r\\n' >&3 && grep -q 'UP' <&3"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.6.1
+    container_name: occupi-grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?set GRAFANA_ADMIN_USER in docker/server/.env}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in docker/server/.env}
+      GF_INSTALL_PLUGINS: influxdata-flightsql-datasource
+      # Consumed by the datasource provisioning file ($INFLUXDB_TOKEN).
+      INFLUXDB_TOKEN: ${INFLUXDB_TOKEN}
+    volumes:
+      - ./grafana/datasources:/etc/grafana/provisioning/datasources:ro
+      - ../shared/grafana/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    # Not proxied by nginx — reach it via an SSH tunnel:
+    #   ssh -L 3001:127.0.0.1:3001 <server>   →  http://localhost:3001
+    ports:
+      - "127.0.0.1:3001:3000"
+    depends_on:
+      influxdb:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  # The legacy stack (project 'docker') created these names; attaching them as
+  # external keeps every byte of data across the restructure. Fresh install:
+  #   docker volume create docker_influxdb3-data docker_postgres-data
+  influxdb3-data:
+    external: true
+    name: docker_influxdb3-data
+  postgres-data:
+    external: true
+    name: docker_postgres-data
+  grafana-data:

--- a/docker/server/grafana/datasources/influxdb.yaml
+++ b/docker/server/grafana/datasources/influxdb.yaml
@@ -1,0 +1,19 @@
+# FlightSQL datasource for the server InfluxDB 3 — token auth, unlike local.
+# $INFLUXDB_TOKEN is expanded by Grafana's provisioning from the container env.
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB (FlightSQL)
+    uid: occupi-influxdb
+    type: influxdata-flightsql-datasource
+    access: proxy
+    isDefault: true
+    editable: true
+    jsonData:
+      host: influxdb:8181
+      secure: false
+      selectedAuthType: token
+      metadata:
+        - database: occupi
+    secureJsonData:
+      token: $INFLUXDB_TOKEN

--- a/docker/server/keycloak/realm-server.json
+++ b/docker/server/keycloak/realm-server.json
@@ -1,0 +1,236 @@
+{
+  "realm": "occupi",
+  "enabled": true,
+  "registrationAllowed": false,
+  "loginWithEmailAllowed": false,
+  "duplicateEmailsAllowed": true,
+  "sslRequired": "external",
+  "roles": {
+    "realm": [
+      {
+        "name": "admin",
+        "description": "OccuPi administrator — may manage rooms (create/update/delete)"
+      },
+      {
+        "name": "user",
+        "description": "Standard OccuPi user — read access"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "occupi-backend",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "bearerOnly": true,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false
+    },
+    {
+      "clientId": "occupi-frontend",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "bearerOnly": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "redirectUris": [
+        "${OCCUPI_PUBLIC_URL}/*"
+      ],
+      "webOrigins": [
+        "${OCCUPI_PUBLIC_URL}"
+      ]
+    }
+  ],
+  "components": {
+    "org.keycloak.storage.UserStorageProvider": [
+      {
+        "name": "hdm-ldap",
+        "providerId": "ldap",
+        "subComponents": {
+          "org.keycloak.storage.ldap.mappers.LDAPStorageMapper": [
+            {
+              "name": "username",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": [
+                  "uid"
+                ],
+                "user.model.attribute": [
+                  "username"
+                ],
+                "always.read.value.from.ldap": [
+                  "false"
+                ],
+                "is.mandatory.in.ldap": [
+                  "true"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "attribute.force.default": [
+                  "false"
+                ],
+                "is.binary.attribute": [
+                  "false"
+                ]
+              }
+            },
+            {
+              "name": "email",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": [
+                  "mail"
+                ],
+                "user.model.attribute": [
+                  "email"
+                ],
+                "always.read.value.from.ldap": [
+                  "false"
+                ],
+                "is.mandatory.in.ldap": [
+                  "false"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "attribute.force.default": [
+                  "false"
+                ],
+                "is.binary.attribute": [
+                  "false"
+                ]
+              }
+            },
+            {
+              "name": "first name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": [
+                  "givenName"
+                ],
+                "user.model.attribute": [
+                  "firstName"
+                ],
+                "always.read.value.from.ldap": [
+                  "false"
+                ],
+                "is.mandatory.in.ldap": [
+                  "false"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "attribute.force.default": [
+                  "false"
+                ],
+                "is.binary.attribute": [
+                  "false"
+                ]
+              }
+            },
+            {
+              "name": "last name",
+              "providerId": "user-attribute-ldap-mapper",
+              "config": {
+                "ldap.attribute": [
+                  "sn"
+                ],
+                "user.model.attribute": [
+                  "lastName"
+                ],
+                "always.read.value.from.ldap": [
+                  "false"
+                ],
+                "is.mandatory.in.ldap": [
+                  "false"
+                ],
+                "read.only": [
+                  "true"
+                ],
+                "attribute.force.default": [
+                  "false"
+                ],
+                "is.binary.attribute": [
+                  "false"
+                ]
+              }
+            }
+          ]
+        },
+        "config": {
+          "enabled": [
+            "true"
+          ],
+          "priority": [
+            "0"
+          ],
+          "editMode": [
+            "READ_ONLY"
+          ],
+          "syncRegistrations": [
+            "false"
+          ],
+          "vendor": [
+            "other"
+          ],
+          "usernameLDAPAttribute": [
+            "uid"
+          ],
+          "rdnLDAPAttribute": [
+            "uid"
+          ],
+          "uuidLDAPAttribute": [
+            "uid"
+          ],
+          "userObjectClasses": [
+            "inetOrgPerson"
+          ],
+          "connectionUrl": [
+            "ldap://ldap.hdm-stuttgart.de:389"
+          ],
+          "usersDn": [
+            "ou=userlist,dc=hdm-stuttgart,dc=de"
+          ],
+          "authType": [
+            "none"
+          ],
+          "importEnabled": [
+            "false"
+          ],
+          "batchSizeForSync": [
+            "1000"
+          ],
+          "fullSyncPeriod": [
+            "-1"
+          ],
+          "changedSyncPeriod": [
+            "-1"
+          ],
+          "debug": [
+            "false"
+          ],
+          "searchScope": [
+            "1"
+          ],
+          "validatePasswordPolicy": [
+            "false"
+          ],
+          "trustEmail": [
+            "false"
+          ],
+          "connectionPooling": [
+            "true"
+          ],
+          "pagination": [
+            "true"
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
The second half of the one-decision layout: `docker/server/` is the deliberately
configured stack. `cp .env.example .env`, fill EVERY value, `docker compose up -d
--build` — an incomplete `.env` stops at `docker compose config` with a message
naming the missing variable instead of running half-configured with default
passwords. Stacked on #327 (shares `docker/shared/`); retargets to develop once
that merges.

## Changes
- `docker/server/compose.yml` — same topology as local, server discipline:
  `build:` for backend+frontend (`VITE_*` from `PUBLIC_HOST` — the Vite build-time
  constraint is gone, no registry image is tied to a hostname), all ports on
  127.0.0.1, `${VAR:?message}` fail-fast for every secret, Influx CPU/memory caps
  carried over from the prod overlay, `container_name`s kept (`occupi-*` — the
  seed script and the deploy health checks depend on them).
- **InfluxDB with token auth** — no `--without-auth` on the server anymore (closes
  the long-standing known gap). Token bootstrap is a documented one-time
  `docker exec … influxdb3 create token --admin`; the compose healthcheck sends the
  token because `/health` answers 401 without one (verified against 3.9.3-core).
- `keycloak/realm-server.json` — generated from the existing realm: LDAP federation,
  no test users, redirect URIs/webOrigins as `${OCCUPI_PUBLIC_URL}` placeholders.
  **Placeholder substitution at `--import-realm` verified against Keycloak 26.2**
  (throwaway container, imported client showed the substituted URL) — the sed
  fallback from the plan is unnecessary.
- Volume adoption (`name: occupi` + `external: true` with the legacy
  `docker_*-data` names): the VM move costs zero bytes; fresh servers run two
  documented `docker volume create` commands.
- Grafana on 127.0.0.1:3001 (SSH tunnel), FlightSQL datasource provisioned WITH the
  token; dashboard shared from `docker/shared/`.
- `.gitignore` — `docker/server/.env` and `raspberry/docker/.env` (real secrets)
  are ignored; `docker/local/.env` stays committed on purpose.
- `docker/server/README.md` — fresh-install vs. VM adoption, token bootstrap, realm
  caveat, SSH tunnel, pointer to the migration runbook (lands in `deploy/README.md`
  with #315).

## Verification
- `docker compose config` fails with a readable message per missing variable
  (exit 1); passes with a filled `.env`
- Keycloak 26.2 placeholder import: empirically verified (see above)
- InfluxDB 3.9.3-core auth behavior + token creation: empirically verified
- Full boot happens on the VM per runbook (#315) — old and new stack share volumes
  and must never run at the same time

Closes #314