### PR TITLE
ci: run raspberry and mock fleet tests in the pipeline #317

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,62 @@
+name: Python CI
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - 'raspberry/**'
+      - 'docker/local/mock/**'
+  pull_request:
+    branches:
+      - develop
+      - main
+    paths:
+      - 'raspberry/**'
+      - 'docker/local/mock/**'
+
+jobs:
+  raspberry-tests:
+    name: Run Raspberry Sender Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        working-directory: raspberry
+        run: pip install -r requirements-dev.txt
+
+      - name: Run tests
+        working-directory: raspberry
+        run: python -m pytest -v
+
+  mock-fleet-tests:
+    name: Run Mock Fleet Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        working-directory: docker/local/mock
+        run: pip install -r requirements.txt pytest
+
+      - name: Run tests
+        working-directory: docker/local/mock
+        run: python -m pytest tests -v


### PR DESCRIPTION
## Summary
`raspberry/tests` existed but no workflow ever ran it — Python tests now gate
changes the same way `./mvnw test` gates the backend. Stacked on #330.

## Changes
- `.github/workflows/python-ci.yml` — two jobs on Python 3.12: the raspberry
  sender tests (`requirements-dev.txt`, pytest) and the mock fleet tests
  (`docker/local/mock`, covers the walk + the ported demo scenario). Triggers on
  `raspberry/**` and `docker/local/mock/**` for pushes and PRs against
  develop/main, mirroring backend-ci.

## Verification
- Both suites green locally (7 + 14 tests); the workflow runs on this PR

Closes #317