### PR TITLE
refactor: auto-deploy builds from source against docker/server #315

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,16 @@ and the project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   live occupancy for room 137 (#201).
 
 ### Changed
+- Auto-deploy builds from source now: the systemd timer stays exactly as it is
+  (5-minute tick, same units), but `deploy/auto-deploy.sh` triggers on new commits
+  on `origin/develop` instead of moved GHCR digests, builds backend and frontend
+  serially against `docker/server/compose.yml`, health-gates both, and rolls back
+  by resetting to the last good commit and rebuilding (minutes, not seconds — the
+  accepted cost for images that no longer depend on a registry or a baked-in
+  hostname). A swap file is now a documented prerequisite: an unswapped on-server
+  build killed the VM once (#140). The full VM cutover — volume adoption, Influx
+  token bootstrap, timer conversion table, rollback — lives as a runbook in
+  `deploy/README.md` (#315).
 - The backend's InfluxDB connection (`INFLUXDB_URL`/`INFLUXDB_DATABASE`/`INFLUXDB_TOKEN`)
   and the CORS origins (`CORS_ALLOWED_ORIGINS`, comma-separated patterns) are now plain
   environment variables with the previous values as local defaults. The origin list is

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,13 +1,15 @@
 # OccuPi — deploy
 
 Host-side bits that live outside Docker Compose: the Nginx reverse proxy
-([`nginx/occupi.conf`](nginx/occupi.conf)) and the **automatic deploy** timer.
+([`nginx/occupi.conf`](nginx/occupi.conf)), the **automatic deploy** timer and the
+**migration runbook** for moving the VM onto `docker/server/`.
 
 ## Automatic deploy (systemd timer)
 
-The server only ever **pulls** prebuilt images from GHCR and never builds (an
-on-server Maven build once exhausted the swapless VM's RAM, see #140). This timer
-automates the manual `pull` + recreate you would otherwise SSH in to run.
+The server builds backend and frontend **from source** on every new commit to
+`develop` (decision recorded in the ADRs; the GHCR-pull flow this replaced is
+described at the end of this section). The timer automates the manual
+pull + build + recreate you would otherwise SSH in to run.
 
 ```
 auto-deploy.sh              # the deploy logic (versioned here, runs from the repo)
@@ -15,82 +17,95 @@ occupi-autodeploy.service   # one-shot unit that runs the script
 occupi-autodeploy.timer     # fires the service every 5 minutes
 ```
 
+> **Prerequisite: a swap file.** An on-server build once exhausted the swapless
+> VM's RAM and took the box down (#140). Before the first build-based deploy:
+>
+> ```bash
+> fallocate -l 2G /swapfile && chmod 600 /swapfile
+> mkswap /swapfile && swapon /swapfile
+> echo '/swapfile none swap sw 0 0' >> /etc/fstab   # survive reboots
+> ```
+
 ### What a run does
 
-1. **Fast-forwards the repo** (`git pull --ff-only` on `develop`) so compose files
-   and this script stay current. Diverged/blocked checkout → it warns and skips
-   the update instead of forcing anything.
-2. **Pulls** the latest `backend` + `frontend` images from GHCR (download only —
-   running containers are not touched yet).
-3. **Recreates only what changed.** A service is restarted only if its `:latest`
-   image id differs from the one its container is running. Infra
-   (`postgres` / `keycloak` / `influxdb`) is deliberately left alone.
-4. **Health-gates each update with rollback.** After recreating a service it polls
-   a liveness URL (`backend` → `/v3/api-docs`, `frontend` → `/`). If it does not
-   return `200` within ~2 min, it **rolls back** to the previous image, records the
-   bad image digest, and that digest is **not redeployed** until `:latest` moves on.
-5. **Prunes** dangling and >14-day-old unused images to reclaim disk.
+1. **Fetches** `origin/develop` and compares commits. Nothing new and both
+   services running → the run ends right there (cheap no-op every 5 minutes).
+2. **Fast-forwards the repo** — compose files, sources and the script itself.
+   A diverged checkout makes it skip the run instead of forcing anything.
+3. **Builds from source, one service at a time** (`docker compose build backend`,
+   then `frontend`) — serial on purpose, the single-core host must never run two
+   builds at once.
+4. **Recreates and health-gates** each service (`backend` → `/v3/api-docs`,
+   `frontend` → `/`; up to ~2 min each). On failure it **rolls back**: reset to
+   the last good commit, rebuild, and the bad commit is recorded so it is not
+   retried until `develop` moves past it.
+5. **Prunes** dangling and >14-day-old unused images — source builds leave
+   layers behind on every run.
 
-It is safe to run on every tick: when nothing changed it is a no-op. Only one run
-executes at a time (flock).
+Infra (postgres / keycloak / influxdb / grafana) is deliberately never touched:
+pinned versions, updated manually. Only one run executes at a time (flock).
 
-> **Note:** auto-deploy means *every merge to `develop` goes live by itself*
-> within ~5–10 min (CI build + next tick). That is the intended behaviour.
+> **Note:** auto-deploy still means *every merge to `develop` goes live by
+> itself* — now within ~5–10 min including the build instead of a registry pull.
+> Rollback is a rebuild and takes minutes, not seconds; that is the accepted
+> cost of images that no longer depend on a registry or a baked-in hostname.
+
+### Was sich am Timer geändert hat (GHCR-Pull → Build)
+
+Der 5-Minuten-Mechanismus ist ein systemd-**Timer**, kein Crontab:
+`occupi-autodeploy.timer` startet alle 5 Minuten `occupi-autodeploy.service`,
+und der führt `deploy/auto-deploy.sh` aus. **An den beiden Unit-Dateien ändert
+sich nichts** — gleicher Timer, gleicher Rhythmus, gleiche Befehle
+(`systemctl`/`journalctl` wie gehabt). Nur die Logik im Skript ist neu:
+
+| | vorher (GHCR-Pull) | jetzt (Build from source) |
+|---|---|---|
+| Auslöser | `:latest`-Image-Digest hat sich bewegt | neuer Commit auf `origin/develop` |
+| Beschaffung | `docker compose pull` aus GHCR | `docker compose build` aus dem Repo |
+| Compose-Dateien | `docker/docker-compose.yml` + `prod`-Overlay | `docker/server/compose.yml` |
+| Rollback | vorheriges Image re-taggen (Sekunden) | Reset auf letzten guten Commit + Rebuild (Minuten) |
+| Merker für „kaputt" | Bad-Digest-Datei | Bad-Commit-Datei |
+
+Da das Skript direkt aus dem Repo läuft, aktiviert sich die neue Logik von
+selbst mit dem `git pull` des Cutovers — die Units müssen nicht neu kopiert
+werden.
 
 ### Install (one-time, on the server, as root)
 
-After this is merged to `develop` and the repo is pulled on the server:
-
 ```bash
 cd /home/Elhan/Occupi
-git pull --ff-only                      # get the deploy/ files
+git pull --ff-only
 
-# Copy the units into systemd (cp, not symlink — most reliable for enable):
 cp deploy/occupi-autodeploy.service deploy/occupi-autodeploy.timer /etc/systemd/system/
-
 systemctl daemon-reload
 systemctl enable --now occupi-autodeploy.timer
 
-# Optional: run it once now and watch it
-systemctl start occupi-autodeploy.service
+systemctl start occupi-autodeploy.service   # optional: run once now
 journalctl -u occupi-autodeploy -f
 ```
-
-The **script** (`auto-deploy.sh`) runs straight from the repo, so it stays current
-via `git pull` automatically. Only the two **unit files** are copied — re-`cp` them
-+ `systemctl daemon-reload` on the rare occasion they change.
 
 ### Operate
 
 ```bash
 systemctl list-timers occupi-autodeploy.timer     # when does it next run?
 journalctl -u occupi-autodeploy -n 100 --no-pager # recent deploy logs
-systemctl start occupi-autodeploy.service         # deploy now (don't wait for the tick)
+systemctl start occupi-autodeploy.service         # deploy now (don't wait)
 
-# Pause / resume automatic deploys:
-systemctl stop occupi-autodeploy.timer            # pause
+systemctl stop occupi-autodeploy.timer            # pause automatic deploys
 systemctl start occupi-autodeploy.timer           # resume
 ```
 
-A failed deploy makes the **service** unit fail (visible in
-`systemctl status occupi-autodeploy.service` and `journalctl`). The site stays up
-because the script rolls back.
-
-### Change the deploy logic later
-
-`auto-deploy.sh` runs straight from the repo, so editing it via Git (push to
-`develop`) takes effect on the next tick — **no server access needed**. Only
-changing the schedule in `occupi-autodeploy.timer` needs a server-side re-`cp`
-+ `systemctl daemon-reload`.
+A failed deploy makes the service unit fail (visible in `systemctl status` /
+`journalctl`); the site stays up because the script rolls back to the last good
+commit. On non-standard hosts, `REPO_DIR` and `BRANCH` are env-overridable.
 
 ### Manual deploy (no timer)
 
-The timer just automates this; you can always do it by hand:
-
 ```bash
-cd /home/Elhan/Occupi/docker
-docker compose -f docker-compose.yml -f docker-compose.prod.yml pull
-docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+cd /home/Elhan/Occupi && git pull --ff-only
+cd docker/server
+docker compose build backend && docker compose build frontend
+docker compose up -d
 ```
 
 ### Uninstall
@@ -100,6 +115,94 @@ systemctl disable --now occupi-autodeploy.timer
 rm -f /etc/systemd/system/occupi-autodeploy.{service,timer}
 systemctl daemon-reload
 ```
+
+## Migrations-Runbook: VM auf docker/server umziehen
+
+Einmaliger Cutover von der alten Struktur (base + prod-Overlay, GHCR-Images) auf
+`docker/server/`. Kernpunkt: `docker/server/compose.yml` adoptiert die
+**bestehenden** Volumes (`docker_influxdb3-data`, `docker_postgres-data`) extern —
+es werden null Bytes kopiert, die Historie bleibt vollständig. Geplante Downtime:
+wenige Minuten plus der erste Build.
+
+**Niemals alten und neuen Stack gleichzeitig starten** — gleiche Volumes, gleiche
+Containernamen.
+
+1. **Automatik einfrieren** (sonst führt der Timer den Cutover unbeaufsichtigt
+   aus, sobald das neue Skript auf `develop` liegt):
+
+   ```bash
+   systemctl stop occupi-autodeploy.timer occupi-autodeploy.service
+   ```
+
+2. **Backups:**
+
+   ```bash
+   docker exec occupi-postgres pg_dumpall -U occupi > ~/backup-$(date +%F).sql
+   docker run --rm -v docker_influxdb3-data:/v -v ~/:/bk alpine \
+     tar czf /bk/influx-backup-$(date +%F).tgz /v
+   ```
+
+3. **Swap anlegen** (falls noch nicht vorhanden — siehe Kasten oben; ohne Swap
+   kann der erste Build die VM abschießen, das ist #140 in neu).
+
+4. **Repo aktualisieren:** `git -C /home/Elhan/Occupi pull --ff-only`
+
+5. **`docker/server/.env` füllen:** `cp docker/server/.env.example docker/server/.env`,
+   Werte aus der alten `docker/.env` übernehmen (`POSTGRES_PASSWORD`,
+   `KEYCLOAK_ADMIN_PASSWORD`; `KC_HOSTNAME` heißt jetzt `PUBLIC_HOST`), Neues
+   setzen (`GRAFANA_ADMIN_*`, `CORS_ALLOWED_ORIGINS`); `INFLUXDB_TOKEN` bleibt
+   vorerst der Platzhalter. `docker compose config` in `docker/server/` meldet
+   jede fehlende Pflichtvariable.
+
+6. **Alten Stack stoppen** (niemals `down -v` — die Volumes gehören jetzt dem
+   neuen Stack):
+
+   ```bash
+   cd /home/Elhan/Occupi/docker
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml down
+   ```
+
+7. **InfluxDB-Token-Bootstrap** (Influx läuft ab jetzt MIT Auth):
+
+   ```bash
+   cd /home/Elhan/Occupi/docker/server
+   docker compose up -d influxdb          # Healthcheck bleibt rot, ist ok
+   docker exec occupi-influxdb3 influxdb3 create token --admin
+   # apiv3_...-Token in .env als INFLUXDB_TOKEN eintragen
+   ```
+
+8. **Stack hochziehen:** `docker compose up -d --build` (erster Build dauert
+   einige Minuten; Projekt `occupi`, externe Volumes docken an).
+
+9. **Verifizieren:** Startseite, `https://<host>/api/rooms` (Raumliste intakt),
+   Login über `/auth`, `/ws`-Verbindung des Pi (Reconnect-Queue des Senders
+   überbrückt den Neustart), History-Chart eines Bestandsraums (beweist das
+   Influx-Volume), Grafana-Datasource healthy (SSH-Tunnel auf :3001), und in
+   Postgres existiert die `sensors`-Tabelle samt FK (`\d sensors`).
+
+10. **Keycloak-Hinweis:** Der Realm existiert bereits in Postgres —
+    `realm-server.json` wird auf der VM nie importiert; Realm-Änderungen laufen
+    weiter über die Admin-Console.
+
+11. **Laufender Pi — null Datenlücke:** Der Sender schickt unverändert
+    `{roomId, sensorId, …}`; das Backend liest das als Claim + Geräte-ID, der
+    Raum existiert, die Daten fließen weiter. Beim späteren Umzug des Pi auf
+    `raspberry/docker/` **dieselbe `SENSOR_ID` (`sensor-01`) wiederverwenden**,
+    damit Registry- und Metrik-Historie zusammenbleiben.
+
+12. **Automatik wieder aktivieren:**
+
+    ```bash
+    systemctl start occupi-autodeploy.timer
+    journalctl -u occupi-autodeploy -f     # einen grünen Lauf abwarten
+    ```
+
+**Rollback:** Solange die alten Compose-Dateien existieren (`docker/docker-compose*.yml`,
+Löschung erst nach Soak-Phase): neuen Stack `down` (ohne `-v`), alten mit
+`-f docker-compose.yml -f docker-compose.prod.yml up -d` starten — die Daten
+liegen in denselben Volumes. Influx-Auth-Probleme: übergangsweise
+`--without-auth` in `docker/server/compose.yml` re-aktivieren und forward fixen.
+Postgres-Notfall: Dump aus Schritt 2 einspielen.
 
 ## Demo data seed
 
@@ -134,10 +237,9 @@ One run always drops and reseeds the whole table, so repeating it is safe.
    recreates the cache with the backend's exact definition right after the
    first chunk (#294).
 3. **Upserts the demo rooms** in the Postgres `rooms` table. The traffic light
-   divides live counts by these capacities, so the live rooms must match
-   `DEMO_ROOMS` in `raspberry/config.py` exactly (`016E:50`, `136:20`,
-   `011:250`). Room 137 keeps whatever the admin panel says; the Keycloak
-   database is never touched.
+   divides live counts by these capacities, so the live rooms must match the
+   demo sender's room list exactly (`016E:50`, `136:20`, `011:250`). Room 137
+   keeps whatever the admin panel says; the Keycloak database is never touched.
 4. **Restarts the backend.** It creates its InfluxDB caches only at startup
    (#294), and the restart also drops the chart caches (#280), so the fresh
    data shows up immediately.

--- a/deploy/auto-deploy.sh
+++ b/deploy/auto-deploy.sh
@@ -1,23 +1,26 @@
 #!/usr/bin/env bash
 #
-# OccuPi — automatic deploy (poll & apply the latest GHCR images, health-gated).
+# OccuPi — automatic deploy (build from source on new commits, health-gated).
 #
 # Invoked periodically by occupi-autodeploy.timer. Each run:
-#   1. fast-forwards the repo (compose files + this script itself),
-#   2. pulls the latest backend/frontend images from GHCR,
-#   3. recreates ONLY the services whose image actually changed,
-#   4. health-checks each; on failure it ROLLS BACK to the previous image and
-#      records the bad digest so it is not redeployed until :latest moves on,
+#   1. fetches origin and compares commits — no new commit on the branch means
+#      the run is a cheap no-op,
+#   2. fast-forwards the repo (compose files, sources and this script itself),
+#   3. builds backend and frontend from source, ONE AT A TIME (the single-core
+#      host must never run two builds at once; a swap file is required — an
+#      unswapped build killed this VM once, see #140 and deploy/README.md),
+#   4. recreates the two services and health-checks them; on failure it ROLLS
+#      BACK to the last good commit (reset + rebuild) and records the bad
+#      commit so it is not retried until the branch moves on,
 #   5. prunes old images to reclaim disk.
 #
-# Infra (postgres / keycloak / influxdb) is intentionally NOT touched here —
-# those are pinned versions and updated manually (a DB major upgrade can need
-# migration steps). See deploy/README.md.
+# Infra (postgres / keycloak / influxdb / grafana) is intentionally NOT touched
+# here — pinned versions, updated manually. See deploy/README.md.
 #
 # Runs as root via systemd. Logs go to journald:  journalctl -u occupi-autodeploy
 #
-# The server only ever PULLS prebuilt images and never builds (see #140), so this
-# always uses the prod overlay explicitly — never the local override.
+# The stack lives in docker/server (single compose file + .env); the legacy
+# GHCR-pull flow this replaced is described in deploy/README.md.
 
 set -euo pipefail
 
@@ -26,10 +29,9 @@ set -euo pipefail
 # mid-run; reading it up front prevents that from corrupting execution.
 {
 
-# ── Configuration ────────────────────────────────────────────────────────────
-REPO_DIR="/home/Elhan/Occupi"
-BRANCH="develop"
-REGISTRY_OWNER="ghcr.io/elhan-salaji"
+# ── Configuration (env-overridable for non-standard hosts) ───────────────────
+REPO_DIR="${REPO_DIR:-/home/Elhan/Occupi}"
+BRANCH="${BRANCH:-develop}"
 SERVICES=(backend frontend)          # infra is updated manually on purpose
 STATE_DIR="/var/lib/occupi-autodeploy"
 LOCKFILE="/run/occupi-autodeploy.lock"
@@ -37,22 +39,17 @@ HEALTH_RETRIES=40                    # 40 x 3s = up to 120s for a service to com
 HEALTH_DELAY=3
 PRUNE_OLDER_THAN="336h"              # drop unused images older than 14 days
 
-COMPOSE_DIR="$REPO_DIR/docker"
+COMPOSE_FILE="$REPO_DIR/docker/server/compose.yml"
 
 log() { echo "[$(date -Is)] $*"; }
 
-# Compose helper — ALWAYS base + prod overlay, never the local override.
+# Compose helper — project dir is docker/server so its .env is picked up.
 dc() {
-  docker compose -f "$COMPOSE_DIR/docker-compose.yml" \
-                 -f "$COMPOSE_DIR/docker-compose.prod.yml" "$@"
+  docker compose --project-directory "$REPO_DIR/docker/server" \
+                 -f "$COMPOSE_FILE" "$@"
 }
 
-img_ref()       { echo "$REGISTRY_OWNER/occupi-$1:latest"; }
-running_image() { docker inspect --format '{{.Image}}' "occupi-$1" 2>/dev/null || echo "none"; }
-tag_image_id()  { docker image inspect --format '{{.Id}}' "$(img_ref "$1")" 2>/dev/null || echo "none"; }
-tag_digest()    { docker image inspect --format '{{if .RepoDigests}}{{index .RepoDigests 0}}{{end}}' "$(img_ref "$1")" 2>/dev/null || echo ""; }
-
-# Liveness URL per service, checked from the host (the prod overlay publishes
+# Liveness URL per service, checked from the host (docker/server publishes
 # these on 127.0.0.1). backend: /v3/api-docs is permitAll in the prod
 # SecurityConfig -> 200 when up. frontend: nginx serves the SPA index -> 200.
 health_url() {
@@ -75,6 +72,27 @@ wait_healthy() {
   return 1
 }
 
+# Serial build + recreate + health-gate for every service. Returns non-zero on
+# the first failure, leaving the loop early.
+build_and_apply() {
+  local svc
+  for svc in "${SERVICES[@]}"; do
+    log "$svc: building"
+    dc build "$svc" || { log "ERROR: $svc build failed"; return 1; }
+  done
+  for svc in "${SERVICES[@]}"; do
+    log "$svc: recreating"
+    dc up -d "$svc" || { log "ERROR: $svc up failed"; return 1; }
+    if wait_healthy "$(health_url "$svc")"; then
+      log "$svc: healthy"
+    else
+      log "ERROR: $svc did not come up healthy"
+      return 1
+    fi
+  done
+  return 0
+}
+
 # ── Single-instance lock (skip if a previous run is still going) ─────────────
 exec 9>"$LOCKFILE"
 if ! flock -n 9; then
@@ -83,87 +101,78 @@ if ! flock -n 9; then
 fi
 
 mkdir -p "$STATE_DIR"
+LAST_GOOD_FILE="$STATE_DIR/last-good-commit"
+BAD_FILE="$STATE_DIR/bad-commit"
 
-# ── 1. Sync the repo (compose files + this script) ───────────────────────────
+# ── 1. What does origin have? ────────────────────────────────────────────────
 log "fetching origin/$BRANCH in $REPO_DIR"
-if git -C "$REPO_DIR" fetch --quiet --prune origin "$BRANCH"; then
-  if git -C "$REPO_DIR" merge-base --is-ancestor HEAD "origin/$BRANCH"; then
-    if git -C "$REPO_DIR" pull --ff-only --quiet origin "$BRANCH"; then
-      log "repo fast-forwarded to $(git -C "$REPO_DIR" rev-parse --short HEAD)"
-    else
-      log "WARN: git pull failed — continuing with existing checkout"
-    fi
-  else
-    log "WARN: local HEAD diverged from origin/$BRANCH — skipping repo update"
+if ! git -C "$REPO_DIR" fetch --quiet --prune origin "$BRANCH"; then
+  log "WARN: git fetch failed — nothing to compare, exiting"
+  exit 0
+fi
+
+remote=$(git -C "$REPO_DIR" rev-parse "origin/$BRANCH")
+head=$(git -C "$REPO_DIR" rev-parse HEAD)
+
+if [ -f "$BAD_FILE" ] && [ "$(cat "$BAD_FILE")" = "$remote" ]; then
+  log "origin/$BRANCH ($remote) is known-bad — waiting for a new commit"
+  exit 0
+fi
+
+# Nothing new AND the services are running -> cheap no-op. When a service is
+# down despite an unchanged commit (first adoption, crashed container), fall
+# through and rebuild the current checkout.
+if [ "$remote" = "$head" ]; then
+  running=$(dc ps --status running --format '{{.Service}}' 2>/dev/null || true)
+  if echo "$running" | grep -q "backend" && echo "$running" | grep -q "frontend"; then
+    log "nothing to deploy — already at $(git -C "$REPO_DIR" rev-parse --short HEAD)"
+    exit 0
   fi
+  log "commit unchanged but services not running — rebuilding current checkout"
 else
-  log "WARN: git fetch failed — continuing with existing checkout"
-fi
-
-# ── 2. Pull the latest images (download only; running containers untouched) ───
-log "pulling images: ${SERVICES[*]}"
-dc pull "${SERVICES[@]}" || log "WARN: docker pull failed — using locally cached images"
-
-# ── 3. Apply changed services, health-gated with rollback ────────────────────
-failed=0
-changed_any=0
-
-for svc in "${SERVICES[@]}"; do
-  before=$(running_image "$svc")
-  after=$(tag_image_id "$svc")
-
-  if [ "$before" = "$after" ] && [ "$before" != "none" ]; then
-    log "$svc: up to date"
-    continue
-  fi
-
-  digest=$(tag_digest "$svc")
-  bad_marker="$STATE_DIR/$svc.bad"
-  if [ -n "$digest" ] && [ -f "$bad_marker" ] && [ "$(cat "$bad_marker")" = "$digest" ]; then
-    log "$svc: current :latest digest is known-bad — skipping until it changes"
-    continue
-  fi
-
-  changed_any=1
-  log "$svc: updating ($before -> $after)"
-
-  ok=1
-  dc up -d "$svc" || ok=0
-  if [ "$ok" = "1" ] && wait_healthy "$(health_url "$svc")"; then
-    log "$svc: healthy after update"
-    rm -f "$bad_marker"
+  # ── 2. Fast-forward the repo ───────────────────────────────────────────────
+  if git -C "$REPO_DIR" merge-base --is-ancestor HEAD "origin/$BRANCH"; then
+    git -C "$REPO_DIR" pull --ff-only --quiet origin "$BRANCH"
+    log "repo fast-forwarded to $(git -C "$REPO_DIR" rev-parse --short HEAD)"
   else
-    log "ERROR: $svc did not come up healthy"
-    failed=1
-    if [ -n "$digest" ]; then echo "$digest" > "$bad_marker"; fi
-    if [ "$before" != "none" ]; then
-      log "$svc: rolling back to previous image $before"
-      docker tag "$before" "$(img_ref "$svc")" || true
-      dc up -d "$svc" || true
-      if wait_healthy "$(health_url "$svc")"; then
-        log "$svc: healthy again after rollback"
-      else
-        log "CRITICAL: $svc still unhealthy after rollback — manual intervention needed"
-      fi
-    else
-      log "CRITICAL: $svc has no previous image to roll back to — manual intervention needed"
-    fi
+    log "WARN: local HEAD diverged from origin/$BRANCH — skipping this run"
+    exit 0
   fi
-done
-
-# ── 4. Reclaim disk ──────────────────────────────────────────────────────────
-docker image prune -f >/dev/null 2>&1 || true
-docker image prune -af --filter "until=$PRUNE_OLDER_THAN" >/dev/null 2>&1 || true
-
-if [ "$changed_any" = "0" ]; then
-  log "nothing to deploy — already current"
 fi
 
-if [ "$failed" != "0" ]; then
+# ── 3. Build serially, recreate, health-gate ─────────────────────────────────
+deployed=$(git -C "$REPO_DIR" rev-parse HEAD)
+
+if build_and_apply; then
+  echo "$deployed" > "$LAST_GOOD_FILE"
+  rm -f "$BAD_FILE"
+  log "deploy of $(git -C "$REPO_DIR" rev-parse --short HEAD) finished OK"
+else
+  echo "$deployed" > "$BAD_FILE"
+  last_good=$(cat "$LAST_GOOD_FILE" 2>/dev/null || echo "")
+  if [ -n "$last_good" ] && [ "$last_good" != "$deployed" ]; then
+    log "rolling back to last good commit ${last_good:0:8} (rebuild takes a few minutes)"
+    # The server checkout is deploy-only — reset is safe, and the bad-commit
+    # marker keeps the next tick from re-deploying the bad commit until the
+    # branch moves past it.
+    git -C "$REPO_DIR" reset --hard "$last_good"
+    if build_and_apply; then
+      log "rollback to ${last_good:0:8} healthy"
+    else
+      log "CRITICAL: rollback build also failed — manual intervention needed"
+    fi
+  else
+    log "CRITICAL: no last good commit to roll back to — manual intervention needed"
+  fi
+  docker image prune -f >/dev/null 2>&1 || true
   log "auto-deploy finished WITH ERRORS"
   exit 1
 fi
-log "auto-deploy finished OK"
+
+# ── 4. Reclaim disk (source builds leave dangling layers behind) ─────────────
+docker image prune -f >/dev/null 2>&1 || true
+docker image prune -af --filter "until=$PRUNE_OLDER_THAN" >/dev/null 2>&1 || true
+
 exit 0
 
 }


### PR DESCRIPTION
## Summary
Unattended deploys keep working after the restructure — now git-driven. The systemd
timer (`occupi-autodeploy.timer`, 5-minute tick) stays byte-identical; only the
script it runs changes: new commit on `origin/develop` → serial source build
against `docker/server/compose.yml` → recreate → health checks → rollback to the
last good commit on failure. Stacked on #328.

## Changes
- `deploy/auto-deploy.sh` — rewritten around commits instead of registry digests:
  cheap no-op when nothing moved and both services run; fast-forward guard
  unchanged; `docker compose build backend` then `frontend` (serial on purpose —
  single-core host); health gates as before; rollback = `git reset --hard
  <last-good>` + rebuild, with a bad-commit marker so a broken commit is not
  retried until develop moves past it; `REPO_DIR`/`BRANCH` env-overridable; same
  flock/journald/prune discipline as before (source builds shed layers each run).
- `deploy/README.md` — updated operate/manual-deploy sections, a **swap-file
  prerequisite box** (an unswapped on-server build killed this VM once, #140 —
  that history is why the old flow pulled from GHCR; the swap step is mandatory
  now), the requested **timer conversion explanation** (what stays: units, tick,
  systemctl/journalctl; what changes: trigger, procurement, compose file, rollback
  semantics — as a table), and the full **VM migration runbook**: freeze timer →
  backups → swap → .env from example → old stack down → Influx token bootstrap →
  `up -d --build` → verification incl. `sensors` table → Pi keeps streaming with
  zero gap (same SENSOR_ID) → rollback path while the legacy compose files exist.
- Demo-seed section untouched (container names stay `occupi-*` in docker/server
  for exactly this reason).

## Verification
- `bash -n` clean; dry logic reviewed against the old script's edge cases
  (diverged checkout, missing lockfile dir, first adoption with unchanged commit
  but stopped services)
- The real first run happens supervised during the VM cutover (runbook step 12)

Closes #315