### PR TITLE
fix: Keycloak admin console locally blocked by HTTPS required #333

### DIFF
--- a/docker/local/README.md
+++ b/docker/local/README.md
@@ -67,6 +67,11 @@ Der lokale Realm läuft mit `sslRequired: none`: Der Stack spricht bewusst
 Mit `external` (dem Server-Wert) antwortet Keycloak sonst mit „HTTPS required",
 sobald eine Anfrage nicht von einer als lokal geltenden Adresse kommt.
 
+Für die **Admin-Console** (master-Realm, den Keycloak selbst anlegt und der
+nie importiert wird) erledigt das der `keycloak-init`-Einmaldienst bei jedem
+Start — ohne ihn bliebe die Console unter Docker Desktop mit „HTTPS required"
+gesperrt.
+
 **Realm-Änderungen:** `--import-realm` importiert `keycloak/realm-local.json`
 nur in eine leere Keycloak-Datenbank. Nach einer Änderung an der Datei:
 `docker compose down -v && docker compose up -d --build`.

--- a/docker/local/compose.yml
+++ b/docker/local/compose.yml
@@ -152,6 +152,27 @@ services:
       start_period: 30s
     restart: unless-stopped
 
+  # One-shot: allows plain-HTTP access to the ADMIN CONSOLE (master realm).
+  # The occupi realm gets sslRequired=none via the import file, but Keycloak
+  # bootstraps the master realm itself — it is never imported. Docker Desktop
+  # hands host connections to the container with a source address Keycloak does
+  # not treat as local, so without this the console answers "HTTPS required".
+  # Idempotent, runs on every up, survives `down -v`.
+  keycloak-init:
+    image: quay.io/keycloak/keycloak:26.2
+    restart: "no"
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - >
+        /opt/keycloak/bin/kcadm.sh config credentials
+        --server http://keycloak:8080 --realm master
+        --user ${KEYCLOAK_ADMIN:-admin} --password ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+        && /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE
+        && echo "master realm: sslRequired=NONE (plain-HTTP admin console)"
+    depends_on:
+      keycloak:
+        condition: service_healthy
+
   grafana:
     image: grafana/grafana:11.6.1
     environment:


### PR DESCRIPTION
## Summary
Follow-up to the local-stack auth fix: the occupi realm runs plain-HTTP via its
import file, but the **master** realm (admin console login) is bootstrapped by
Keycloak itself and never imported — it kept `sslRequired: external`. Docker
Desktop hands host connections to the container with a source address Keycloak
does not classify as local, so http://localhost:8180 answered "HTTPS required".

## Changes
- `docker/local/compose.yml` — one-shot `keycloak-init` sidecar: waits for
  keycloak healthy, then `kcadm.sh update realms/master -s sslRequired=NONE`.
  Idempotent, runs on every `up`, survives `docker compose down -v` (which the
  README recommends after realm-file edits — a manual kcadm fix would silently
  vanish exactly then).
- `docker/local/README.md` — explains why the console needs this while the
  occupi realm is covered by the import file.

## Verification (fresh volumes)
- `docker compose down -v && docker compose up -d`: keycloak-init logs the
  update, `/realms/master/.well-known/openid-configuration` answers 200 over
  plain HTTP, the admin console page loads
- Full auth flow intact after the reset: seeded `occupi-admin` login +
  `GET /api/sensors` → 200 (prod profile)

Closes #333